### PR TITLE
Handle auto size for nodes

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/elements/AbstractSequenceNode.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/elements/AbstractSequenceNode.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.diagram.sequence.business.internal.elements;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gmf.runtime.notation.Bounds;
@@ -19,6 +20,8 @@ import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.diagram.DDiagramElement;
+import org.eclipse.sirius.diagram.DNode;
+import org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery;
 import org.eclipse.sirius.diagram.ui.tools.api.util.GMFNotationHelper;
 import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.ext.base.Options;
@@ -61,9 +64,14 @@ abstract class AbstractSequenceNode extends AbstractSequenceElement implements I
         if (!(node.getElement() instanceof DDiagramElement)) {
             return null;
         } else {
-            Point absLoc = GMFNotationHelper.getAbsoluteLocation(node);
             int width = GMFNotationHelper.getWidth(node);
             int height = GMFNotationHelper.getHeight(node);
+            Point absLoc = GMFNotationHelper.getAbsoluteLocation(node);
+            if (node.getElement() instanceof DNode dnode) {
+                Dimension dimension = new DNodeQuery(dnode).getDefaultDimension();
+                width = Math.max(dimension.width, width);
+                height = Math.max(dimension.height, height);
+            }
             return new Rectangle(absLoc.x, absLoc.y, width, height);
         }
     }

--- a/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/elements/InstanceRole.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/elements/InstanceRole.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.diagram.sequence.business.internal.elements;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.notation.Bounds;
@@ -24,6 +25,7 @@ import org.eclipse.sirius.diagram.DNode;
 import org.eclipse.sirius.diagram.business.api.query.NodeStyleQuery;
 import org.eclipse.sirius.diagram.sequence.description.DescriptionPackage;
 import org.eclipse.sirius.diagram.sequence.tool.internal.Messages;
+import org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery;
 import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.sirius.viewpoint.DRepresentationElement;
