### PR TITLE
[releng] Do not run PR checks once merged to master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,11 @@ pipeline {
 
     stages {
         stage('Parallel Tests') {
+            when {
+                not {
+                    branch 'master'
+                }
+            }
             parallel {
                 stage('JUnit') {
                     agent {


### PR DESCRIPTION
For now we only use the `Jenkinsfile` to run a subset of our tests to validate PRs.
Once a PR has been merged on master, there is no point in re-running these tests again. It only occupies slots on the CI server and slows down feedback on other PRs in progress.

This does not mean we do not run the (full) test suite on `master`, but given the time it takes to run this is in a different job than.