@@ -135,7 +137,14 @@ public class InstanceRole extends AbstractSequenceNode {
     public Rectangle getProperLogicalBounds() {
         if (getNotationNode().getLayoutConstraint() instanceof Bounds) {
             Bounds bounds = (Bounds) getNotationNode().getLayoutConstraint();
-            return new Rectangle(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+            int width = bounds.getWidth();
+            int height = bounds.getHeight();
+            if (view.getElement() instanceof DNode dnode) {
+                Dimension dimension = new DNodeQuery(dnode).getDefaultDimension();
+                width = Math.max(dimension.width, width);
+                height = Math.max(dimension.height, height);
+            }
+            return new Rectangle(bounds.getX(), bounds.getY(), width, height);
         } else {
             throw new RuntimeException();
         }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/image/WorkspaceImageHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/image/WorkspaceImageHelper.java
@@ -25,10 +25,6 @@ import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor;
-import org.eclipse.gmf.runtime.notation.LayoutConstraint;
-import org.eclipse.gmf.runtime.notation.Node;
-import org.eclipse.gmf.runtime.notation.NotationPackage;
-import org.eclipse.gmf.runtime.notation.Size;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.common.ui.tools.api.util.EclipseUIUtil;
@@ -41,7 +37,6 @@ import org.eclipse.sirius.diagram.DNodeContainer;
 import org.eclipse.sirius.diagram.DiagramPackage;
 import org.eclipse.sirius.diagram.NodeStyle;
 import org.eclipse.sirius.diagram.WorkspaceImage;
-import org.eclipse.sirius.diagram.business.api.query.EObjectQuery;
 import org.eclipse.sirius.diagram.business.internal.metamodel.helper.StyleHelper;
 import org.eclipse.sirius.diagram.description.style.BorderedStyleDescription;
 import org.eclipse.sirius.diagram.description.style.StyleFactory;
@@ -144,31 +139,7 @@ public class WorkspaceImageHelper {
             Object newWorkspaceImageStyle = getNewWorkspaceImageStyle(basicLabelStyle, workspacePath);
             updateWorkspacePathCmd = SetCommand.create(domain, basicLabelStyle.eContainer(), feature, newWorkspaceImageStyle);
         }
-        Command updateHeightCmd = getUpdateHeightCommand(domain, basicLabelStyle);
-        if (updateHeightCmd != null) {
-            updateWorkspacePathCmd = updateWorkspacePathCmd.chain(updateHeightCmd);
-        }
         return updateWorkspacePathCmd;
-    }
-
-    private Command getUpdateHeightCommand(TransactionalEditingDomain domain, BasicLabelStyle basicLabelStyle) {
-        Command updateHeightCommand = null;
-        EObjectQuery eObjectQuery = new EObjectQuery(basicLabelStyle.eContainer());
-        Collection<EObject> inverseReferences = eObjectQuery.getInverseReferences(NotationPackage.Literals.VIEW__ELEMENT);
-        if (!inverseReferences.isEmpty()) {
-            EObject next = inverseReferences.iterator().next();
-            if (next instanceof Node) {
-                Node node = (Node) next;
-                LayoutConstraint layoutConstraint = node.getLayoutConstraint();
-                if (layoutConstraint instanceof Size) {
-                    Size size = (Size) layoutConstraint;
-                    if (size.getHeight() != -1) {
-                        updateHeightCommand = SetCommand.create(domain, size, NotationPackage.Literals.SIZE__HEIGHT, -1);
-                    }
-                }
-            }
-        }
-        return updateHeightCommand;
     }
 
     private Object getFeature(BasicLabelStyle basicLabelStyle) {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/api/part/AbstractDiagramBorderNodeEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/api/part/AbstractDiagramBorderNodeEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2008, 2023 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.StackLayout;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.common.notify.Notification;
@@ -47,6 +48,7 @@ import org.eclipse.gmf.runtime.diagram.ui.requests.CreateViewRequest;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateViewRequest.ViewDescriptor;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.IBorderItemLocator;
 import org.eclipse.gmf.runtime.gef.ui.figures.NodeFigure;
+import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.common.tools.api.util.StringUtil;
 import org.eclipse.sirius.diagram.DDiagram;
@@ -71,6 +73,7 @@ import org.eclipse.sirius.diagram.ui.edit.internal.part.PortLayoutHelper;
 import org.eclipse.sirius.diagram.ui.edit.internal.validators.ResizeValidator;
 import org.eclipse.sirius.diagram.ui.graphical.edit.policies.SiriusDecoratorEditPolicy;
 import org.eclipse.sirius.diagram.ui.graphical.edit.policies.SpecificBorderItemSelectionEditPolicy;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.AutoSizeNodeLayout;
 import org.eclipse.sirius.diagram.ui.internal.view.factories.ViewLocationHint;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
 import org.eclipse.sirius.diagram.ui.tools.api.figure.FoldingToggleAwareClippingStrategy;
@@ -78,6 +81,7 @@ import org.eclipse.sirius.diagram.ui.tools.api.figure.FoldingToggleImageFigure;
 import org.eclipse.sirius.diagram.ui.tools.api.layout.LayoutUtils;
 import org.eclipse.sirius.diagram.ui.tools.api.permission.EditPartAuthorityListener;
 import org.eclipse.sirius.diagram.ui.tools.internal.figure.SiriusDBorderedNodeFigure;
+import org.eclipse.sirius.diagram.ui.tools.internal.figure.ViewNodeFigure;
 import org.eclipse.sirius.diagram.ui.tools.internal.ruler.SiriusSnapToHelperUtil;
 import org.eclipse.sirius.diagram.ui.tools.internal.ui.SiriusDragEditPartsTrackerEx;
 import org.eclipse.sirius.ecore.extender.business.api.permission.IPermissionAuthority;
@@ -115,12 +119,21 @@ public abstract class AbstractDiagramBorderNodeEditPart extends BorderedBorderIt
 
     @Override
     protected NodeFigure createNodeFigure() {
-        DBorderedNodeFigure nodeFigure = new SiriusDBorderedNodeFigure(createMainFigure(), this);
+        NodeFigure mainFigure = createMainFigure();
+        DBorderedNodeFigure nodeFigure = new SiriusDBorderedNodeFigure(mainFigure, this);
         DiagramBorderNodeEditPartOperation.updateAuthorizedSide(nodeFigure, this);
         nodeFigure.getBorderItemContainer().add(new FoldingToggleImageFigure(this));
         nodeFigure.getBorderItemContainer().setClippingStrategy(new FoldingToggleAwareClippingStrategy());
+        mainFigure.setLayoutManager(new AutoSizeNodeLayout(new StackLayout(), (Node) getModel(), (DNode) resolveSemanticElement(), nodeFigure, getPrimaryShape().getNodeLabel()));
         return nodeFigure;
     }
+
+    /**
+     * Returns the primary shape.
+     * 
+     * @return the primary shape.
+     */
+    public abstract ViewNodeFigure getPrimaryShape();
 
     @Override
     protected void registerModel() {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/internal/part/AbstractDiagramNodeEditPartRefreshVisualsOperation.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/internal/part/AbstractDiagramNodeEditPartRefreshVisualsOperation.java
@@ -76,8 +76,7 @@ public class AbstractDiagramNodeEditPartRefreshVisualsOperation {
     /**
      * Check if refresh can occur.
      * 
-     * @return <code>true</code> if refresh methods could be called safely,
-     *         <code>false</code> otherwise
+     * @return <code>true</code> if refresh methods could be called safely, <code>false</code> otherwise
      */
     public boolean canRefresh() {
         return node != null;
@@ -180,8 +179,10 @@ public class AbstractDiagramNodeEditPartRefreshVisualsOperation {
 
         final int tmpWidth = ((Integer) getStructuralFeatureValue(NotationPackage.eINSTANCE.getSize_Width())).intValue();
         DDiagramElementQuery query = new DDiagramElementQuery(node);
-        if (tmpWidth > 0 && (new DNodeQuery(node).allowsHorizontalResize() || query.isCollapsed())) {
+        if (new DNodeQuery(node).allowsHorizontalResize() || query.isCollapsed() && tmpWidth > 0) {
             width = tmpWidth;
+        } else if (tmpWidth <= 0) {
+            width = -1;
         }
 
         // style
@@ -210,8 +211,10 @@ public class AbstractDiagramNodeEditPartRefreshVisualsOperation {
         }
 
         final int tmpHeight = ((Integer) getStructuralFeatureValue(NotationPackage.eINSTANCE.getSize_Height())).intValue();
-         if (tmpHeight > 0) {
+        if (tmpHeight > 0) {
             height = tmpHeight;
+        } else {
+            height = -1;
         }
 
         // workspace image ? keep ratio
@@ -223,10 +226,8 @@ public class AbstractDiagramNodeEditPartRefreshVisualsOperation {
     }
 
     /**
-     * Convenience method to retreive the value for the supplied value from the
-     * editpart's associated view element. Same as calling
-     * <code> ViewUtil.getStructuralFeatureValue(getNotationView(),feature)</code>
-     * .
+     * Convenience method to retreive the value for the supplied value from the editpart's associated view element. Same
+     * as calling <code> ViewUtil.getStructuralFeatureValue(getNotationView(),feature)</code> .
      * 
      * @param feature
      *            the feature

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/AutoSizeNodeLayout.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/AutoSizeNodeLayout.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2023 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.internal.edit.parts;
+
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.LayoutManager;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.gmf.runtime.gef.ui.figures.DefaultSizeNodeFigure;
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.sirius.diagram.DNode;
+import org.eclipse.sirius.diagram.Square;
+import org.eclipse.sirius.diagram.business.api.query.DNodeQuery;
+import org.eclipse.sirius.diagram.description.style.SquareDescription;
+import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.IStyleConfigurationRegistry;
+import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.StyleConfiguration;
+import org.eclipse.sirius.diagram.ui.tools.internal.figure.SiriusDBorderedNodeFigure;
+import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.SiriusWrapLabel;
+
+/**
+ * Displays nodes whose Size Computation Expression is set to "-1". These nodes must be resized according to their label
+ * size.
+ * 
+ * @author <a href="mailto:glenn.plouhinec@obeo.fr">Glenn Plouhinec</a>
+ */
+public class AutoSizeNodeLayout implements LayoutManager {
+
+    /**
+     * A margin of 20 around the label.
+     */
+    private static final Dimension LABEL_MARGIN = new Dimension(20, 20);
+
+    /**
+     * The associated {@link DNode}.
+     */
+    private DNode dNode;
+
+    /**
+     * The main figure to resize, which is usually a {@link SiriusDBorderedNodeFigure}.
+     */
+    private IFigure mainFigure;
+
+    /**
+     * The {@link SiriusWrapLabel} used to get the size of the label.
+     */
+    private SiriusWrapLabel nodeLabel;
+
+    /**
+     * The default {@link LayoutManager}.
+     */
+    private LayoutManager wrappedLayoutManager;
+
+    /**
+     * The associated GMF {@link Node}.
+     */
+    private Node node;
+
+    /**
+     * Creates a new instance of {@link AutoSizeNodeLayout}.
+     * 
+     * @param wrappedLayoutManager
+     *            the {@link LayoutManager} to use if the node should not be autosized.
+     * @param node
+     *            the associated GMF {@link Node}.
+     * @param dnode
+     *            the associated {@link DNode}.
+     * @param mainFigure
+     *            the main figure to resize, which is usually a {@link SiriusDBorderedNodeFigure}.
+     * @param nodeLabel
+     *            the {@link SiriusWrapLabel} used to get the size of the label.
+     */
+    public AutoSizeNodeLayout(LayoutManager wrappedLayoutManager, Node node, DNode dnode, IFigure mainFigure, SiriusWrapLabel nodeLabel) {
+        this.wrappedLayoutManager = wrappedLayoutManager;
+        this.node = node;
+        this.dNode = dnode;
+        this.mainFigure = mainFigure;
+        this.nodeLabel = nodeLabel;
+    }
+
+    /**
+     * {@inheritDoc} This method has been overridden to handle Size Computation Expression = "-1". In this case, if the
+     * node has not been manually resized, the figure size should be resized automatically, depending the size of the
+     * label.
+     */
+    @Override
+    public void layout(IFigure parent) {
+        if (node != null && dNode.getStyle().getDescription() instanceof SquareDescription) {
+            Bounds bounds = (Bounds) this.node.getLayoutConstraint();
+            boolean hasDefaultBounds = bounds.getHeight() == -1 || bounds.getWidth() == -1;
+            if (new org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery(this.dNode).isAutoSizeStyle() || hasDefaultBounds) {
+                DNodeQuery dNodeQuery = new DNodeQuery(this.dNode);
+                Dimension autoSizedDimension = getAutoSizedDimension(parent);
+                Dimension defaultDimension = new org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery(this.dNode).getDefaultDimension();
+                Dimension newSize = autoSizedDimension.getCopy();
+                if (!new org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery(this.dNode).isAutoSizeStyle()) {
+                    // It may happens if the style is updated before the figure (i.e. with conditional styles), it was
+                    // in auto-size mode before: Size Computation Expression and GMF Bounds were set to -1, but now it's
+                    // not in auto-size mode and we should set the defaultDimension
+                    newSize = defaultDimension.getCopy();
+                }
+                if (!hasDefaultBounds) {
+                    // If the node has been manually resized, we should not change its bounds.
+                    newSize = new Dimension(bounds.getWidth(), bounds.getHeight());
+                }
+                if (hasDefaultBounds && dNode.getStyle() instanceof Square square && square.getWidth() != null && square.getWidth().intValue() > 0) {
+                    // Handle specific case Width Expression of the Square Style.
+                    newSize.setWidth(defaultDimension.width);
+                }
+                if (hasDefaultBounds && dNode.getStyle() instanceof Square square && square.getHeight() != null && square.getHeight().intValue() > 0) {
+                    // Handle specific case Height Expression of the Square Style.
+                    newSize.setHeight(defaultDimension.height);
+                }
+
+                if (bounds.getHeight() == -1 && bounds.getWidth() != -1 && dNodeQuery.allowsHorizontalResize()) {
+                    // Horizontal resizing case.
+                    newSize.setWidth(bounds.getWidth());
+                }
+                if (bounds.getHeight() != -1 && bounds.getWidth() == -1 && dNodeQuery.allowsVerticalResize()) {
+                    // Vertical resizing case.
+                    newSize.setHeight(bounds.getHeight());
+                }
+                parent.setSize(newSize);
+                this.mainFigure.setSize(newSize);
+                this.nodeLabel.setSize(newSize);
+            }
+        }
+        this.wrappedLayoutManager.layout(parent);
+    }
+
+    private Dimension getAutoSizedDimension(IFigure parent) {
+        Dimension autoSizedDimension;
+        StyleConfiguration styleConfiguration = IStyleConfigurationRegistry.INSTANCE.getStyleConfiguration(dNode.getDiagramElementMapping(), dNode.getStyle());
+        if (parent instanceof DefaultSizeNodeFigure defaultSizeNodeFigure && styleConfiguration != null) {
+            autoSizedDimension = styleConfiguration.fitToText(this.dNode, this.nodeLabel, defaultSizeNodeFigure);
+        } else {
+            autoSizedDimension = this.nodeLabel.getPreferredSize().getCopy();
+            autoSizedDimension.expand(LABEL_MARGIN);
+        }
+        return autoSizedDimension;
+    }
+
+    @Override
+    public Object getConstraint(IFigure child) {
+        return this.wrappedLayoutManager.getConstraint(child);
+    }
+
+    @Override
+    public Dimension getMinimumSize(IFigure container, int wHint, int hHint) {
+        return this.wrappedLayoutManager.getMinimumSize(container, wHint, hHint);
+    }
+
+    @Override
+    public Dimension getPreferredSize(IFigure container, int wHint, int hHint) {
+        return this.wrappedLayoutManager.getPreferredSize(container, wHint, hHint);
+    }
+
+    @Override
+    public void invalidate() {
+        this.wrappedLayoutManager.invalidate();
+    }
+
+    @Override
+    public void remove(IFigure child) {
+        this.wrappedLayoutManager.remove(child);
+    }
+
+    @Override
+    public void setConstraint(IFigure child, Object constraint) {
+        this.wrappedLayoutManager.setConstraint(child, constraint);
+    }
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNode2EditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNode2EditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ package org.eclipse.sirius.diagram.ui.internal.edit.parts;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.StackLayout;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
@@ -41,9 +40,9 @@ import org.eclipse.sirius.diagram.ui.internal.edit.policies.DNode2ItemSemanticEd
 import org.eclipse.sirius.diagram.ui.part.SiriusVisualIDRegistry;
 import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.IStyleConfigurationRegistry;
 import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.StyleConfiguration;
+import org.eclipse.sirius.diagram.ui.tools.internal.figure.ViewNodeFigure;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.AirDefaultSizeNodeFigure;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.SiriusWrapLabel;
-import org.eclipse.sirius.diagram.ui.tools.internal.figure.ViewNodeFigure;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.util.AnchorProvider;
 import org.eclipse.sirius.viewpoint.DStylizable;
 
@@ -140,6 +139,7 @@ public class DNode2EditPart extends AbstractDiagramBorderNodeEditPart {
     /**
      * @not-generated
      */
+    @Override
     public ViewNodeFigure getPrimaryShape() {
         return (ViewNodeFigure) primaryShape;
     }
@@ -188,7 +188,7 @@ public class DNode2EditPart extends AbstractDiagramBorderNodeEditPart {
      * @not-generated
      */
     protected NodeFigure createNodePlate() {
-        DefaultSizeNodeFigure result = null;
+        DefaultSizeNodeFigure result = new AirDefaultSizeNodeFigure(10, 10, null);
         final EObject eObj = resolveSemanticElement();
         if (eObj instanceof DStylizable && eObj instanceof DDiagramElement) {
             final DStylizable viewNode = (DStylizable) eObj;
@@ -246,10 +246,11 @@ public class DNode2EditPart extends AbstractDiagramBorderNodeEditPart {
     @Override
     protected NodeFigure createMainFigure() {
         final NodeFigure figure = createNodePlate();
-        figure.setLayoutManager(new StackLayout());
-        final IFigure shape = createNodeShape();
-        figure.add(shape);
-        contentPane = setupContentPane(shape);
+        if (figure != null) {
+            final IFigure shape = createNodeShape();
+            figure.add(shape);
+            contentPane = setupContentPane(shape);
+        }
         return figure;
     }
 

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNode3EditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNode3EditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import org.eclipse.gmf.runtime.draw2d.ui.figures.ConstrainedToolbarLayout;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.IBorderItemLocator;
 import org.eclipse.gmf.runtime.gef.ui.figures.DefaultSizeNodeFigure;
 import org.eclipse.gmf.runtime.gef.ui.figures.NodeFigure;
+import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.diagram.DDiagramElement;
 import org.eclipse.sirius.diagram.DNode;
@@ -204,9 +205,11 @@ public class DNode3EditPart extends AbstractDiagramNodeEditPart {
      */
     @Override
     protected NodeFigure createNodeFigure() {
-        DBorderedNodeFigure nodeFigure = new SiriusDBorderedNodeFigure(createMainFigure(), this);
+        NodeFigure mainFigure = createMainFigure();
+        DBorderedNodeFigure nodeFigure = new SiriusDBorderedNodeFigure(mainFigure, this);
         nodeFigure.getBorderItemContainer().add(new FoldingToggleImageFigure(this));
         nodeFigure.getBorderItemContainer().setClippingStrategy(new FoldingToggleAwareClippingStrategy());
+        mainFigure.setLayoutManager(new AutoSizeNodeLayout(new FlowLayout(), (Node) getModel(), (DNode) resolveSemanticElement(), nodeFigure, getPrimaryShape().getNodeLabel()));
         return nodeFigure;
     }
 
@@ -285,7 +288,6 @@ public class DNode3EditPart extends AbstractDiagramNodeEditPart {
     protected NodeFigure createMainFigure() {
         final NodeFigure figure = createNodePlate();
         if (figure != null) {
-            figure.setLayoutManager(new FlowLayout());
             final IFigure shape = createNodeShape();
             figure.add(shape);
             contentPane = setupContentPane(shape);

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNode4EditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNode4EditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ package org.eclipse.sirius.diagram.ui.internal.edit.parts;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.StackLayout;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
@@ -38,9 +37,9 @@ import org.eclipse.sirius.diagram.ui.internal.edit.policies.DNode4ItemSemanticEd
 import org.eclipse.sirius.diagram.ui.part.SiriusVisualIDRegistry;
 import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.IStyleConfigurationRegistry;
 import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.StyleConfiguration;
+import org.eclipse.sirius.diagram.ui.tools.internal.figure.ViewNodeFigure;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.AirDefaultSizeNodeFigure;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.SiriusWrapLabel;
-import org.eclipse.sirius.diagram.ui.tools.internal.figure.ViewNodeFigure;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.util.AnchorProvider;
 import org.eclipse.sirius.viewpoint.DStylizable;
 
@@ -116,6 +115,7 @@ public class DNode4EditPart extends AbstractDiagramBorderNodeEditPart {
     /**
      * @not-generated
      */
+    @Override
     public ViewNodeFigure getPrimaryShape() {
         return (ViewNodeFigure) primaryShape;
     }
@@ -151,7 +151,7 @@ public class DNode4EditPart extends AbstractDiagramBorderNodeEditPart {
      * @not-generated
      */
     protected NodeFigure createNodePlate() {
-        DefaultSizeNodeFigure result = null;
+        DefaultSizeNodeFigure result = new AirDefaultSizeNodeFigure(10, 10, null);
         final EObject eObj = resolveSemanticElement();
         if (eObj instanceof DStylizable && eObj instanceof DDiagramElement) {
             final DStylizable viewNode = (DStylizable) eObj;
@@ -209,10 +209,11 @@ public class DNode4EditPart extends AbstractDiagramBorderNodeEditPart {
     @Override
     protected NodeFigure createMainFigure() {
         final NodeFigure figure = createNodePlate();
-        figure.setLayoutManager(new StackLayout());
-        final IFigure shape = createNodeShape();
-        figure.add(shape);
-        contentPane = setupContentPane(shape);
+        if (figure != null) {
+            final IFigure shape = createNodeShape();
+            figure.add(shape);
+            contentPane = setupContentPane(shape);
+        }
         return figure;
     }
 

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNodeEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DNodeEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import org.eclipse.gmf.runtime.draw2d.ui.figures.ConstrainedToolbarLayout;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.IBorderItemLocator;
 import org.eclipse.gmf.runtime.gef.ui.figures.DefaultSizeNodeFigure;
 import org.eclipse.gmf.runtime.gef.ui.figures.NodeFigure;
+import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.diagram.DDiagramElement;
 import org.eclipse.sirius.diagram.DNode;
@@ -204,9 +205,11 @@ public class DNodeEditPart extends AbstractDiagramNodeEditPart {
      */
     @Override
     protected NodeFigure createNodeFigure() {
-        DBorderedNodeFigure nodeFigure = new SiriusDBorderedNodeFigure(createMainFigure(), this);
+        NodeFigure mainFigure = createMainFigure();
+        DBorderedNodeFigure nodeFigure = new SiriusDBorderedNodeFigure(mainFigure, this);
         nodeFigure.getBorderItemContainer().add(new FoldingToggleImageFigure(this));
         nodeFigure.getBorderItemContainer().setClippingStrategy(new FoldingToggleAwareClippingStrategy());
+        mainFigure.setLayoutManager(new AutoSizeNodeLayout(new FlowLayout(), (Node) getModel(), (DNode) resolveSemanticElement(), nodeFigure, getPrimaryShape().getNodeLabel()));
         return nodeFigure;
     }
 
@@ -285,7 +288,6 @@ public class DNodeEditPart extends AbstractDiagramNodeEditPart {
     protected NodeFigure createMainFigure() {
         final NodeFigure figure = createNodePlate();
         if (figure != null) {
-            figure.setLayoutManager(new FlowLayout());
             final IFigure shape = createNodeShape();
             figure.add(shape);
             contentPane = setupContentPane(shape);

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
@@ -55,6 +55,7 @@ import org.eclipse.sirius.diagram.DNodeList;
 import org.eclipse.sirius.diagram.ResizeKind;
 import org.eclipse.sirius.diagram.business.api.query.DDiagramElementQuery;
 import org.eclipse.sirius.diagram.business.api.refresh.CanonicalSynchronizer;
+import org.eclipse.sirius.diagram.description.style.SquareDescription;
 import org.eclipse.sirius.diagram.model.business.internal.query.DDiagramElementContainerExperimentalQuery;
 import org.eclipse.sirius.diagram.model.business.internal.query.DNodeContainerExperimentalQuery;
 import org.eclipse.sirius.diagram.ui.business.api.query.ViewQuery;
@@ -763,8 +764,15 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
 
     private Dimension getDefaultSize(AbstractDNode abstractDNode) {
         Dimension defaultSize = new Dimension(-1, -1);
-        if (abstractDNode instanceof DNode) {
-            defaultSize = new DNodeQuery((DNode) abstractDNode).getDefaultDimension();
+        if (abstractDNode instanceof DNode viewNode) {
+            boolean isSquareDescription = false;
+            if (viewNode.getStyle() != null) {
+                isSquareDescription = viewNode.getStyle().getDescription() instanceof SquareDescription;
+            }
+            boolean isAutoSizeStyle = new DNodeQuery(viewNode).isAutoSizeStyle();
+            if (!isSquareDescription || (isSquareDescription && !isAutoSizeStyle)) {
+                defaultSize = new DNodeQuery(viewNode).getDefaultDimension();
+            }
         }
         return defaultSize;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/view/factories/AbstractDNodeViewFactory.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/view/factories/AbstractDNodeViewFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,14 +31,14 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.diagram.DDiagramElement;
 import org.eclipse.sirius.diagram.DNode;
 import org.eclipse.sirius.diagram.business.api.query.DDiagramElementQuery;
+import org.eclipse.sirius.diagram.description.style.SquareDescription;
 import org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DDiagramEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeEditPart;
 import org.eclipse.sirius.diagram.ui.part.SiriusVisualIDRegistry;
 
 /**
- * Abstract view factory to gather the creation of the different type of view
- * created from DNode.
+ * Abstract view factory to gather the creation of the different type of view created from DNode.
  * 
  * @author mporhel
  * 
@@ -126,9 +126,16 @@ public abstract class AbstractDNodeViewFactory extends AbstractDesignerNodeFacto
             Size size = (Size) ((Node) view).getLayoutConstraint();
             DNode viewNode = semanticAdapter.getAdapter(DNode.class);
             if (viewNode != null) {
-                Dimension defaultDimension = new DNodeQuery(viewNode).getDefaultDimension();
-                size.setHeight(defaultDimension.height);
-                size.setWidth(defaultDimension.width);
+                boolean isSquareDescription = false;
+                if (viewNode.getStyle() != null) {
+                    isSquareDescription = viewNode.getStyle().getDescription() instanceof SquareDescription;
+                }
+                boolean isAutoSizeStyle = new DNodeQuery(viewNode).isAutoSizeStyle();
+                if (!isSquareDescription || (isSquareDescription && !isAutoSizeStyle)) {
+                    Dimension defaultDimension = new DNodeQuery(viewNode).getDefaultDimension();
+                    size.setHeight(defaultDimension.height);
+                    size.setWidth(defaultDimension.width);
+                }
             }
         }
     }

--- a/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/metamodel/helper/StyleHelper.java
+++ b/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/metamodel/helper/StyleHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2019 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -968,7 +968,7 @@ public final class StyleHelper {
                     node.setWidth(size);
                 }
             } else {
-                safeSetComputedSize(node, size);
+                setComputedSize(node, description);
             }
         }
     }
@@ -1113,15 +1113,15 @@ public final class StyleHelper {
         }
         if (style.eContainer() instanceof DNode) {
             final DNode node = (DNode) style.eContainer();
-            if (style.getWidth() != 0 && style.getHeight() != 0) {
-                if (node.getWidth() == null || node.getWidth().intValue() != style.getWidth().intValue()) {
-                    node.setWidth(style.getWidth());
-                }
-                if (node.getHeight() == null || node.getHeight().intValue() != style.getHeight().intValue()) {
-                    node.setHeight(style.getHeight());
-                }
-            } else {
-                setComputedSize(node, description);
+            if (style.getWidth() != 0 && (node.getWidth() == null || node.getWidth().intValue() != style.getWidth().intValue())) {
+                node.setWidth(style.getWidth());
+            } else if (style.getWidth() == 0) {
+                setComputedWidth(node, description);
+            }
+            if (style.getHeight() != 0 && (node.getHeight() == null || node.getHeight().intValue() != style.getHeight().intValue())) {
+                node.setHeight(style.getHeight());
+            } else if (style.getHeight() == 0) {
+                setComputedHeight(node, description);
             }
         }
     }
@@ -1551,19 +1551,36 @@ public final class StyleHelper {
      *            Node style. May be <code>null</code>
      */
     public void setComputedSize(DNode node, NodeStyleDescription style) {
+        setComputedHeight(node, style);
+        setComputedWidth(node, style);
+    }
+
+    private void setComputedHeight(DNode node, NodeStyleDescription style) {
         if (style != null && !StringUtil.isEmpty(style.getSizeComputationExpression())) {
             Integer computedSize = computeStyleSize(node.getTarget(), style);
-            safeSetComputedSize(node, computedSize);
+            safeSetComputedHeight(node, computedSize);
         }
     }
 
-    private void safeSetComputedSize(DNode node, Integer computedSize) {
+    private void setComputedWidth(DNode node, NodeStyleDescription style) {
+        if (style != null && !StringUtil.isEmpty(style.getSizeComputationExpression())) {
+            Integer computedSize = computeStyleSize(node.getTarget(), style);
+            safeSetComputedWidth(node, computedSize);
+        }
+    }
+
+    private void safeSetComputedHeight(DNode node, Integer computedSize) {
+        if (computedSize.intValue() >= 0) {
+            if (!computedSize.equals(node.getHeight())) {
+                node.setHeight(computedSize);
+            }
+        }
+    }
+
+    private void safeSetComputedWidth(DNode node, Integer computedSize) {
         if (computedSize.intValue() >= 0) {
             if (!computedSize.equals(node.getWidth())) {
                 node.setWidth(computedSize);
-            }
-            if (!computedSize.equals(node.getHeight())) {
-                node.setHeight(computedSize);
             }
         }
     }

--- a/plugins/org.eclipse.sirius.doc/doc/specifier/diagrams/Diagrams.html
+++ b/plugins/org.eclipse.sirius.doc/doc/specifier/diagrams/Diagrams.html
@@ -1430,7 +1430,7 @@
 				<em>Size Computation Expression</em> if specified.
 			</li>
 			<li>
-				<em>Size Computation Expression</em>: An expression used to dynamically compute the size of a graphical element. It is evaluated in the context of the target element, and should return an integer.
+				<em>Size Computation Expression</em>: An expression used to dynamically compute the size of a graphical element. It is evaluated in the context of the target element, and should return an integer. By default, the value 3 is used to define a size of 30 pixels for the graphic element. The -1 value can be used to use the &#8220;auto size&#8221; mode, which works for all styles applicable to Containers, and the Square style applicable to Nodes. For WorkspaceImage style, set -1 as Size Computation Expression to use the size of the image as the size of the graphic element.
 			</li>
 			<li>
 				<em>Border Size Computation Expression</em>: An expression which is used to dynamically compute the size of the border of graphical element. It is evaluated in the context of the target element, and should return the border size 

--- a/plugins/org.eclipse.sirius.doc/doc/specifier/diagrams/Diagrams.textile
+++ b/plugins/org.eclipse.sirius.doc/doc/specifier/diagrams/Diagrams.textile
@@ -537,7 +537,7 @@ Most styles give you some control on the size of the graphical elements. The pro
 
 * _Allow resizing_: You can decide if end-users are allowed to resize graphical elements _Horizontally_ and/or _Vertically_. Most styles allow resizing on both directions by default.
 * Initial _Width_ and _Height_ can be specified explicitly. A value of 0 indicates no explicit width or height. The initial value will be taken from the style's default or from the _Size Computation Expression_ if specified.
-* _Size Computation Expression_: An expression used to dynamically compute the size of a graphical element. It is evaluated in the context of the target element, and should return an integer.
+* _Size Computation Expression_: An expression used to dynamically compute the size of a graphical element. It is evaluated in the context of the target element, and should return an integer. By default, the value 3 is used to define a size of 30 pixels for the graphic element. The -1 value can be used to use the "auto size" mode, which works for all styles applicable to Containers, and the Square style applicable to Nodes. For WorkspaceImage style, set -1 as Size Computation Expression to use the size of the image as the size of the graphic element.
 * _Border Size Computation Expression_: An expression which is used to dynamically compute the size of the border of graphical element. It is evaluated in the context of the target element, and should return the border size _in pixels_.
 
 h3(#colors). Colors

--- a/plugins/org.eclipse.sirius.tests.junit/data/unit/layout/data/xmi/storedFormat-DiagType5__of__MyPackage.xmi
+++ b/plugins/org.eclipse.sirius.tests.junit/data/unit/layout/data/xmi/storedFormat-DiagType5__of__MyPackage.xmi
@@ -6,7 +6,7 @@
     </label>
     <location x="630"/>
   </formatdata:NodeFormatData>
-  <formatdata:NodeFormatData id="//p2/p2-1/new%20EClass%201" width="30" height="30">
+  <formatdata:NodeFormatData id="//p2/p2-1/new%20EClass%201" width="10" height="10">
     <label id="//p2/p2-1/new%20EClass%201">
       <location y="5"/>
     </label>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/size/github-issue-65/github-issue-65.aird
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/size/github-issue-65/github-issue-65.aird
@@ -1,0 +1,622 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_HXsPIGg6Ee6D6pL7xzqmfg" selectedViews="_HVxmwGg-Ee6D6pL7xzqmfg _A8nnIGhQEe61iIFaFaTqIQ" version="15.2.0.202303281325">
+    <semanticResources>github-issue-65.ecore</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_HVxmwGg-Ee6D6pL7xzqmfg">
+      <viewpoint xmi:type="description:Viewpoint" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_zVcRsWhNEe61iIFaFaTqIQ" name="new github-issue-65" repPath="#_zVbqoGhNEe61iIFaFaTqIQ" changeId="1697041455502">
+        <description xmi:type="description_1:DiagramDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']"/>
+        <target xmi:type="ecore:EPackage" href="github-issue-65.ecore#/"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_zVbqoGhNEe61iIFaFaTqIQ">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_zVf8EGhNEe61iIFaFaTqIQ" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_zVf8EWhNEe61iIFaFaTqIQ" type="Sirius" element="_zVbqoGhNEe61iIFaFaTqIQ" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_zVjmcGhNEe61iIFaFaTqIQ" type="2001" element="_zVf8E2hNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVjmc2hNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVjmdGhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVmp1mhNEe61iIFaFaTqIQ" type="3003" element="_zVhKMGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmp12hNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmp2GhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVjmcWhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVjmcmhNEe61iIFaFaTqIQ"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVjmdWhNEe61iIFaFaTqIQ" type="2001" element="_zVhKMmhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVkNgGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVkNgWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ0GhNEe61iIFaFaTqIQ" type="3003" element="_zVhxQGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ0WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ0mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVjmdmhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVjmd2hNEe61iIFaFaTqIQ" x="160"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVkNgmhNEe61iIFaFaTqIQ" type="2001" element="_zVhxQmhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVkNhWhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVkNhmhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ02hNEe61iIFaFaTqIQ" type="3003" element="_zVhxQ2hNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ1GhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ1WhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVkNg2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVkNhGhNEe61iIFaFaTqIQ" x="320"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVkNh2hNEe61iIFaFaTqIQ" type="2001" element="_zVhxRWhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVkNimhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVkNi2hNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ1mhNEe61iIFaFaTqIQ" type="3003" element="_zVhxRmhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ12hNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ2GhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVkNiGhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVkNiWhNEe61iIFaFaTqIQ" x="430"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVkNjGhNEe61iIFaFaTqIQ" type="2001" element="_zVhxSGhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVkNj2hNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVkNkGhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ2WhNEe61iIFaFaTqIQ" type="3003" element="_zVhxSWhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ2mhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ22hNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVkNjWhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVkNjmhNEe61iIFaFaTqIQ" x="590"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVkNkWhNEe61iIFaFaTqIQ" type="2001" element="_zVhxS2hNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVkNlGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVkNlWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ3GhNEe61iIFaFaTqIQ" type="3003" element="_zVhxTGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ3WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ3mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVkNkmhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVkNk2hNEe61iIFaFaTqIQ" x="750"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVkNlmhNEe61iIFaFaTqIQ" type="2001" element="_zVhxTmhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVkNmWhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVkNmmhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ32hNEe61iIFaFaTqIQ" type="3003" element="_zVhxT2hNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ4GhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ4WhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVkNl2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVkNmGhNEe61iIFaFaTqIQ" x="860"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVkNm2hNEe61iIFaFaTqIQ" type="2001" element="_zVhxUWhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVk0kGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVk0kWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ4mhNEe61iIFaFaTqIQ" type="3003" element="_zVhxUmhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ42hNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ5GhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVkNnGhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVkNnWhNEe61iIFaFaTqIQ" y="90"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVk0kmhNEe61iIFaFaTqIQ" type="2001" element="_zVhxVGhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVk0lWhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVk0lmhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ5WhNEe61iIFaFaTqIQ" type="3003" element="_zVhxVWhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ5mhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ52hNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVk0k2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVk0lGhNEe61iIFaFaTqIQ" x="160" y="94"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVk0l2hNEe61iIFaFaTqIQ" type="2001" element="_zVhxV2hNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVk0mmhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVk0m2hNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ6GhNEe61iIFaFaTqIQ" type="3003" element="_zVhxWGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ6WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ6mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVk0mGhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVk0mWhNEe61iIFaFaTqIQ" x="320" y="94"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVk0nGhNEe61iIFaFaTqIQ" type="2001" element="_zVhxWmhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVk0n2hNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVk0oGhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVnQ62hNEe61iIFaFaTqIQ" type="3003" element="_zViYUGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVnQ7GhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVnQ7WhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVk0nWhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVk0nmhNEe61iIFaFaTqIQ" x="430" y="90"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVk0oWhNEe61iIFaFaTqIQ" type="2001" element="_zViYUmhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVk0pGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVk0pWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn34GhNEe61iIFaFaTqIQ" type="3003" element="_zViYU2hNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn34WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn34mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVk0omhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVk0o2hNEe61iIFaFaTqIQ" x="590" y="90"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVk0pmhNEe61iIFaFaTqIQ" type="2001" element="_zViYVWhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVk0qWhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVk0qmhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn342hNEe61iIFaFaTqIQ" type="3003" element="_zViYVmhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn35GhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn35WhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVk0p2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVk0qGhNEe61iIFaFaTqIQ" x="750" y="90"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVlboGhNEe61iIFaFaTqIQ" type="2001" element="_zViYWGhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVlbo2hNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVlbpGhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn35mhNEe61iIFaFaTqIQ" type="3003" element="_zViYWWhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn352hNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn36GhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVlboWhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVlbomhNEe61iIFaFaTqIQ" x="860" y="94"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVlbpWhNEe61iIFaFaTqIQ" type="2001" element="_zViYW2hNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVlbqGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVlbqWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn36WhNEe61iIFaFaTqIQ" type="3003" element="_zViYXGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn36mhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn362hNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVlbpmhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVlbp2hNEe61iIFaFaTqIQ" y="170" width="120" height="120"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVlbqmhNEe61iIFaFaTqIQ" type="2001" element="_zViYXmhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVlbrWhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVlbrmhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn37GhNEe61iIFaFaTqIQ" type="3003" element="_zViYX2hNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn37WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn37mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVlbq2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVlbrGhNEe61iIFaFaTqIQ" x="180" y="170" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVlbr2hNEe61iIFaFaTqIQ" type="2001" element="_zViYYWhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVlbsmhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVlbs2hNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn372hNEe61iIFaFaTqIQ" type="3003" element="_zViYYmhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn38GhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn38WhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVlbsGhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVlbsWhNEe61iIFaFaTqIQ" x="360" y="170" width="50" height="120"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVlbtGhNEe61iIFaFaTqIQ" type="2001" element="_zViYZGhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVlbt2hNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVlbuGhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn38mhNEe61iIFaFaTqIQ" type="3003" element="_zViYZWhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn382hNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn39GhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVlbtWhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVlbtmhNEe61iIFaFaTqIQ" x="470" y="170" width="120" height="120"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVlbuWhNEe61iIFaFaTqIQ" type="2001" element="_zViYZ2hNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmCsGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmCsWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn39WhNEe61iIFaFaTqIQ" type="3003" element="_zViYaGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn39mhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn392hNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVlbumhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVlbu2hNEe61iIFaFaTqIQ" x="650" y="170" width="120" height="120"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmCsmhNEe61iIFaFaTqIQ" type="2001" element="_zVi_YWhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmCtWhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmCtmhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn3-GhNEe61iIFaFaTqIQ" type="3003" element="_zVi_YmhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn3-WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn3-mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmCs2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmCtGhNEe61iIFaFaTqIQ" x="830" y="170" width="50" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmCt2hNEe61iIFaFaTqIQ" type="2001" element="_zVi_ZGhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmCumhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmCu2hNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVn3-2hNEe61iIFaFaTqIQ" type="3003" element="_zVi_ZWhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVn3_GhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVn3_WhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmCuGhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmCuWhNEe61iIFaFaTqIQ" x="940" y="170" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmCvGhNEe61iIFaFaTqIQ" type="2001" element="_zVi_Z2hNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmCv2hNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmCwGhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVoe8GhNEe61iIFaFaTqIQ" type="3003" element="_zVi_aGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVoe8WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVoe8mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmCvWhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmCvmhNEe61iIFaFaTqIQ" y="340" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmCwWhNEe61iIFaFaTqIQ" type="2001" element="_zVi_amhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmCxGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmCxWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVoe82hNEe61iIFaFaTqIQ" type="3003" element="_zVi_a2hNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVoe9GhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVoe9WhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmCwmhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmCw2hNEe61iIFaFaTqIQ" x="180" y="340" width="50" height="120"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmCxmhNEe61iIFaFaTqIQ" type="2001" element="_zVi_bWhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmpwGhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmpwWhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVoe9mhNEe61iIFaFaTqIQ" type="3003" element="_zVi_bmhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVoe92hNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVoe-GhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmCx2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmCyGhNEe61iIFaFaTqIQ" x="290" y="340" width="50" height="120"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmpwmhNEe61iIFaFaTqIQ" type="2001" element="_zVi_cGhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmpxWhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmpxmhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVoe-WhNEe61iIFaFaTqIQ" type="3003" element="_zVi_cWhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVoe-mhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVoe-2hNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmpw2hNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmpxGhNEe61iIFaFaTqIQ" x="400" y="340" width="50" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmpx2hNEe61iIFaFaTqIQ" type="2001" element="_zVi_c2hNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmpymhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmpy2hNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVoe_GhNEe61iIFaFaTqIQ" type="3003" element="_zVi_dGhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVoe_WhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVoe_mhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmpyGhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmpyWhNEe61iIFaFaTqIQ" x="510" y="340" width="50" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmpzGhNEe61iIFaFaTqIQ" type="2001" element="_zVi_dmhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmpz2hNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmp0GhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVoe_2hNEe61iIFaFaTqIQ" type="3003" element="_zVi_d2hNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVofAGhNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVofAWhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmpzWhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmpzmhNEe61iIFaFaTqIQ" x="620" y="340" width="50" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_zVmp0WhNEe61iIFaFaTqIQ" type="2001" element="_zVi_eWhNEe61iIFaFaTqIQ">
+          <children xmi:type="notation:Node" xmi:id="_zVmp1GhNEe61iIFaFaTqIQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_zVmp1WhNEe61iIFaFaTqIQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_zVofAmhNEe61iIFaFaTqIQ" type="3003" element="_zVi_emhNEe61iIFaFaTqIQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_zVofA2hNEe61iIFaFaTqIQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVofBGhNEe61iIFaFaTqIQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_zVmp0mhNEe61iIFaFaTqIQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zVmp02hNEe61iIFaFaTqIQ" x="730" y="340" width="120" height="120"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_zVf8EmhNEe61iIFaFaTqIQ"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_zVi_fGhNEe61iIFaFaTqIQ" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_zVi_fWhNEe61iIFaFaTqIQ"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVf8E2hNEe61iIFaFaTqIQ" name="EClass01" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass01"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass01"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhKMGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhKMmhNEe61iIFaFaTqIQ" name="EClass02" height="5" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass02"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass02"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxQGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxQmhNEe61iIFaFaTqIQ" name="EClass03" width="5" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass03"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass03"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxQ2hNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxRWhNEe61iIFaFaTqIQ" name="EClass04" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass04"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass04"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxRmhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.3/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxSGhNEe61iIFaFaTqIQ" name="EClass05" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass05"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass05"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxSWhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.4/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxS2hNEe61iIFaFaTqIQ" name="EClass06" width="5" height="5" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass06"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass06"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxTGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxTmhNEe61iIFaFaTqIQ" name="EClass07" height="5" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass07"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass07"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxT2hNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.6/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxUWhNEe61iIFaFaTqIQ" name="EClass08" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass08"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass08"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxUmhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.7/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxVGhNEe61iIFaFaTqIQ" name="EClass09" width="5" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass09"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass09"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxVWhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.8/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxV2hNEe61iIFaFaTqIQ" name="EClass10" width="5" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass10"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass10"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVhxWGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.9/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVhxWmhNEe61iIFaFaTqIQ" name="EClass11" width="5" height="5" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass11"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass11"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYUGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.10/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYUmhNEe61iIFaFaTqIQ" name="EClass12" width="5" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass12"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass12"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYU2hNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.11/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYVWhNEe61iIFaFaTqIQ" name="EClass13" width="5" height="5">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass13"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass13"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYVmhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.12/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYWGhNEe61iIFaFaTqIQ" name="EClass14">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass14"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass14"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYWWhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.13/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYW2hNEe61iIFaFaTqIQ" name="EClass15" width="12" height="12" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass15"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass15"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYXGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.14/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYXmhNEe61iIFaFaTqIQ" name="EClass16" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass16"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass16"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYX2hNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.15/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYYWhNEe61iIFaFaTqIQ" name="EClass17" width="5" height="12" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass17"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass17"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYYmhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.16/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYZGhNEe61iIFaFaTqIQ" name="EClass18" width="12" height="12" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass18"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass18"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYZWhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.17/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zViYZ2hNEe61iIFaFaTqIQ" name="EClass19" width="12" height="12" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass19"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass19"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zViYaGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.18/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_YWhNEe61iIFaFaTqIQ" name="EClass20" width="5" height="5" resizeKind="NSEW">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass20"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass20"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_YmhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.19/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_ZGhNEe61iIFaFaTqIQ" name="EClass21" width="12" height="5" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass21"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass21"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_ZWhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.20/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_Z2hNEe61iIFaFaTqIQ" name="EClass22" width="12" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass22"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass22"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_aGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.21/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_amhNEe61iIFaFaTqIQ" name="EClass23" width="5" height="12" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass23"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass23"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_a2hNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.22/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_bWhNEe61iIFaFaTqIQ" name="EClass24" width="5" height="12" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass24"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass24"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_bmhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.23/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_cGhNEe61iIFaFaTqIQ" name="EClass25" width="5" height="5" resizeKind="NORTH_SOUTH">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass25"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass25"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_cWhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.24/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_c2hNEe61iIFaFaTqIQ" name="EClass26" width="5" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass26"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass26"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_dGhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.25/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_dmhNEe61iIFaFaTqIQ" name="EClass27" width="5" height="5">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass27"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass27"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_d2hNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node" width="5" height="5">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.26/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_zVi_eWhNEe61iIFaFaTqIQ" name="EClass28" width="12" height="12">
+      <target xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass28"/>
+      <semanticElements xmi:type="ecore:EClass" href="github-issue-65.ecore#//EClass28"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_zVi_emhNEe61iIFaFaTqIQ" labelSize="12" labelPosition="node">
+        <description xmi:type="style:SquareDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']/@conditionnalStyles.27/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_zVcRsGhNEe61iIFaFaTqIQ"/>
+    <activatedLayers xmi:type="description_1:Layer" href="github-issue-65.odesign#//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer"/>
+    <target xmi:type="ecore:EPackage" href="github-issue-65.ecore#/"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/size/github-issue-65/github-issue-65.ecore
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/size/github-issue-65/github-issue-65.ecore
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="EPackageRoot">
+  <eClassifiers xsi:type="ecore:EClass" name="EClass01"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass02"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass03"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass04"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass05"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass06"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass07"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass08"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass09"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass10"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass11"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass12"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass13"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass14"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass15"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass16"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass17"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass18"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass19"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass20"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass21"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass22"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass23"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass24"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass25"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass26"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass27"/>
+  <eClassifiers xsi:type="ecore:EClass" name="EClass28"/>
+</ecore:EPackage>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/size/github-issue-65/github-issue-65.odesign
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/size/github-issue-65/github-issue-65.odesign
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" xmlns:tool_1="http://www.eclipse.org/sirius/description/tool/1.1.0" name="github-issue-65" version="12.0.0.2017041100">
+  <ownedViewpoints name="github-issue-65" label="github-issue-65">
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" name="github-issue-65" label="github-issue-65" domainClass="EPackage" enablePopupBars="true">
+      <metamodel href="http://www.eclipse.org/emf/2002/Ecore#/"/>
+      <defaultLayer name="Default">
+        <nodeMappings name="eClass1" labelDirectEdit="//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@toolSections.0/@ownedTools[name='editClassName']" domainClass="EClass">
+          <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NSEW">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+          </style>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass01'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass02'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NSEW" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass03'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NSEW" width="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass04'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NORTH_SOUTH">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass05'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="EAST_WEST">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass06'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NSEW" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass07'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NORTH_SOUTH" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass08'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="EAST_WEST" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass09'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NORTH_SOUTH" width="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass10'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="EAST_WEST" width="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass11'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="NORTH_SOUTH" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass12'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" resizeKind="EAST_WEST" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass13'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass14'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="-1" labelPosition="node">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass15'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass16'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NSEW" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass17'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NSEW" width="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass18'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NORTH_SOUTH">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass19'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="EAST_WEST">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass20'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NSEW" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass21'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NORTH_SOUTH" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass22'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="EAST_WEST" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass23'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NORTH_SOUTH" width="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass24'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="EAST_WEST" width="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass25'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="NORTH_SOUTH" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass26'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" resizeKind="EAST_WEST" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass27'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node" width="5" height="5">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+          <conditionnalStyles predicateExpression="aql:self.name='EClass28'">
+            <style xsi:type="style:SquareDescription" labelSize="12" sizeComputationExpression="12" labelPosition="node">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </conditionnalStyles>
+        </nodeMappings>
+        <toolSections name="CreationTools">
+          <ownedTools xsi:type="tool:NodeCreationDescription" name="EClass" nodeMappings="//@ownedViewpoints[name='github-issue-65']/@ownedRepresentations[name='github-issue-65']/@defaultLayer/@nodeMappings[name='eClass1']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="ecore::EClass" referenceName="eClassifiers">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="name" valueExpression="aql:'EClass'+self.ePackage.eClassifiers->filter(ecore::EClass)->size()"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:DirectEditLabel" name="editClassName">
+            <mask mask="{0}"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:SetValue" featureName="name" valueExpression="var:arg0"/>
+            </initialOperation>
+          </ownedTools>
+        </toolSections>
+      </defaultLayer>
+    </ownedRepresentations>
+  </ownedViewpoints>
+</description:Group>

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SetStyleToWorkspaceImageTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SetStyleToWorkspaceImageTests.java
@@ -795,7 +795,7 @@ public class SetStyleToWorkspaceImageTests extends AbstractSiriusSwtBotGefTestCa
         Dimension newGMFSize = getSize((Node) part.getNotationView());
         Dimension newD2DSize = getSize(part.getFigure());
 
-        assertEquals("The GMF height should be set to -1.", -1, newGMFSize.height);
+        assertEquals("The GMF height should be kept.", oldGMFSize.height, newGMFSize.height);
         assertEquals("The GMF width should be kept.", oldGMFSize.width, newGMFSize.width);
 
         if (part instanceof IDiagramContainerEditPart || part instanceof IDiagramListEditPart) {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SizeComputationExpressionTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SizeComputationExpressionTest.java
@@ -1,0 +1,288 @@
+/*******************************************************************************
+ * Copyright (c) 2023 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.tests.swtbot;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNodeEditPart;
+import org.eclipse.sirius.diagram.ui.tools.api.layout.LayoutUtils;
+import org.eclipse.sirius.tests.support.api.GraphicTestsSupportHelp;
+import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
+import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
+import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckEditPartMoved;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckEditPartResized;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.TextEditorAppearedCondition;
+import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
+import org.junit.Assert;
+
+/**
+ * This class tests different configurations of the size computation expression.
+ * 
+ * @author gplouhinec
+ */
+public class SizeComputationExpressionTest extends AbstractSiriusSwtBotGefTestCase {
+
+    private UIResource sessionAirdResource;
+
+    private UILocalSession localSession;
+
+    private static final String DATA_UNIT_DIR = "data/unit/size/github-issue-65/"; //$NON-NLS-1$
+
+    private static final String MODEL = "github-issue-65.ecore"; //$NON-NLS-1$
+
+    private static final String SESSION_FILE = "github-issue-65.aird"; //$NON-NLS-1$
+
+    private static final String FILE_DIR = "/"; //$NON-NLS-1$
+
+    private static final String VSM_FILE = "github-issue-65.odesign"; //$NON-NLS-1$
+
+    private static final String REPRESENTATION_DESCRIPTION_NAME = "github-issue-65"; //$NON-NLS-1$
+
+    private static final String REPRESENTATION_NAME = "new " + REPRESENTATION_DESCRIPTION_NAME; //$NON-NLS-1$
+
+    private static final int DEFAULT_WIDTH_OR_HEIGHT = 0;
+
+    private static final int CUSTOM_WIDTH_OR_HEIGHT = 5;
+
+    private static final int AUTO_SIZE_MODE = -1;
+
+    private static final int CUSTOM_SIZE_COMPUTATION_EXPRESSION = 12;
+
+    private static final int WIDTH_AUTO_SIZED = 101;
+
+    private static final int HEIGHT_AUTO_SIZED = 51;
+    
+    private static final int HEIGHT_AFTER_RENAME = 72;
+
+    private static final int WIDTH_AFTER_RENAME = 210;
+
+    private static final String NEW_ECLASS_NAME = "EClass 01234567890123456789"; //$NON-NLS-1$
+
+    @Override
+    protected void onSetUpBeforeClosingWelcomePage() throws Exception {
+        copyFileToTestProject(Activator.PLUGIN_ID, DATA_UNIT_DIR, MODEL, SESSION_FILE, VSM_FILE);
+    }
+
+    @Override
+    protected void onSetUpAfterOpeningDesignerPerspective() throws Exception {
+        sessionAirdResource = new UIResource(designerProject, FILE_DIR, SESSION_FILE);
+        localSession = designerPerspective.openSessionFromFile(sessionAirdResource);
+        editor = (SWTBotSiriusDiagramEditor) openRepresentation(localSession.getOpenedSession(), REPRESENTATION_DESCRIPTION_NAME, REPRESENTATION_NAME, DDiagram.class);
+    }
+
+    public void testAutoSizeComputationExpression() {
+        // Creates an EClass at a free location
+        SWTBotGefEditPart eClassEP = editor.getEditPart("EClass28", AbstractDiagramNodeEditPart.class); //$NON-NLS-1$
+        Point point = editor.getBounds(eClassEP).getTopRight().getCopy();
+        point.x = point.x + 10;
+        editor.activateTool("EClass"); //$NON-NLS-1$
+        editor.click(point);
+
+        // Select the new EClass and direct edit
+        eClassEP = editor.getEditPart("EClass29", AbstractDiagramNodeEditPart.class); //$NON-NLS-1$
+        editor.click(eClassEP);
+        bot.waitUntil(new CheckSelectedCondition(editor, "EClass29", AbstractDiagramNodeEditPart.class)); //$NON-NLS-1$
+        // Click a second time on the edit part to enable the direct edit mode.
+        editor.clickCentered(eClassEP);
+        bot.waitUntil(new TextEditorAppearedCondition(editor, AbstractDiagramNodeEditPart.class, null));
+        // Edit the current edit part by adding a suffix to its current name.
+        editor.directEditType(NEW_ECLASS_NAME);
+
+        // Check that an editPart exists with the expected new name.
+        eClassEP = editor.getEditPart(NEW_ECLASS_NAME, AbstractDiagramNodeEditPart.class);
+
+        // Check its new size
+        Dimension sizeAfterRename = editor.getBounds(eClassEP).getSize().getCopy();
+        assertEquals(HEIGHT_AFTER_RENAME, sizeAfterRename.height);
+        assertEquals(WIDTH_AFTER_RENAME, sizeAfterRename.width);
+
+        moveNodeTwiceAndCheckSize(eClassEP, HEIGHT_AFTER_RENAME, WIDTH_AFTER_RENAME);
+    }
+
+    public void testAllCombinationsSizeComputationExpressionSizeNodeWithSquareStyle() {
+        testSizeComputationExpressionSquareStyle("EClass01", AUTO_SIZE_MODE, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass02", AUTO_SIZE_MODE, CUSTOM_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass03", AUTO_SIZE_MODE, DEFAULT_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass04", AUTO_SIZE_MODE, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass05", AUTO_SIZE_MODE, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass06", AUTO_SIZE_MODE, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass07", AUTO_SIZE_MODE, CUSTOM_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass08", AUTO_SIZE_MODE, CUSTOM_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass09", AUTO_SIZE_MODE, DEFAULT_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass10", AUTO_SIZE_MODE, DEFAULT_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass11", AUTO_SIZE_MODE, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass12", AUTO_SIZE_MODE, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass13", AUTO_SIZE_MODE, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, false, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass14", AUTO_SIZE_MODE, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, false, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass15", CUSTOM_SIZE_COMPUTATION_EXPRESSION, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass16", CUSTOM_SIZE_COMPUTATION_EXPRESSION, CUSTOM_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass17", CUSTOM_SIZE_COMPUTATION_EXPRESSION, DEFAULT_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass18", CUSTOM_SIZE_COMPUTATION_EXPRESSION, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass19", CUSTOM_SIZE_COMPUTATION_EXPRESSION, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass20", CUSTOM_SIZE_COMPUTATION_EXPRESSION, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass21", CUSTOM_SIZE_COMPUTATION_EXPRESSION, CUSTOM_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass22", CUSTOM_SIZE_COMPUTATION_EXPRESSION, CUSTOM_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass23", CUSTOM_SIZE_COMPUTATION_EXPRESSION, DEFAULT_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass24", CUSTOM_SIZE_COMPUTATION_EXPRESSION, DEFAULT_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass25", CUSTOM_SIZE_COMPUTATION_EXPRESSION, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, false, true); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass26", CUSTOM_SIZE_COMPUTATION_EXPRESSION, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, true, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass27", CUSTOM_SIZE_COMPUTATION_EXPRESSION, CUSTOM_WIDTH_OR_HEIGHT, CUSTOM_WIDTH_OR_HEIGHT, false, false); //$NON-NLS-1$
+        testSizeComputationExpressionSquareStyle("EClass28", CUSTOM_SIZE_COMPUTATION_EXPRESSION, DEFAULT_WIDTH_OR_HEIGHT, DEFAULT_WIDTH_OR_HEIGHT, false, false); //$NON-NLS-1$
+    }
+
+    /**
+     * Tests that an element is the right size depending the following parameters after opening the diagram, moving the
+     * element and resizing it.
+     * 
+     * @param eClassName
+     *            the name of the element to test
+     * @param sizeComputationExpression
+     *            value of the Size Computation Expression in VSM; -1 value corresponds to auto size mode
+     * @param heightExpression
+     *            value of the Height Expression in VSM; 0 is the default value
+     * @param widthExpression
+     *            value of the Width Expression in VSM; 0 is the default value
+     * @param horizontalResizingAllowed
+     *            indicates if horizontal resize is allowed in VSM
+     * @param verticalResizingAllowed
+     *            indicates if vertical resize is allowed in VSM
+     */
+    private void testSizeComputationExpressionSquareStyle(String eClassName, int sizeComputationExpression, int heightExpression, int widthExpression, boolean horizontalResizingAllowed,
+            boolean verticalResizingAllowed) {
+        SWTBotGefEditPart eClassEP = editor.getEditPart(eClassName, AbstractDiagramNodeEditPart.class);
+        editor.click(eClassEP);
+        bot.waitUntil(new CheckSelectedCondition(editor, eClassName, AbstractDiagramNodeEditPart.class));
+
+        int expectedHeight = HEIGHT_AUTO_SIZED;
+        int expectedWidth = WIDTH_AUTO_SIZED;
+        if (sizeComputationExpression != -1) {
+            expectedHeight = sizeComputationExpression * LayoutUtils.SCALE;
+            expectedWidth = sizeComputationExpression * LayoutUtils.SCALE;
+        }
+        if (heightExpression != 0) {
+            expectedHeight = heightExpression * LayoutUtils.SCALE;
+        }
+        if (widthExpression != 0) {
+            expectedWidth = widthExpression * LayoutUtils.SCALE;
+        }
+        Dimension size = editor.getBounds(eClassEP).getSize().getCopy();
+        assertEquals(expectedHeight, size.height);
+        assertEquals(expectedWidth, size.width);
+
+        // Move the node twice: A common bug is that the size changes after moving the node once or twice, so we check
+        // that the size hasn't changed.
+        moveNodeTwiceAndCheckSize(eClassEP, expectedHeight, expectedWidth);
+
+        // Resize the node horizontally and vertically.
+        resizeHorizontallyAndVerticallyAndCheckSize(eClassEP, horizontalResizingAllowed, verticalResizingAllowed, expectedHeight, expectedWidth);
+    }
+
+    /**
+     * Used to move a node twice and check that its size hasn't changed after each move. A common bug is that the size
+     * is updated after moving the node once or twice.
+     * 
+     * @param eClassEP
+     *            the element to move
+     * @param expectedHeight
+     *            vertical size value before move
+     * @param expectedWidth
+     *            horizontal size value before move
+     */
+    private void moveNodeTwiceAndCheckSize(SWTBotGefEditPart eClassEP, int expectedHeight, int expectedWidth) {
+        Point eClassCenterBeforeMove = editor.getBounds(eClassEP).getCenter().getCopy();
+        Point eClassNewPosition = new Point(eClassCenterBeforeMove.x + 50, eClassCenterBeforeMove.y + 50);
+        CheckEditPartMoved movedCondition = new CheckEditPartMoved(eClassEP);
+        editor.drag(eClassCenterBeforeMove, eClassNewPosition);
+        // Check it has been properly moved and its size hasn't changed.
+        bot.waitUntil(movedCondition);
+        GraphicTestsSupportHelp.assertEquals(eClassNewPosition, editor.getBounds(eClassEP).getCenter().getCopy(), 2);
+        Dimension sizeAfterMove = editor.getBounds(eClassEP).getSize().getCopy();
+        assertEquals(expectedHeight, sizeAfterMove.height);
+        assertEquals(expectedWidth, sizeAfterMove.width);
+
+        movedCondition = new CheckEditPartMoved(eClassEP);
+        editor.drag(eClassNewPosition, eClassCenterBeforeMove);
+        // Check it has been properly moved a second time and its size hasn't changed.
+        bot.waitUntil(movedCondition);
+        GraphicTestsSupportHelp.assertEquals(eClassCenterBeforeMove, editor.getBounds(eClassEP).getCenter().getCopy(), 2);
+        sizeAfterMove = editor.getBounds(eClassEP).getSize().getCopy();
+        assertEquals(expectedHeight, sizeAfterMove.height);
+        assertEquals(expectedWidth, sizeAfterMove.width);
+    }
+
+    /**
+     * Resize the element horizontally and vertically. If a resize is not allowed, the corresponding size should not be
+     * updated.
+     * 
+     * @param eClassEP
+     *            the element to move
+     * @param horizontalResizingAllowed
+     *            indicates if horizontal resize is allowed
+     * @param verticalResizingAllowed
+     *            indicates if vertical resize is allowed
+     * @param expectedHeightBeforeResize
+     *            vertical size value before resize
+     * @param expectedWidthBeforeResize
+     *            horizontal size value before resize
+     */
+    private void resizeHorizontallyAndVerticallyAndCheckSize(SWTBotGefEditPart eClassEP, boolean horizontalResizingAllowed, boolean verticalResizingAllowed, int expectedHeightBeforeResize,
+            int expectedWidthBeforeResize) {
+        int expectedHeight = expectedHeightBeforeResize;
+        int expectedWidth = expectedWidthBeforeResize;
+
+        // Resize the element horizontally.
+        Point eClassRightBeforeResize = editor.getBounds(eClassEP).getRight().getCopy();
+        Point newRight = new Point(eClassRightBeforeResize.x + 50, eClassRightBeforeResize.y);
+        CheckEditPartResized resizedCondition = new CheckEditPartResized(eClassEP);
+        editor.drag(eClassRightBeforeResize, newRight);
+        Dimension sizeAfterMove = editor.getBounds(eClassEP).getSize().getCopy();
+        if (horizontalResizingAllowed) {
+            // Size should be updated horizontally.
+            bot.waitUntil(resizedCondition);
+            sizeAfterMove = editor.getBounds(eClassEP).getSize().getCopy();
+            GraphicTestsSupportHelp.assertEquals(newRight, editor.getBounds(eClassEP).getRight().getCopy(), 2, 0);
+            assertEquals(expectedHeight, sizeAfterMove.height);
+            Assert.assertEquals(expectedWidth + 50, sizeAfterMove.width, 2);
+            expectedWidth = sizeAfterMove.width;
+        } else {
+            // Size should not be updated.
+            GraphicTestsSupportHelp.assertEquals(eClassRightBeforeResize, editor.getBounds(eClassEP).getRight().getCopy(), 0);
+            assertEquals(expectedHeight, sizeAfterMove.height);
+            assertEquals(expectedWidth, sizeAfterMove.width);
+        }
+
+        // Resize the element vertically
+        Point eClassBottomBeforeResize = editor.getBounds(eClassEP).getBottom().getCopy();
+        Point newBottom = new Point(eClassBottomBeforeResize.x, eClassBottomBeforeResize.y + 50);
+        resizedCondition = new CheckEditPartResized(eClassEP);
+        editor.drag(eClassBottomBeforeResize, newBottom);
+        sizeAfterMove = editor.getBounds(eClassEP).getSize().getCopy();
+        if (verticalResizingAllowed) {
+            // Size should be updated vertically.
+            bot.waitUntil(resizedCondition);
+            sizeAfterMove = editor.getBounds(eClassEP).getSize().getCopy();
+            GraphicTestsSupportHelp.assertEquals(newBottom, editor.getBounds(eClassEP).getBottom().getCopy(), 0, 2);
+            Assert.assertEquals(expectedHeight + 50, sizeAfterMove.height, 2);
+            assertEquals(expectedWidth, sizeAfterMove.width);
+        } else {
+            // Size should not be updated.
+            GraphicTestsSupportHelp.assertEquals(eClassBottomBeforeResize, editor.getBounds(eClassEP).getBottom().getCopy(), 0);
+            assertEquals(expectedHeight, sizeAfterMove.height);
+            assertEquals(expectedWidth, sizeAfterMove.width);
+        }
+    }
+}

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/InstanceRoleResizableEditPolicyTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/InstanceRoleResizableEditPolicyTests.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.diagram.sequence.ui.tool.internal.edit.part.InstanceRo
 import org.eclipse.sirius.diagram.sequence.ui.tool.internal.edit.part.SequenceMessageEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckEditPartMoved;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckEditPartResized;
+import org.eclipse.sirius.tests.swtbot.support.utils.SWTBotUtils;
 import org.eclipse.sirius.tests.unit.diagram.sequence.InteractionsConstants;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
 import org.eclipse.swtbot.swt.finder.waits.ICondition;
@@ -145,12 +146,14 @@ public class InstanceRoleResizableEditPolicyTests extends AbstractDefaultModelSe
         // Create a fourteenth InstanceRoleEditPart's figure named D
         String LIFELINE_D = "d";
         SWTBotGefEditPart instanceRoleEditPartDBot = createParticipant(LIFELINE_D, instanceRoleEditPartCBounds.getRight().x, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_D += " : ";
 
         // Create a fourteenth InstanceRoleEditPart's figure named E and dropped
         // between LIFELINE_B and LIFELINE_C
         String LIFELINE_E = "e";
         createParticipant("e", instanceRoleEditPartCBounds.x - LayoutConstants.LIFELINES_MIN_X_GAP / 2, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_E += " : ";
 
         assertEquals(origin, editor.getLocation(LIFELINE_A, InstanceRoleEditPart.class));
@@ -172,6 +175,7 @@ public class InstanceRoleResizableEditPolicyTests extends AbstractDefaultModelSe
         // Create a fourteenth InstanceRoleEditPart's figure named D
         String LIFELINE_D = "d";
         SWTBotGefEditPart instanceRoleEditPartDBot = createParticipant(LIFELINE_D, instanceRoleEditPartCBounds.getRight().x, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_D += " : ";
         Rectangle instanceRoleEditPartDBounds = editor.getBounds(instanceRoleEditPartDBot);
 
@@ -179,6 +183,7 @@ public class InstanceRoleResizableEditPolicyTests extends AbstractDefaultModelSe
         // between LIFELINE_B and LIFELINE_C
         String LIFELINE_E = "e";
         SWTBotGefEditPart instanceRoleEditPartEBot = createParticipant(LIFELINE_E, instanceRoleEditPartDBounds.getTopRight().x, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_E += " : ";
         Rectangle instanceRoleEditPartEBounds = editor.getBounds(instanceRoleEditPartEBot);
 
@@ -203,12 +208,14 @@ public class InstanceRoleResizableEditPolicyTests extends AbstractDefaultModelSe
         // Create a fourteenth InstanceRoleEditPart's figure named D
         String LIFELINE_D = "d";
         SWTBotGefEditPart instanceRoleEditPartDBot = createParticipant(LIFELINE_D, instanceRoleEditPartCBounds.getRight().x, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_D += " : ";
         Rectangle instanceRoleEditPartDBounds = editor.getBounds(instanceRoleEditPartDBot);
 
         // Create a fourteenth InstanceRoleEditPart's figure named E
         String LIFELINE_E = "e";
         SWTBotGefEditPart instanceRoleEditPartEBot = createParticipant("e", instanceRoleEditPartDBounds.getTopRight().x, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_E += " : ";
         Rectangle instanceRoleEditPartEBounds = editor.getBounds(instanceRoleEditPartEBot);
 
@@ -217,6 +224,7 @@ public class InstanceRoleResizableEditPolicyTests extends AbstractDefaultModelSe
         int delta = 10;
         ICondition condition = new CheckEditPartMoved(instanceRoleEditPartDBot);
         createMessage(InteractionsConstants.CREATE_TOOL_ID, LIFELINE_B, instanceRoleEditPartBBounds.getBottom().y + delta, LIFELINE_D, instanceRoleEditPartDBounds.y + 10);
+        SWTBotUtils.waitAllUiEvents();
         bot.waitUntil(condition);
 
         assertEquals(instanceRoleEditPartABounds.getLocation(), editor.getLocation(LIFELINE_A, InstanceRoleEditPart.class));
@@ -270,18 +278,21 @@ public class InstanceRoleResizableEditPolicyTests extends AbstractDefaultModelSe
         // Create a fourteenth InstanceRoleEditPart's figure named D
         String LIFELINE_D = "d";
         SWTBotGefEditPart instanceRoleEditPartDBot = createParticipant(LIFELINE_D, instanceRoleEditPartCBounds.getRight().x, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_D += " : ";
         Rectangle instanceRoleEditPartDBounds = editor.getBounds(instanceRoleEditPartDBot);
 
         // Create a fourteenth InstanceRoleEditPart's figure named E
         String LIFELINE_E = "e";
         createParticipant("e", instanceRoleEditPartDBounds.getTopRight().x, LayoutConstants.LIFELINES_START_Y);
+        SWTBotUtils.waitAllUiEvents();
         LIFELINE_E += " : ";
 
         // Multiple moving of LIFELINE_A and LIFELINE_C on LIFELINE_D to have :
         // LIFELINE_B, LIFELINE_A, LIFELINE_D, LIFELINE_E and LIFELINE_C order
         editor.select(instanceRoleEditPartABot.parent(), instanceRoleEditPartCBot.parent());
         editor.drag(instanceRoleEditPartABot.parent(), instanceRoleEditPartCBounds.getTopRight().x, origin.y);
+        SWTBotUtils.waitAllUiEvents();
 
         assertEquals(instanceRoleEditPartBBounds.getLocation(), editor.getLocation(LIFELINE_B, InstanceRoleEditPart.class));
         Point instanceRoleEditPartAFutureLocation = instanceRoleEditPartCBounds.getTopRight();

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
@@ -52,9 +52,9 @@ import org.eclipse.sirius.tests.swtbot.layout.ContainerAndNodeCopyPasteFormatTes
 import org.eclipse.sirius.tests.swtbot.layout.ContainerDefaultSizeLayoutTest;
 import org.eclipse.sirius.tests.swtbot.layout.EdgeAndPortStabilityOnSemanticChangeTest;
 import org.eclipse.sirius.tests.swtbot.layout.EdgeCopyPasteFormatTest;
+import org.eclipse.sirius.tests.swtbot.layout.EdgeLabelsAlignAndDistributeTests;
 import org.eclipse.sirius.tests.swtbot.layout.EdgeLayoutStabilityWithToolWizardTest;
 import org.eclipse.sirius.tests.swtbot.layout.EdgeStabilityOnCopyPasteLayoutTest;
-import org.eclipse.sirius.tests.swtbot.layout.EdgeLabelsAlignAndDistributeTests;
 import org.eclipse.sirius.tests.swtbot.layout.LayoutStabilityOnManualRefreshTest;
 import org.eclipse.sirius.tests.swtbot.layout.ModifyEdgeLayoutAfterRefreshTest;
 import org.eclipse.sirius.tests.swtbot.layout.PackageLayoutStabilityOnManyViewsCreationToolTest;
@@ -353,6 +353,7 @@ public class AllTestSuite extends TestCase {
         suite.addTestSuite(EditPartSelectionTest.class);
         suite.addTestSuite(LabelFontModificationsTest.class);
         suite.addTestSuite(CreatedElementsLayoutTests.class);
+        suite.addTestSuite(SizeComputationExpressionTest.class);
     }
 
     /**


### PR DESCRIPTION
See issue #65 

The label of nodes is now properly displayed and the size of nodes increases with the size of the label.
![image](https://github.com/eclipse-sirius/sirius-desktop/assets/33932970/03614dd0-597c-4026-a8bf-9908e52c735e)
