### PR TITLE
[145] Arrange linked border nodes when updating their container

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/view/SiriusLayoutDataManager.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/view/SiriusLayoutDataManager.java
@@ -59,8 +59,7 @@ public interface SiriusLayoutDataManager {
     /**
      * Replace the {@link LayoutType#DEFAULT} during the opening of the diagram, if the layout used handle this kind of
      * type (see
-     * org.eclipse.sirius.diagram.ui.business.internal.view.SiriusLayoutDataManagerImpl.arrangeSeveralCreatedViews(List<IAdaptable>,
-     * IGraphicalEditPart, boolean))..
+     * {@link org.eclipse.sirius.diagram.ui.business.internal.view.SiriusLayoutDataManagerImpl#getArrangeCreatedViewsCommand(List, List, IGraphicalEditPart, String)})...
      */
     String LAYOUT_TYPE_ARRANGE_AT_OPENING = "OPENING"; //$NON-NLS-1$
 
@@ -82,6 +81,13 @@ public interface SiriusLayoutDataManager {
      * this value.
      */
     int HORIZONTAL_ARRANGEMENT = 2;
+
+    /**
+     * Replace the {@link LayoutType#DEFAULT} to tag an element and avoid moving it during layout, if the layout used
+     * handle this kind of type (see
+     * {@link org.eclipse.sirius.diagram.ui.business.internal.view.SiriusLayoutDataManagerImpl#getArrangeCreatedViewsCommand(List, List, IGraphicalEditPart, String)})...
+     */
+    String KEEP_FIXED = "KEEP FIXED"; //$NON-NLS-1$
 
     /**
      * Add a new AbstractLayoutData of this SiriusLayoutDataManagerImpl.
@@ -231,6 +237,23 @@ public interface SiriusLayoutDataManager {
      * @return the layout command
      */
     Command getArrangeCreatedViewsCommand(List<IAdaptable> createdViews, List<IAdaptable> centeredCreatedViews, IGraphicalEditPart host, boolean useSpecificLayoutType);
+
+    /**
+     * Layout the new created views.
+     * 
+     * @param createdViews
+     *            the new created views
+     * @param centeredCreatedViews
+     *            the new created views which must be layouted in the center of their containers
+     * @param host
+     *            container edit part
+     * @param specificLayoutType
+     *            the layout type (see {@link LayoutType#DEFAULT},
+     *            {@link SiriusLayoutDataManager#LAYOUT_TYPE_ARRANGE_AT_OPENING},
+     *            {@link SiriusLayoutDataManager#KEEP_FIXED})
+     * @return the layout command
+     */
+    Command getArrangeCreatedViewsCommand(List<IAdaptable> createdViews, List<IAdaptable> centeredCreatedViews, IGraphicalEditPart host, String specificLayoutType);
 
     /**
      * layout the new created views after opening the editor.

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/view/SiriusLayoutDataManagerImpl.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/view/SiriusLayoutDataManagerImpl.java
@@ -509,6 +509,12 @@ public final class SiriusLayoutDataManagerImpl implements SiriusLayoutDataManage
 
     @Override
     public Command getArrangeCreatedViewsCommand(List<IAdaptable> createdViews, List<IAdaptable> centeredCreatedViews, IGraphicalEditPart host, boolean useSpecificLayoutType) {
+        String layoutType = useSpecificLayoutType ? LAYOUT_TYPE_ARRANGE_AT_OPENING : LayoutType.DEFAULT;
+        return getArrangeCreatedViewsCommand(createdViews, centeredCreatedViews, host, layoutType);
+    }
+
+    @Override
+    public Command getArrangeCreatedViewsCommand(List<IAdaptable> createdViews, List<IAdaptable> centeredCreatedViews, IGraphicalEditPart host, String specificLayoutType) {
         // Layout only the views that are not
         // already layout (by a drag'n'drop for example)
         // if (createdViewsToLayout.size() == 1) {
@@ -520,18 +526,25 @@ public final class SiriusLayoutDataManagerImpl implements SiriusLayoutDataManage
             removeAlreadyArrangeMarker(createdViews.get(0));
             return UnexecutableCommand.INSTANCE;
         }
-        return getCreatedViewsCommandFromLayoutType(createdViews, centeredCreatedViews, host, useSpecificLayoutType);
+        return getCreatedViewsCommandFromLayoutType(createdViews, centeredCreatedViews, host, specificLayoutType);
     }
 
     /**
-     * Get the arrange command
+     * Get the arrange command depending the layout type.
      * 
      * @param createdViews
+     *            the new created views
      * @param centeredCreatedViews
+     *            the new created views which must be layouted in the center of their containers
      * @param host
-     * @return the arrange command
+     *            container edit part
+     * @param specificLayoutType
+     *            the layout type (see {@link LayoutType#DEFAULT},
+     *            {@link SiriusLayoutDataManager#LAYOUT_TYPE_ARRANGE_AT_OPENING},
+     *            {@link SiriusLayoutDataManager#KEEP_FIXED})
+     * @return the layout command
      */
-    private Command getCreatedViewsCommandFromLayoutType(List<IAdaptable> createdViews, List<IAdaptable> centeredCreatedViews, IGraphicalEditPart host, boolean useSpecificLayoutType) {
+    private Command getCreatedViewsCommandFromLayoutType(List<IAdaptable> createdViews, List<IAdaptable> centeredCreatedViews, IGraphicalEditPart host, String specificLayoutType) {
         CompoundCommand cc = new CompoundCommand();
         // Center Layout case
         if (centeredCreatedViews != null) {
@@ -545,7 +558,7 @@ public final class SiriusLayoutDataManagerImpl implements SiriusLayoutDataManage
         }
 
         // "normal" layout case
-        return arrangeSeveralCreatedViews(createdViews, host, useSpecificLayoutType);
+        return arrangeSeveralCreatedViews(createdViews, host, specificLayoutType);
     }
 
     /**
@@ -584,10 +597,16 @@ public final class SiriusLayoutDataManagerImpl implements SiriusLayoutDataManage
      * Arrange views.
      * 
      * @param createdViewsAdapters
+     *            the new created views
      * @param host
-     * @return arrange command
+     *            the container edit part
+     * @param specificLayoutType
+     *            the layout type (see {@link LayoutType#DEFAULT},
+     *            {@link SiriusLayoutDataManager#LAYOUT_TYPE_ARRANGE_AT_OPENING},
+     *            {@link SiriusLayoutDataManager#KEEP_FIXED})
+     * @return the arrange command
      */
-    private Command arrangeSeveralCreatedViews(List<IAdaptable> createdViewsAdapters, IGraphicalEditPart host, boolean useSpecificLayoutType) {
+    private Command arrangeSeveralCreatedViews(List<IAdaptable> createdViewsAdapters, IGraphicalEditPart host, String specificLayoutType) {
         if (createdViewsAdapters != null) {
             int size = createdViewsAdapters.size();
             CompoundCommand cc = new CompoundCommand();
@@ -603,12 +622,7 @@ public final class SiriusLayoutDataManagerImpl implements SiriusLayoutDataManage
                 }
 
                 if (createdViewsToLayoutAdapters.size() > 0) {
-                    DeferredLayoutCommand layoutCmd;
-                    if (useSpecificLayoutType) {
-                        layoutCmd = new DeferredLayoutCommand(host.getEditingDomain(), createdViewsToLayoutAdapters, host, LAYOUT_TYPE_ARRANGE_AT_OPENING);
-                    } else {
-                        layoutCmd = new DeferredLayoutCommand(host.getEditingDomain(), createdViewsToLayoutAdapters, host);
-                    }
+                    DeferredLayoutCommand layoutCmd = new DeferredLayoutCommand(host.getEditingDomain(), createdViewsToLayoutAdapters, host, specificLayoutType);
                     cc.add(new ICommandProxy(layoutCmd));
                     return cc;
                 }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
@@ -715,6 +715,8 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
                     }
                 }
             }
+            // If the DNodeContainer has BorderNodes, it should be marked as "to layout", to layout its BorderNodes.
+            isAlreadylayouted = isAlreadylayouted && abstractDNode.getOwnedBorderedNodes().isEmpty();
 
             if (createdView instanceof Node) {
                 Node createdNode = (Node) createdView;

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/layout/SiriusCanonicalLayoutCommand.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/layout/SiriusCanonicalLayoutCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2023 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.services.layout.LayoutType;
 import org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
 import org.eclipse.swt.widgets.Display;
@@ -40,7 +41,7 @@ public class SiriusCanonicalLayoutCommand extends RecordingCommand implements No
 
     private List<IAdaptable> centeredChildViewsAdapters;
 
-    boolean useSpecificLayoutType;
+    private String specificLayoutType;
 
     /**
      * Constructor used to do a layout on all created views child (directly or indirectly) of Diagram. </br>
@@ -70,16 +71,16 @@ public class SiriusCanonicalLayoutCommand extends RecordingCommand implements No
      *            their containers
      */
     public SiriusCanonicalLayoutCommand(TransactionalEditingDomain domain, IGraphicalEditPart parentEditPart, List<IAdaptable> childViewsAdapters, List<IAdaptable> centeredChildViewsAdapters) {
-        this(domain, parentEditPart, childViewsAdapters, centeredChildViewsAdapters, false);
+        this(domain, parentEditPart, childViewsAdapters, centeredChildViewsAdapters, LayoutType.DEFAULT);
     }
 
     public SiriusCanonicalLayoutCommand(TransactionalEditingDomain domain, IGraphicalEditPart parentEditPart, List<IAdaptable> childViewsAdapters, List<IAdaptable> centeredChildViewsAdapters,
-            boolean useSpecificLayoutType) {
+            String specificLayoutType) {
         super(domain, Messages.SiriusCanonicalLayoutCommand_label);
         this.parentEditPart = parentEditPart;
         this.childViewsAdapters = childViewsAdapters;
         this.centeredChildViewsAdapters = centeredChildViewsAdapters;
-        this.useSpecificLayoutType = useSpecificLayoutType;
+        this.specificLayoutType = specificLayoutType;
     }
 
     /**
@@ -110,7 +111,7 @@ public class SiriusCanonicalLayoutCommand extends RecordingCommand implements No
 
     private void executeLayoutDueToExternalChanges() {
         org.eclipse.gef.commands.Command arrangeCmd = SiriusLayoutDataManager.INSTANCE.getArrangeCreatedViewsCommand(childViewsAdapters, centeredChildViewsAdapters, parentEditPart,
-                useSpecificLayoutType);
+                specificLayoutType);
         if (arrangeCmd != null && arrangeCmd.canExecute() && parentEditPart != null && parentEditPart.getRoot() != null) {
             arrangeCmd.execute();
         }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/layout/SiriusCanonicalLayoutHandler.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/layout/SiriusCanonicalLayoutHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2011, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,11 +13,16 @@
 package org.eclipse.sirius.diagram.ui.internal.refresh.layout;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.emf.common.command.Command;
@@ -26,12 +31,18 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.services.layout.LayoutType;
 import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.sirius.diagram.AbstractDNode;
 import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.diagram.DNode;
 import org.eclipse.sirius.diagram.business.internal.dialect.NotYetOpenedDiagramAdapter;
 import org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager;
+import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramBorderNodeEditPart;
+import org.eclipse.sirius.diagram.ui.edit.api.part.IDiagramElementEditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.AbstractDNodeContainerCompartmentEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DDiagramEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerViewNodeContainerCompartment2EditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerViewNodeContainerCompartmentEditPart;
@@ -106,7 +117,7 @@ public final class SiriusCanonicalLayoutHandler {
                 Map<IGraphicalEditPart, List<IAdaptable>> centeredCreatedViewsToLayoutMap = getCreatedViewsToLayoutByContainerPart(diagramEditPart,
                         SiriusLayoutDataManager.INSTANCE.getCreatedViewWithCenterLayout());
                 LayoutProvider layoutProvider = LayoutService.getProvider(diagramEditPart);
-                boolean handleSpecificLayoutType = false;
+                String layoutType = LayoutType.DEFAULT;
                 if (layoutProvider instanceof GenericLayoutProvider && ((GenericLayoutProvider) layoutProvider).shouldReverseLayoutsOrder(diagramEditPart)) {
                     // Reverse order as contrary to classic layout. For example for ELK, it is better to do it from the
                     // lowest level to the highest.
@@ -116,9 +127,9 @@ public final class SiriusCanonicalLayoutHandler {
                         createdViewsToLayoutMap_reverse.put(keys.get(i), createdViewsToLayoutMap.get(keys.get(i)));
                     }
                     createdViewsToLayoutMap = createdViewsToLayoutMap_reverse;
-                    handleSpecificLayoutType = true;
+                    layoutType = SiriusLayoutDataManager.LAYOUT_TYPE_ARRANGE_AT_OPENING;
                 }
-                Command layoutCommand = getLayoutCommand(createdViewsToLayoutMap, centeredCreatedViewsToLayoutMap, editingDomain, handleSpecificLayoutType);
+                Command layoutCommand = getLayoutCommand(createdViewsToLayoutMap, centeredCreatedViewsToLayoutMap, editingDomain, layoutType);
                 if (layoutCommand.canExecute()) {
                     editingDomain.getCommandStack().execute(layoutCommand);
                 }
@@ -195,8 +206,217 @@ public final class SiriusCanonicalLayoutHandler {
         return viewAdapters;
     }
 
+    /**
+     * Gets BorderNodes of an adapted view.
+     * 
+     * @param viewAdapter
+     *            the adapted view
+     * @return the set of BorderNodes of the adapted view.
+     */
+    private static Set<DNode> getBorderNodes(IAdaptable viewAdapter) {
+        Set<DNode> borderNodes;
+        View createdView = viewAdapter.getAdapter(View.class);
+        if (createdView != null && createdView.getElement() instanceof AbstractDNode dnode) {
+            borderNodes = new HashSet<>(dnode.getOwnedBorderedNodes());
+        } else {
+            borderNodes = Collections.emptySet();
+        }
+        return borderNodes;
+    }
+
+    /**
+     * Gets BorderNodes of an EditPart.
+     * 
+     * @param elementEditPart
+     *            the EditPart
+     * @return the set of BorderNodes of the EditPart.
+     */
+    private static Set<DNode> getBorderNodes(IDiagramElementEditPart elementEditPart) {
+        Set<DNode> borderNodes;
+        if (elementEditPart.resolveDiagramElement() instanceof AbstractDNode dnode) {
+            borderNodes = new HashSet<>(dnode.getOwnedBorderedNodes());
+        } else {
+            borderNodes = Collections.emptySet();
+        }
+        return borderNodes;
+    }
+
+    /**
+     * Check if an EditPart has BorderNodes.
+     * 
+     * @param elementEditPart
+     *            the EditPart
+     * @return {@code true} if the EditPart has BorderNodes; {@code false} otherwise.
+     */
+    private static boolean hasBorderNodes(IDiagramElementEditPart elementEditPart) {
+        return !getBorderNodes(elementEditPart).isEmpty();
+    }
+
+    /**
+     * Check if an adapted view has BorderNodes.
+     * 
+     * @param viewAdapter
+     *            the adapted view
+     * @return {@code true} if the adapted view has BorderNodes; {@code false} otherwise.
+     */
+    private static boolean hasBorderNodes(IAdaptable viewAdapter) {
+        return !getBorderNodes(viewAdapter).isEmpty();
+    }
+
+    /**
+     * Used to get all adapted views which has border nodes and can be associated to the specified compartment.
+     * 
+     * @param compartmentEP
+     *            the compartment
+     * @param viewAdapters
+     *            all adapted views associated to the compartment
+     * @return the map of the Compartment EP which contains the BorderedNode EditPart associated to its adapted view
+     */
+    private static Map<IGraphicalEditPart, List<IAdaptable>> getBorderedNodesFromCompartment(AbstractDNodeContainerCompartmentEditPart compartmentEP, List<IAdaptable> viewAdapters) {
+        List<IAdaptable> existingList = new ArrayList<>();
+        for (IAdaptable viewAdapter : viewAdapters) {
+            if (hasBorderNodes(viewAdapter)) {
+                View createdView = viewAdapter.getAdapter(View.class);
+                if (createdView != null && createdView.getElement() instanceof AbstractDNode) {
+                    existingList.add(viewAdapter);
+                }
+            }
+        }
+
+        Map<IGraphicalEditPart, List<IAdaptable>> borderedNodesToLayoutMap = new LinkedHashMap<IGraphicalEditPart, List<IAdaptable>>();
+        borderedNodesToLayoutMap.put(compartmentEP, existingList);
+        return borderedNodesToLayoutMap;
+    }
+
+    private static List<View> getViews(Collection<IAdaptable> viewAdapters) {
+        return viewAdapters.stream().map(viewAdapter -> viewAdapter.getAdapter(View.class)).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    /**
+     * Used to get the BorderedNode from a BorderNode.
+     * 
+     * @param borderNodeEP
+     *            the border node
+     * @return the map of the BorderedNode EditPart associated to its adapted view
+     */
+    private static Map<IGraphicalEditPart, List<IAdaptable>> getBorderedNodesFromBorderNode(AbstractDiagramBorderNodeEditPart borderNodeEP) {
+        Map<IGraphicalEditPart, List<IAdaptable>> borderedNodesToLayoutMap = new LinkedHashMap<IGraphicalEditPart, List<IAdaptable>>();
+        if (borderNodeEP.getParent() instanceof IDiagramElementEditPart parentEP && hasBorderNodes(parentEP) && parentEP.getModel() instanceof View parentView) {
+            List<IAdaptable> viewAdapters = List.of(new EObjectAdapter(parentView));
+            borderedNodesToLayoutMap.put(parentEP, viewAdapters);
+        }
+        return borderedNodesToLayoutMap;
+    }
+
+    /**
+     * Used to perform an intelligible "borderedNodesToLayout.putAll(newBorderedNodesToLayout)". Since the value of the
+     * map is a {@code List<IAdaptable>}, we need to check that the adapted view we want to add is not present in the
+     * list.
+     * 
+     * @param borderedNodesToLayout
+     *            the map to complete
+     * @param newBorderedNodesToLayout
+     *            the Map for which we want to put all the elements in the other
+     */
+    private static void addBorderedNodeToLayout(Map<IGraphicalEditPart, List<IAdaptable>> borderedNodesToLayout, Map<IGraphicalEditPart, List<IAdaptable>> newBorderedNodesToLayout) {
+        List<View> existingViews = getViews(borderedNodesToLayout.values().stream().flatMap(List::stream).toList());
+        for (Entry<IGraphicalEditPart, List<IAdaptable>> entryToLayout : newBorderedNodesToLayout.entrySet()) {
+            IGraphicalEditPart newEditPart = entryToLayout.getKey();
+
+            List<IAdaptable> existingAdapters = borderedNodesToLayout.get(newEditPart);
+            List<View> potentialNewViews = getViews(entryToLayout.getValue());
+            for (View view : potentialNewViews) {
+                if (!existingViews.contains(view)) {
+                    if (existingAdapters == null) {
+                        existingAdapters = new ArrayList<>();
+                        borderedNodesToLayout.put(newEditPart, existingAdapters);
+                    }
+                    existingAdapters.add(new EObjectAdapter(view));
+                }
+            }
+        }
+    }
+
+    /**
+     * Make a copy of "allViewsToLayout" parameter without the elements whose layout is already managed. The
+     * allViewsToLayout parameter cannot be modified with a remove, as it is potentially being iterated over.
+     * 
+     * @param managedLayout
+     *            elements whose layout is already managed
+     * @param allViewsToLayout
+     *            all views to layout
+     * @return a copy of "allViewsToLayout" parameter without the elements whose layout is already managed
+     */
+    private static Map<IGraphicalEditPart, List<IAdaptable>> removeViewsAdaptersManagedLayout(Map<IGraphicalEditPart, List<IAdaptable>> managedLayout,
+            Map<IGraphicalEditPart, List<IAdaptable>> allViewsToLayout) {
+        Map<IGraphicalEditPart, List<IAdaptable>> remainingViewsToLayoutMap = new LinkedHashMap<IGraphicalEditPart, List<IAdaptable>>();
+        List<View> managedViews = getViews(managedLayout.values().stream().flatMap(List::stream).toList());
+        for (Entry<IGraphicalEditPart, List<IAdaptable>> entryToLayout : allViewsToLayout.entrySet()) {
+            List<IAdaptable> viewsNotManaged = new ArrayList<>();
+            for (IAdaptable viewAdapter : entryToLayout.getValue()) {
+                View view = viewAdapter.getAdapter(View.class);
+                if (!managedViews.contains(view)) {
+                    viewsNotManaged.add(viewAdapter);
+                }
+            }
+            if (!viewsNotManaged.isEmpty()) {
+                remainingViewsToLayoutMap.put(entryToLayout.getKey(), viewsNotManaged);
+            }
+        }
+        return remainingViewsToLayoutMap;
+    }
+
+    /**
+     * This method helps to layout bordered nodes with border nodes. Border nodes are not laid out, but their parent
+     * bordered node or the compartment containing their parent is laid out.
+     * 
+     * @param createdViewsToLayoutMap
+     *            the map of all adaptable GMF views associated to the edit part to layout
+     * @param editingDomain
+     *            the editing domain
+     * @param compoundCommand
+     *            the command
+     * @return the remaining views and edit part to lay out
+     */
+    private static Map<IGraphicalEditPart, List<IAdaptable>> layoutBorderAndBorderedNodes(Map<IGraphicalEditPart, List<IAdaptable>> createdViewsToLayoutMap, TransactionalEditingDomain editingDomain,
+            CompoundCommand compoundCommand) {
+        Map<IGraphicalEditPart, List<IAdaptable>> borderedNodesToLayout = new LinkedHashMap<IGraphicalEditPart, List<IAdaptable>>();
+        Map<IGraphicalEditPart, List<IAdaptable>> remainingViewsToLayoutMap = new LinkedHashMap<IGraphicalEditPart, List<IAdaptable>>(createdViewsToLayoutMap);
+        for (Entry<IGraphicalEditPart, List<IAdaptable>> entryToLayout : createdViewsToLayoutMap.entrySet()) {
+            IGraphicalEditPart editPart = entryToLayout.getKey();
+            List<IAdaptable> viewAdapters = entryToLayout.getValue();
+            if (editPart instanceof AbstractDNodeContainerCompartmentEditPart compartmentEP) {
+                // CompartmentEditPart case: we should only layout GMF Views with BorderNodes
+                Map<IGraphicalEditPart, List<IAdaptable>> borderedNodesFromCompartment = getBorderedNodesFromCompartment(compartmentEP, viewAdapters);
+                remainingViewsToLayoutMap = removeViewsAdaptersManagedLayout(borderedNodesFromCompartment, remainingViewsToLayoutMap);
+                addBorderedNodeToLayout(borderedNodesToLayout, borderedNodesFromCompartment);
+            } else if (editPart instanceof IDiagramElementEditPart elementEP && hasBorderNodes(elementEP)) {
+                // BorderedNode case: laid out if there is BorderNodes.
+                remainingViewsToLayoutMap = removeViewsAdaptersManagedLayout(Map.of(elementEP, viewAdapters), remainingViewsToLayoutMap);
+                addBorderedNodeToLayout(borderedNodesToLayout, Map.of(elementEP, viewAdapters));
+            } else if (editPart instanceof AbstractDiagramBorderNodeEditPart borderNodeEP) {
+                // BorderNode case: they are not laid out, but their parent may.
+                remainingViewsToLayoutMap = removeViewsAdaptersManagedLayout(Map.of(borderNodeEP, viewAdapters), remainingViewsToLayoutMap);
+                Map<IGraphicalEditPart, List<IAdaptable>> borderedNodesFromBorderNode = getBorderedNodesFromBorderNode(borderNodeEP);
+                remainingViewsToLayoutMap = removeViewsAdaptersManagedLayout(borderedNodesFromBorderNode, remainingViewsToLayoutMap);
+                addBorderedNodeToLayout(borderedNodesToLayout, borderedNodesFromBorderNode);
+            }
+        }
+        // Layout BorderedNodes or their Compartment.
+        for (Entry<IGraphicalEditPart, List<IAdaptable>> borderedNodeEntry : borderedNodesToLayout.entrySet()) {
+            IGraphicalEditPart editPart = borderedNodeEntry.getKey();
+            List<IAdaptable> childViewsAdapters = borderedNodeEntry.getValue();
+            // The KEEP_FIXED layout is used to avoid moving the BorderedNode, it should be located where the user
+            // clicked.
+            Command siriusCanonicalLayoutCommand = new SiriusCanonicalLayoutCommand(editingDomain, editPart, childViewsAdapters, null, SiriusLayoutDataManager.KEEP_FIXED);
+            compoundCommand.append(siriusCanonicalLayoutCommand);
+        }
+        return remainingViewsToLayoutMap;
+    }
+
     private static Command getLayoutCommand(Map<IGraphicalEditPart, List<IAdaptable>> createdViewsToLayoutMap, Map<IGraphicalEditPart, List<IAdaptable>> centeredCreatedViewsToLayoutMap,
-            TransactionalEditingDomain editingDomain, boolean useSpecificLayoutType) {
+            TransactionalEditingDomain editingDomain, String specificLayoutType) {
+
         final CompoundCommand compoundCommand = new CompoundCommand();
         // A label is explicitly added to avoid to rely on the first command of the list and also to facilitate
         // debugging.
@@ -204,7 +424,6 @@ public final class SiriusCanonicalLayoutHandler {
         // Filter type of element to layout to avoid having elements layout
         // computed multiple times
         Predicate<Entry<IGraphicalEditPart, List<IAdaptable>>> typeOfElementToLayout = new Predicate<Map.Entry<IGraphicalEditPart, List<IAdaptable>>>() {
-
             @Override
             public boolean apply(Entry<IGraphicalEditPart, List<IAdaptable>> input) {
                 return input.getKey() instanceof DDiagramEditPart || input.getKey() instanceof DNodeContainerViewNodeContainerCompartmentEditPart
@@ -212,18 +431,18 @@ public final class SiriusCanonicalLayoutHandler {
                                 && !(input.getKey().getParent().getParent() instanceof DNodeContainerViewNodeContainerCompartment2EditPart));
             }
         };
-
-        for (Entry<IGraphicalEditPart, List<IAdaptable>> entry : Iterables.filter(createdViewsToLayoutMap.entrySet(), typeOfElementToLayout)) {
+        Map<IGraphicalEditPart, List<IAdaptable>> remainingViewsToLayoutMap = layoutBorderAndBorderedNodes(createdViewsToLayoutMap, editingDomain, compoundCommand);
+        for (Entry<IGraphicalEditPart, List<IAdaptable>> entry : remainingViewsToLayoutMap.entrySet()) {
             IGraphicalEditPart parentEditPart = entry.getKey();
             List<IAdaptable> childViewsAdapters = entry.getValue();
-            Command viewpointLayoutCanonicalSynchronizerCommand = new SiriusCanonicalLayoutCommand(editingDomain, parentEditPart, childViewsAdapters, null, useSpecificLayoutType);
+            Command viewpointLayoutCanonicalSynchronizerCommand = new SiriusCanonicalLayoutCommand(editingDomain, parentEditPart, childViewsAdapters, null, specificLayoutType);
             compoundCommand.append(viewpointLayoutCanonicalSynchronizerCommand);
         }
 
         for (Entry<IGraphicalEditPart, List<IAdaptable>> entry : Iterables.filter(centeredCreatedViewsToLayoutMap.entrySet(), typeOfElementToLayout)) {
             IGraphicalEditPart parentEditPart = entry.getKey();
             List<IAdaptable> childViewsAdapters = entry.getValue();
-            Command viewpointLayoutCanonicalSynchronizerCommand = new SiriusCanonicalLayoutCommand(editingDomain, parentEditPart, null, childViewsAdapters, useSpecificLayoutType);
+            Command viewpointLayoutCanonicalSynchronizerCommand = new SiriusCanonicalLayoutCommand(editingDomain, parentEditPart, null, childViewsAdapters, specificLayoutType);
             compoundCommand.append(viewpointLayoutCanonicalSynchronizerCommand);
         }
         return compoundCommand;
@@ -242,7 +461,7 @@ public final class SiriusCanonicalLayoutHandler {
         Map<IGraphicalEditPart, List<IAdaptable>> createdViewsToLayoutMap = oldGetCreatedViewsToLayoutMap(diagramEditPart);
         Map<IGraphicalEditPart, List<IAdaptable>> createdViewsWithSpecialLayoutMap = oldGetCreatedViewsWithSpecialLayoutMap(diagramEditPart);
         LayoutProvider layoutProvider = LayoutService.getProvider(diagramEditPart);
-        boolean handleSpecificLayoutType = false;
+        String layoutType = LayoutType.DEFAULT;
         if (layoutProvider instanceof GenericLayoutProvider && ((GenericLayoutProvider) layoutProvider).shouldReverseLayoutsOrder(diagramEditPart)) {
             // Reverse order as contrary to classic layout. For example for ELK, it is better to do it from the lowest
             // level
@@ -254,9 +473,9 @@ public final class SiriusCanonicalLayoutHandler {
                 createdViewsToLayoutMap_reverse.put(keys.get(i), createdViewsToLayoutMap.get(keys.get(i)));
             }
             createdViewsToLayoutMap = createdViewsToLayoutMap_reverse;
-            handleSpecificLayoutType = true;
+            layoutType = SiriusLayoutDataManager.LAYOUT_TYPE_ARRANGE_AT_OPENING;
         }
-        Command layoutCommand = getLayoutCommand(createdViewsToLayoutMap, createdViewsWithSpecialLayoutMap, editingDomain, handleSpecificLayoutType);
+        Command layoutCommand = getLayoutCommand(createdViewsToLayoutMap, createdViewsWithSpecialLayoutMap, editingDomain, layoutType);
         if (layoutCommand.canExecute()) {
             editingDomain.getCommandStack().execute(layoutCommand);
         }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/layout/provider/DefaultLayoutProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/layout/provider/DefaultLayoutProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2008, 2009 THALES GLOBAL SERVICES.
+ * Copyright (c) 2007, 2008, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,9 @@ public class DefaultLayoutProvider extends AbstractLayoutProvider {
             ILayoutNodeOperation layoutNodeOperation = (ILayoutNodeOperation) operation;
             IAdaptable layoutHint = layoutNodeOperation.getLayoutHint();
             String layoutType = layoutHint.getAdapter(String.class);
-            return (LayoutType.DEFAULT.equals(layoutType) || SiriusLayoutDataManager.LAYOUT_TYPE_ARRANGE_AT_OPENING.equals(layoutType)) && isLayoutForSiriusDiagram(layoutNodeOperation);
+            boolean canHandleLayoutType = LayoutType.DEFAULT.equals(layoutType) || SiriusLayoutDataManager.LAYOUT_TYPE_ARRANGE_AT_OPENING.equals(layoutType)
+                    || SiriusLayoutDataManager.KEEP_FIXED.equals(layoutType);
+            return canHandleLayoutType && isLayoutForSiriusDiagram(layoutNodeOperation);
         }
         return false;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/DOperationHistoryListener.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/DOperationHistoryListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2009, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -78,6 +78,9 @@ public class DOperationHistoryListener implements IOperationHistoryListener {
                 result = false;
             } else if (Messages.SiriusContainerEditPolicy_arrangeCommandLabel.equals(originalCommand.getLabel())) {
                 // The operation is already an arrange command. No need to launch another one.
+                result = false;
+            } else if (Messages.PasteStyleDataCommand_label.equals(originalCommand.getLabel())) {
+                // Paste style operation doesn't need to launch an arrange command. 
                 result = false;
             }
         } else if (event.getOperation() instanceof EMFCommandOperation) {

--- a/plugins/org.eclipse.sirius.doc/doc/Release_Notes.html
+++ b/plugins/org.eclipse.sirius.doc/doc/Release_Notes.html
@@ -182,6 +182,21 @@
 		<ul>
 			<li><span class="label label-info">Modified</span> ArrangeBorderNodesAction.initAction now has two parameters for its text: when there is no selection, when there is a selection.</li>
 		</ul>
+		<h4 id="Changesinorg.eclipse.sirius.diagram.ui">Changes in 
+			<code>org.eclipse.sirius.diagram.ui</code>
+		</h4>
+		<ul>
+			<li><span class="label label-success">Added</span> The constant 
+				<code>org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.KEEP_FIXED</code> has been added to tag elements to be laid out and indicate that their location should not be modified.
+			</li>
+			<li><span class="label label-success">Added</span> Method 
+				<code>org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.getArrangeCreatedViewsCommand(List&lt;IAdaptable&gt;, List&lt;IAdaptable&gt;, IGraphicalEditPart, String)</code> has been added to handle the new 
+				<code>KEEP_FIXED</code> layout tag. There are now 3 types of tags that can be used for layout: 
+				<code>org.eclipse.gmf.runtime.diagram.ui.services.layout.LayoutType.DEFAULT</code>, 
+				<code>org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.LAYOUT_TYPE_ARRANGE_AT_OPENING</code> and 
+				<code>org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.KEEP_FIXED</code>.
+			</li>
+		</ul>
 		<h2 id="sirius7.3.0">Changes in Sirius 7.3.0</h2>
 		<h3 id="UserVisibleChanges2">User-Visible Changes</h3>
 		<ul>
@@ -189,7 +204,7 @@
 		</ul>
 		<h3 id="SpecifierVisibleChanges2">Specifier-Visible Changes</h3>
 		<h3 id="DeveloperVisibleChanges2">Developer-Visible Changes</h3>
-		<h4 id="Changesinorg.eclipse.sirius.diagram.ui">Changes in 
+		<h4 id="Changesinorg.eclipse.sirius.diagram.ui2">Changes in 
 			<code>org.eclipse.sirius.diagram.ui</code>
 		</h4>
 		<ul>
@@ -247,7 +262,7 @@
 			</li>
 		</ul>
 		<h3 id="DeveloperVisibleChanges3">Developer-Visible Changes</h3>
-		<h4 id="Changesinorg.eclipse.sirius.diagram.ui2">Changes in 
+		<h4 id="Changesinorg.eclipse.sirius.diagram.ui3">Changes in 
 			<code>org.eclipse.sirius.diagram.ui</code>
 		</h4>
 		<ul>
@@ -366,7 +381,7 @@
 				<code>org.eclipse.sirius.business.api.session.Session.getSharedMainDAnalysis()</code> is added to get the DAnalysis that holds data and can be shared in some context such as CDO.
 			</li>
 		</ul>
-		<h4 id="Changesinorg.eclipse.sirius.diagram.ui3">Changes in 
+		<h4 id="Changesinorg.eclipse.sirius.diagram.ui4">Changes in 
 			<code>org.eclipse.sirius.diagram.ui</code>
 		</h4>
 		<ul>
@@ -693,7 +708,7 @@
 				<code>org.eclipse.sirius.diagram.business.internal.metamodel.helper.ContentHelper.getAllEdgeMappings(diagramDescription, false)</code> alongside with the getAllNodeMappings and getAllContainerMappings methods.
 			</li>
 		</ul>
-		<h4 id="Changesinorg.eclipse.sirius.diagram.ui4">Changes in 
+		<h4 id="Changesinorg.eclipse.sirius.diagram.ui5">Changes in 
 			<code>org.eclipse.sirius.diagram.ui</code>
 		</h4>
 		<ul>
@@ -885,7 +900,7 @@
 				</ul>
 			</li>
 		</ul>
-		<h4 id="Changesinorg.eclipse.sirius.diagram.ui5">Changes in 
+		<h4 id="Changesinorg.eclipse.sirius.diagram.ui6">Changes in 
 			<code>org.eclipse.sirius.diagram.ui</code>
 		</h4>
 		<ul>
@@ -1007,7 +1022,7 @@
 				<code>new DRepresentationQuery(DRpresentation).isAutoRefresh()</code> instead.
 			</li>
 		</ul>
-		<h4 id="Changesinorg.eclipse.sirius.diagram.ui6">Changes in 
+		<h4 id="Changesinorg.eclipse.sirius.diagram.ui7">Changes in 
 			<code>org.eclipse.sirius.diagram.ui</code>
 		</h4>
 		<ul>

--- a/plugins/org.eclipse.sirius.doc/doc/Release_Notes.textile
+++ b/plugins/org.eclipse.sirius.doc/doc/Release_Notes.textile
@@ -21,6 +21,11 @@ h3. Developer-Visible Changes
 
 * <span class="label label-info">Modified</span> ArrangeBorderNodesAction.initAction now has two parameters for its text: when there is no selection, when there is a selection.
 
+h4. Changes in @org.eclipse.sirius.diagram.ui@
+
+* <span class="label label-success">Added</span> The constant @org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.KEEP_FIXED@ has been added to tag elements to be laid out and indicate that their location should not be modified.
+* <span class="label label-success">Added</span> Method @org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.getArrangeCreatedViewsCommand(List<IAdaptable>, List<IAdaptable>, IGraphicalEditPart, String)@ has been added to handle the new @KEEP_FIXED@ layout tag. There are now 3 types of tags that can be used for layout: @org.eclipse.gmf.runtime.diagram.ui.services.layout.LayoutType.DEFAULT@, @org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.LAYOUT_TYPE_ARRANGE_AT_OPENING@ and @org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager.KEEP_FIXED@.
+
 h2(#sirius7.3.0). Changes in Sirius 7.3.0
 
 h3. User-Visible Changes

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/borderNodeSide/github-issue-145/github-issue-145.aird
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/borderNodeSide/github-issue-145/github-issue-145.aird
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_y44KYHPmEe6NVsJd--VKdg" selectedViews="_ZnO6cHP7Ee6NVsJd--VKdg" version="15.2.0.202303281325">
+    <semanticResources>github-issue-145.ecore</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_ZnO6cHP7Ee6NVsJd--VKdg">
+      <viewpoint xmi:type="description:Viewpoint" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_a3ngEnQCEe6NVsJd--VKdg" name="github-issue-145" repPath="#_a3ngEHQCEe6NVsJd--VKdg" changeId="1698749922921">
+        <description xmi:type="description_1:DiagramDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']"/>
+        <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#/"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_a3ngEHQCEe6NVsJd--VKdg">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_a3ngFHQCEe6NVsJd--VKdg" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_a3ngFXQCEe6NVsJd--VKdg" type="Sirius" element="_a3ngEHQCEe6NVsJd--VKdg" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_rJh9cHQEEe6dasfQ-RvkYQ" type="2002" element="_rJeTEHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_rJh9c3QEEe6dasfQ-RvkYQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_rJikgHQEEe6dasfQ-RvkYQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_rJikgXQEEe6dasfQ-RvkYQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_rJikgnQEEe6dasfQ-RvkYQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_rJh9cXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rJh9cnQEEe6dasfQ-RvkYQ" x="273" y="180" width="263" height="163"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_r0vdonQEEe6dasfQ-RvkYQ" type="2002" element="_r0saUHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_r0wEsHQEEe6dasfQ-RvkYQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_r0wEsXQEEe6dasfQ-RvkYQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_r0wEsnQEEe6dasfQ-RvkYQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_r0wEs3QEEe6dasfQ-RvkYQ"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_8i3AwHQEEe6dasfQ-RvkYQ" type="3012" element="_8izWYHQEEe6dasfQ-RvkYQ">
+            <children xmi:type="notation:Node" xmi:id="_8i3n0HQEEe6dasfQ-RvkYQ" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_8i3n0XQEEe6dasfQ-RvkYQ" x="-14" y="-14"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_8i3n0nQEEe6dasfQ-RvkYQ" type="3003" element="_8iz9cHQEEe6dasfQ-RvkYQ">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_8i3n03QEEe6dasfQ-RvkYQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8i3n1HQEEe6dasfQ-RvkYQ"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_8i3AwXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8i3AwnQEEe6dasfQ-RvkYQ" x="70" y="60" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_r0vdo3QEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r0vdpHQEEe6dasfQ-RvkYQ" x="330" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_r9wPsHQEEe6dasfQ-RvkYQ" type="2002" element="_r9slUHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_r9wPs3QEEe6dasfQ-RvkYQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_r9wPtHQEEe6dasfQ-RvkYQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_r9wPtXQEEe6dasfQ-RvkYQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_r9wPtnQEEe6dasfQ-RvkYQ"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_8smyoHQEEe6dasfQ-RvkYQ" type="3012" element="_8sjIQHQEEe6dasfQ-RvkYQ">
+            <children xmi:type="notation:Node" xmi:id="_8smyo3QEEe6dasfQ-RvkYQ" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_8smypHQEEe6dasfQ-RvkYQ" x="-14" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_8snZsHQEEe6dasfQ-RvkYQ" type="3003" element="_8sjvUHQEEe6dasfQ-RvkYQ">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_8snZsXQEEe6dasfQ-RvkYQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8snZsnQEEe6dasfQ-RvkYQ"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_8smyoXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8smyonQEEe6dasfQ-RvkYQ" x="-2" y="33" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_r9wPsXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r9wPsnQEEe6dasfQ-RvkYQ" x="640" y="227"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_sFwVIHQEEe6dasfQ-RvkYQ" type="2002" element="_sFtR0HQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_sFw8MHQEEe6dasfQ-RvkYQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_sFw8MXQEEe6dasfQ-RvkYQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_sFw8MnQEEe6dasfQ-RvkYQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_sFw8M3QEEe6dasfQ-RvkYQ"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_80j0wHQEEe6dasfQ-RvkYQ" type="3012" element="_80fjUHQEEe6dasfQ-RvkYQ">
+            <children xmi:type="notation:Node" xmi:id="_80j0w3QEEe6dasfQ-RvkYQ" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_80j0xHQEEe6dasfQ-RvkYQ" x="11" y="-1"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_80kb0HQEEe6dasfQ-RvkYQ" type="3003" element="_80gKYHQEEe6dasfQ-RvkYQ">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_80kb0XQEEe6dasfQ-RvkYQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_80kb0nQEEe6dasfQ-RvkYQ"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_80j0wXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_80j0wnQEEe6dasfQ-RvkYQ" x="70" y="-2" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_sFwVIXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sFwVInQEEe6dasfQ-RvkYQ" x="330" y="440"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_sNKksHQEEe6dasfQ-RvkYQ" type="2002" element="_sNG6UHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_sNKks3QEEe6dasfQ-RvkYQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_sNLLwHQEEe6dasfQ-RvkYQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_sNLLwXQEEe6dasfQ-RvkYQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_sNLLwnQEEe6dasfQ-RvkYQ"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_89d5IHQEEe6dasfQ-RvkYQ" type="3012" element="_89a10HQEEe6dasfQ-RvkYQ">
+            <children xmi:type="notation:Node" xmi:id="_89d5I3QEEe6dasfQ-RvkYQ" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_89d5JHQEEe6dasfQ-RvkYQ" x="-14" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_89fHQHQEEe6dasfQ-RvkYQ" type="3003" element="_89a10XQEEe6dasfQ-RvkYQ">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_89fHQXQEEe6dasfQ-RvkYQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_89fHQnQEEe6dasfQ-RvkYQ"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_89d5IXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_89d5InQEEe6dasfQ-RvkYQ" x="140" y="33" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_sNKksXQEEe6dasfQ-RvkYQ" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sNKksnQEEe6dasfQ-RvkYQ" x="20" y="227"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_lOYNkHc5Ee6tFshxpN8P6Q" type="2002" element="_lOLZQHc5Ee6tFshxpN8P6Q">
+          <children xmi:type="notation:Node" xmi:id="_lOY0oHc5Ee6tFshxpN8P6Q" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_lOY0oXc5Ee6tFshxpN8P6Q" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_lyg1YHc5Ee6tFshxpN8P6Q" type="3008" element="_OU8lgXQJEe6tFshxpN8P6Q">
+              <children xmi:type="notation:Node" xmi:id="_lyg1Y3c5Ee6tFshxpN8P6Q" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_lyg1ZHc5Ee6tFshxpN8P6Q" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_lyg1ZXc5Ee6tFshxpN8P6Q"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_lyg1Znc5Ee6tFshxpN8P6Q"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_lyg1Z3c5Ee6tFshxpN8P6Q" type="3012" element="_OU9zoHQJEe6tFshxpN8P6Q">
+                <children xmi:type="notation:Node" xmi:id="_lyg1anc5Ee6tFshxpN8P6Q" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_lyg1a3c5Ee6tFshxpN8P6Q" x="11" y="-1"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_lyjRpXc5Ee6tFshxpN8P6Q" type="3003" element="_OU9zoXQJEe6tFshxpN8P6Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_lyjRpnc5Ee6tFshxpN8P6Q" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyjRp3c5Ee6tFshxpN8P6Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_lyg1aHc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyg1aXc5Ee6tFshxpN8P6Q" x="-2" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_lyiDgHc5Ee6tFshxpN8P6Q" type="3012" element="_OU-asHQJEe6tFshxpN8P6Q">
+                <children xmi:type="notation:Node" xmi:id="_lyiqkHc5Ee6tFshxpN8P6Q" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_lyiqkXc5Ee6tFshxpN8P6Q" x="11" y="-1"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_lyjRqHc5Ee6tFshxpN8P6Q" type="3003" element="_OU-asXQJEe6tFshxpN8P6Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_lyjRqXc5Ee6tFshxpN8P6Q" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyjRqnc5Ee6tFshxpN8P6Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_lyiDgXc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyiDgnc5Ee6tFshxpN8P6Q" x="-2" y="15" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_lyiqknc5Ee6tFshxpN8P6Q" type="3012" element="_OU-asnQJEe6tFshxpN8P6Q">
+                <children xmi:type="notation:Node" xmi:id="_lyiqlXc5Ee6tFshxpN8P6Q" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_lyiqlnc5Ee6tFshxpN8P6Q" x="11" y="-1"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_lyjRq3c5Ee6tFshxpN8P6Q" type="3003" element="_OU-as3QJEe6tFshxpN8P6Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_lyjRrHc5Ee6tFshxpN8P6Q" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyjRrXc5Ee6tFshxpN8P6Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_lyiqk3c5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyiqlHc5Ee6tFshxpN8P6Q" x="-2" y="30" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_lyjRoHc5Ee6tFshxpN8P6Q" type="3012" element="_OU-atHQJEe6tFshxpN8P6Q">
+                <children xmi:type="notation:Node" xmi:id="_lyjRo3c5Ee6tFshxpN8P6Q" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_lyjRpHc5Ee6tFshxpN8P6Q" x="11" y="-1"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_lyj4sHc5Ee6tFshxpN8P6Q" type="3003" element="_OU-atXQJEe6tFshxpN8P6Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_lyj4sXc5Ee6tFshxpN8P6Q" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyj4snc5Ee6tFshxpN8P6Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_lyjRoXc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyjRonc5Ee6tFshxpN8P6Q" x="-2" y="45" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lyg1YXc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="12"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyg1Ync5Ee6tFshxpN8P6Q" x="35" y="44"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_lOY0onc5Ee6tFshxpN8P6Q"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_lOY0o3c5Ee6tFshxpN8P6Q"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_lOYNkXc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lOYNknc5Ee6tFshxpN8P6Q" x="554" y="20" width="236" height="153"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Me2bsHfcEe6Lz7yDzRK87A" type="2002" element="_MesDoHfcEe6Lz7yDzRK87A">
+          <children xmi:type="notation:Node" xmi:id="_Me6GEHfcEe6Lz7yDzRK87A" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Me6GEXfcEe6Lz7yDzRK87A" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Me6GEnfcEe6Lz7yDzRK87A"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Me6GE3fcEe6Lz7yDzRK87A"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Me2bsXfcEe6Lz7yDzRK87A" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Me2bsnfcEe6Lz7yDzRK87A" x="553" y="359" width="238" height="151"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_XDxzAHfcEe6Lz7yDzRK87A" type="2002" element="_XDuIoHfcEe6Lz7yDzRK87A">
+          <children xmi:type="notation:Node" xmi:id="_XDxzA3fcEe6Lz7yDzRK87A" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_XDyaEHfcEe6Lz7yDzRK87A" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_XDyaEXfcEe6Lz7yDzRK87A"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_XDyaEnfcEe6Lz7yDzRK87A"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_XDxzAXfcEe6Lz7yDzRK87A" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XDxzAnfcEe6Lz7yDzRK87A" x="20" y="359" width="236" height="151"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Z8GrAHfcEe6Lz7yDzRK87A" type="2002" element="_Z8CZkHfcEe6Lz7yDzRK87A">
+          <children xmi:type="notation:Node" xmi:id="_Z8GrA3fcEe6Lz7yDzRK87A" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Z8GrBHfcEe6Lz7yDzRK87A" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Z8GrBXfcEe6Lz7yDzRK87A"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Z8GrBnfcEe6Lz7yDzRK87A"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Z8GrAXfcEe6Lz7yDzRK87A" fontName="Segoe UI" fontHeight="12"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Z8GrAnfcEe6Lz7yDzRK87A" x="20" y="21" width="236" height="151"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_a3ngFnQCEe6NVsJd--VKdg"/>
+        <edges xmi:type="notation:Edge" xmi:id="_lyj4s3c5Ee6tFshxpN8P6Q" type="4001" element="_OVDTMHQJEe6tFshxpN8P6Q" source="_lyg1Z3c5Ee6tFshxpN8P6Q" target="_8i3AwHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_lyj4t3c5Ee6tFshxpN8P6Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyj4uHc5Ee6tFshxpN8P6Q" x="4" y="-7"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lyj4uXc5Ee6tFshxpN8P6Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lyj4unc5Ee6tFshxpN8P6Q" x="4" y="-8"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lykfwHc5Ee6tFshxpN8P6Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykfwXc5Ee6tFshxpN8P6Q" x="1" y="-9"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lyj4tHc5Ee6tFshxpN8P6Q"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lyj4tXc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lyj4tnc5Ee6tFshxpN8P6Q" points="[-5, 0, 187, -10]$[-187, 9, 5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykfwnc5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykfw3c5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_lykfxHc5Ee6tFshxpN8P6Q" type="4001" element="_OVDTNXQJEe6tFshxpN8P6Q" source="_lyiDgHc5Ee6tFshxpN8P6Q" target="_8smyoHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_lykfyHc5Ee6tFshxpN8P6Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykfyXc5Ee6tFshxpN8P6Q" x="2" y="-3"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lykfync5Ee6tFshxpN8P6Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykfy3c5Ee6tFshxpN8P6Q" x="3" y="-3"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lykfzHc5Ee6tFshxpN8P6Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykfzXc5Ee6tFshxpN8P6Q" x="3" y="-3"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lykfxXc5Ee6tFshxpN8P6Q"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lykfxnc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lykfx3c5Ee6tFshxpN8P6Q" points="[1, 5, -45, -170]$[44, 170, -2, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykfznc5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykfz3c5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_lykf0Hc5Ee6tFshxpN8P6Q" type="4001" element="_OVD6QnQJEe6tFshxpN8P6Q" source="_lyiqknc5Ee6tFshxpN8P6Q" target="_80j0wHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_lykf1Hc5Ee6tFshxpN8P6Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykf1Xc5Ee6tFshxpN8P6Q" x="-1" y="-3"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lykf1nc5Ee6tFshxpN8P6Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykf13c5Ee6tFshxpN8P6Q" x="-1" y="-3"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lykf2Hc5Ee6tFshxpN8P6Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lykf2Xc5Ee6tFshxpN8P6Q" y="-1"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lykf0Xc5Ee6tFshxpN8P6Q"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lykf0nc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lykf03c5Ee6tFshxpN8P6Q" points="[-3, 5, 189, -333]$[-190, 333, 2, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykf2nc5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lykf23c5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_lykf3Hc5Ee6tFshxpN8P6Q" type="4001" element="_OVD6R3QJEe6tFshxpN8P6Q" source="_lyjRoHc5Ee6tFshxpN8P6Q" target="_89d5IHQEEe6dasfQ-RvkYQ">
+          <children xmi:type="notation:Node" xmi:id="_lylG0Hc5Ee6tFshxpN8P6Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lylG0Xc5Ee6tFshxpN8P6Q" x="9" y="-1"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lylG0nc5Ee6tFshxpN8P6Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lylG03c5Ee6tFshxpN8P6Q" x="9" y="-1"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lylG1Hc5Ee6tFshxpN8P6Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lylG1Xc5Ee6tFshxpN8P6Q" x="6" y="-1"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lykf3Xc5Ee6tFshxpN8P6Q"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lykf3nc5Ee6tFshxpN8P6Q" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lykf33c5Ee6tFshxpN8P6Q" points="[-5, 1, 427, -144]$[-427, 143, 5, -2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lylG1nc5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lylG13c5Ee6tFshxpN8P6Q" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_a3ouMHQCEe6NVsJd--VKdg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_a3ouMXQCEe6NVsJd--VKdg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_rJeTEHQEEe6dasfQ-RvkYQ" name="EPackage1">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage1"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage1"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_rJe6IHQEEe6dasfQ-RvkYQ" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_r0saUHQEEe6dasfQ-RvkYQ" name="EPackage2">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage2"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage2"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_8izWYHQEEe6dasfQ-RvkYQ" name="EClass2_1" incomingEdges="_OVDTMHQJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+        <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage2/EClass2_1"/>
+        <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage2/EClass2_1"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:Square" uid="_8iz9cHQEEe6dasfQ-RvkYQ" showIcon="false" color="114,159,207">
+          <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_r0saUXQEEe6dasfQ-RvkYQ" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_r9slUHQEEe6dasfQ-RvkYQ" name="EPackage3">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage3"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage3"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_8sjIQHQEEe6dasfQ-RvkYQ" name="EClass3_2" incomingEdges="_OVDTNXQJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+        <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage3/EClass3_2"/>
+        <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage3/EClass3_2"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:Square" uid="_8sjvUHQEEe6dasfQ-RvkYQ" showIcon="false" color="114,159,207">
+          <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_r9tMYHQEEe6dasfQ-RvkYQ" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_sFtR0HQEEe6dasfQ-RvkYQ" name="EPackage4">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage4"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage4"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_80fjUHQEEe6dasfQ-RvkYQ" name="EClass4_3" incomingEdges="_OVD6QnQJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+        <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage4/EClass4_3"/>
+        <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage4/EClass4_3"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:Square" uid="_80gKYHQEEe6dasfQ-RvkYQ" showIcon="false" color="114,159,207">
+          <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_sFtR0XQEEe6dasfQ-RvkYQ" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_sNG6UHQEEe6dasfQ-RvkYQ" name="EPackage5">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage5"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage5"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_89a10HQEEe6dasfQ-RvkYQ" name="EClass5_4" incomingEdges="_OVD6R3QJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+        <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage5/EClass5_4"/>
+        <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage5/EClass5_4"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:Square" uid="_89a10XQEEe6dasfQ-RvkYQ" showIcon="false" color="114,159,207">
+          <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_sNG6UXQEEe6dasfQ-RvkYQ" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_OVDTMHQJEe6tFshxpN8P6Q" name="ERef1" sourceNode="_OU9zoHQJEe6tFshxpN8P6Q" targetNode="_8izWYHQEEe6dasfQ-RvkYQ">
+      <target xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_1/ERef1"/>
+      <semanticElements xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_1/ERef1"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_OVDTMXQJEe6tFshxpN8P6Q" targetArrow="InputClosedArrow" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_OVDTMnQJEe6tFshxpN8P6Q" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_OVDTNXQJEe6tFshxpN8P6Q" name="ERef2" sourceNode="_OU-asHQJEe6tFshxpN8P6Q" targetNode="_8sjIQHQEEe6dasfQ-RvkYQ">
+      <target xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_2/ERef2"/>
+      <semanticElements xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_2/ERef2"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_OVDTNnQJEe6tFshxpN8P6Q" targetArrow="InputClosedArrow" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_OVDTN3QJEe6tFshxpN8P6Q" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_OVD6QnQJEe6tFshxpN8P6Q" name="ERef3" sourceNode="_OU-asnQJEe6tFshxpN8P6Q" targetNode="_80fjUHQEEe6dasfQ-RvkYQ">
+      <target xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_3/ERef3"/>
+      <semanticElements xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_3/ERef3"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_OVD6Q3QJEe6tFshxpN8P6Q" targetArrow="InputClosedArrow" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_OVD6RHQJEe6tFshxpN8P6Q" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_OVD6R3QJEe6tFshxpN8P6Q" name="ERef4" sourceNode="_OU-atHQJEe6tFshxpN8P6Q" targetNode="_89a10HQEEe6dasfQ-RvkYQ">
+      <target xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_4/ERef4"/>
+      <semanticElements xmi:type="ecore:EReference" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_4/ERef4"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_OVD6SHQJEe6tFshxpN8P6Q" targetArrow="InputClosedArrow" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_OVD6SXQJEe6tFshxpN8P6Q" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lOLZQHc5Ee6tFshxpN8P6Q" name="EPackage6">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage6"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage6"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lONOcHc5Ee6tFshxpN8P6Q" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_OU8lgXQJEe6tFshxpN8P6Q" name="SubEPackage1">
+        <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage6/SubEPackage1"/>
+        <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage6/SubEPackage1"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_OU9zoHQJEe6tFshxpN8P6Q" name="EClass1_1" outgoingEdges="_OVDTMHQJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+          <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_1"/>
+          <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_1"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_OU9zoXQJEe6tFshxpN8P6Q" showIcon="false" color="114,159,207">
+            <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_OU-asHQJEe6tFshxpN8P6Q" name="EClass1_2" outgoingEdges="_OVDTNXQJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+          <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_2"/>
+          <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_2"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_OU-asXQJEe6tFshxpN8P6Q" showIcon="false" color="114,159,207">
+            <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_OU-asnQJEe6tFshxpN8P6Q" name="EClass1_3" outgoingEdges="_OVD6QnQJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+          <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_3"/>
+          <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_3"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_OU-as3QJEe6tFshxpN8P6Q" showIcon="false" color="114,159,207">
+            <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_OU-atHQJEe6tFshxpN8P6Q" name="EClass1_4" outgoingEdges="_OVD6R3QJEe6tFshxpN8P6Q" width="1" height="1" resizeKind="NSEW">
+          <target xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_4"/>
+          <semanticElements xmi:type="ecore:EClass" href="github-issue-145.ecore#//EPackage6/SubEPackage1/EClass1_4"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_OU-atXQJEe6tFshxpN8P6Q" showIcon="false" color="114,159,207">
+            <description xmi:type="style:SquareDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_OU8lgnQJEe6tFshxpN8P6Q" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_MesDoHfcEe6Lz7yDzRK87A" name="EPackage7">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage7"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage7"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_MesDoXfcEe6Lz7yDzRK87A" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_XDuIoHfcEe6Lz7yDzRK87A" name="EPackage8">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage8"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage8"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_XDuIoXfcEe6Lz7yDzRK87A" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Z8CZkHfcEe6Lz7yDzRK87A" name="EPackage9">
+      <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage9"/>
+      <semanticElements xmi:type="ecore:EPackage" href="github-issue-145.ecore#//EPackage9"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Z8DAoHfcEe6Lz7yDzRK87A" labelSize="12" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_a3ngEXQCEe6NVsJd--VKdg"/>
+    <activatedLayers xmi:type="description_1:Layer" href="github-issue-145.odesign#//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer"/>
+    <target xmi:type="ecore:EPackage" href="github-issue-145.ecore#/"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/borderNodeSide/github-issue-145/github-issue-145.ecore
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/borderNodeSide/github-issue-145/github-issue-145.ecore
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="EPackageRoot">
+  <eSubpackages name="EPackage1"/>
+  <eSubpackages name="EPackage2">
+    <eClassifiers xsi:type="ecore:EClass" name="EClass2_1"/>
+  </eSubpackages>
+  <eSubpackages name="EPackage3">
+    <eClassifiers xsi:type="ecore:EClass" name="EClass3_2"/>
+  </eSubpackages>
+  <eSubpackages name="EPackage4">
+    <eClassifiers xsi:type="ecore:EClass" name="EClass4_3"/>
+  </eSubpackages>
+  <eSubpackages name="EPackage5">
+    <eClassifiers xsi:type="ecore:EClass" name="EClass5_4"/>
+  </eSubpackages>
+  <eSubpackages name="EPackage6">
+    <eSubpackages name="SubEPackage1">
+      <eClassifiers xsi:type="ecore:EClass" name="EClass1_1">
+        <eStructuralFeatures xsi:type="ecore:EReference" name="ERef1" eType="#//EPackage2/EClass2_1"/>
+      </eClassifiers>
+      <eClassifiers xsi:type="ecore:EClass" name="EClass1_2">
+        <eStructuralFeatures xsi:type="ecore:EReference" name="ERef2" eType="#//EPackage3/EClass3_2"/>
+      </eClassifiers>
+      <eClassifiers xsi:type="ecore:EClass" name="EClass1_3">
+        <eStructuralFeatures xsi:type="ecore:EReference" name="ERef3" eType="#//EPackage4/EClass4_3"/>
+      </eClassifiers>
+      <eClassifiers xsi:type="ecore:EClass" name="EClass1_4">
+        <eStructuralFeatures xsi:type="ecore:EReference" name="ERef4" eType="#//EPackage5/EClass5_4"/>
+      </eClassifiers>
+    </eSubpackages>
+  </eSubpackages>
+  <eSubpackages name="EPackage7"/>
+  <eSubpackages name="EPackage8"/>
+  <eSubpackages name="EPackage9"/>
+</ecore:EPackage>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/borderNodeSide/github-issue-145/github-issue-145.odesign
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/borderNodeSide/github-issue-145/github-issue-145.odesign
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" xmlns:tool_1="http://www.eclipse.org/sirius/description/tool/1.1.0" name="github-issue-145" version="12.0.0.2017041100">
+  <ownedViewpoints name="github-issue-145" label="github-issue-145">
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" dropDescriptions="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@toolSections.1/@ownedTools[name='EPackageDrop']" name="github-issue-145" domainClass="EPackage" enablePopupBars="true">
+      <metamodel href="http://www.eclipse.org/emf/2002/Ecore#/"/>
+      <defaultLayer name="Default">
+        <edgeMappings name="EReference Edge" semanticCandidatesExpression="aql:self.eAllContents()" sourceMapping="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']" targetMapping="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']" targetFinderExpression="aql:self.eReferenceType" sourceFinderExpression="aql:self.eContainer()" domainClass="EReference" useDomainElement="true">
+          <style targetArrow="InputClosedArrow">
+            <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <centerLabelStyleDescription showIcon="false" labelExpression="aql:self.name">
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </centerLabelStyleDescription>
+          </style>
+        </edgeMappings>
+        <containerMappings name="EPackage Container" semanticCandidatesExpression="aql:self.eSubpackages" createElements="false" domainClass="EPackage" dropDescriptions="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@toolSections.1/@ownedTools[name='EPackageDrop'] //@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@toolSections.1/@ownedTools[name='EClassDrop']" reusedContainerMappings="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']">
+          <borderedNodeMappings name="EClass BorderNode" semanticCandidatesExpression="aql:self.eContents()->filter(ecore::EClass)" domainClass="EClass">
+            <style xsi:type="style:SquareDescription" showIcon="false" sizeComputationExpression="1" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='blue']"/>
+            </style>
+          </borderedNodeMappings>
+          <style xsi:type="style:FlatContainerStyleDescription" borderSizeComputationExpression="1" labelSize="12" roundedCorner="true">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_blue']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </containerMappings>
+        <toolSections name="CreationTools">
+          <ownedTools xsi:type="tool:ContainerCreationDescription" name="EPackage" precondition="aql:container.oclIsTypeOf(ecore::EPackage)" containerMappings="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="ecore::EPackage" referenceName="eSubpackages">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="name" valueExpression="aql:'EPackage'+self.eSuperPackage.eSubpackages->size()"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:NodeCreationDescription" name="EClass" nodeMappings="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="ecore::EClass" referenceName="eClassifiers">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="name" valueExpression="aql:'EClass'+self.ePackage.eClassifiers->filter(ecore::EClass)->size()"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:EdgeCreationDescription" name="EReference" edgeMappings="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@edgeMappings[name='EReference%20Edge']">
+            <sourceVariable name="source"/>
+            <targetVariable name="target"/>
+            <sourceViewVariable name="sourceView"/>
+            <targetViewVariable name="targetView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:source">
+                <subModelOperations xsi:type="tool_1:CreateInstance" typeName="ecore::EReference" referenceName="eReferences">
+                  <subModelOperations xsi:type="tool_1:SetValue" featureName="eType" valueExpression="var:target"/>
+                  <subModelOperations xsi:type="tool_1:SetValue" featureName="name" valueExpression="aql:'ERef' + source.ePackage.eAllContents(ecore::EReference)->size()"/>
+                </subModelOperations>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+        </toolSections>
+        <toolSections name="DragAndDropTools">
+          <ownedTools xsi:type="tool:ContainerDropDescription" name="EPackageDrop" precondition="aql:self.oclIsTypeOf(ecore::EPackage)" mappings="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']" dragSource="BOTH">
+            <oldContainer name="oldSemanticContainer"/>
+            <newContainer name="newSemanticContainer"/>
+            <element name="element"/>
+            <newViewContainer name="newContainerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:newSemanticContainer">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="eSubpackages" valueExpression="var:element"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:ContainerDropDescription" name="EClassDrop" mappings="//@ownedViewpoints[name='github-issue-145']/@ownedRepresentations[name='github-issue-145']/@defaultLayer/@containerMappings[name='EPackage%20Container']/@borderedNodeMappings[name='EClass%20BorderNode']" dragSource="BOTH">
+            <oldContainer name="oldSemanticContainer"/>
+            <newContainer name="newSemanticContainer"/>
+            <element name="element"/>
+            <newViewContainer name="newContainerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:newSemanticContainer">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="eClassifiers" valueExpression="var:element"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+        </toolSections>
+      </defaultLayer>
+    </ownedRepresentations>
+  </ownedViewpoints>
+</description:Group>

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LinkedBorderNodeLocationTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LinkedBorderNodeLocationTest.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2023 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.tests.swtbot;
+
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramBorderNodeEditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainer2EditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerEditPart;
+import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
+import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
+import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckEditPartMoved;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
+import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
+
+/**
+ * This class tests the location of linked border nodes.
+ * 
+ * @author gplouhinec
+ *
+ */
+public class LinkedBorderNodeLocationTest extends AbstractSiriusSwtBotGefTestCase {
+
+    private static final int OFFSET_BORDER_NORTH = 8;
+
+    private static final int OFFSET_BORDER_WEST = 8;
+
+    private static final int OFFSET_BORDER_SOUTH = 10;
+
+    private static final int SAFETY_MARGIN = 2;
+
+    private static final int OFFSET_BORDER_EAST = 10;
+
+    private UIResource sessionAirdResource;
+
+    private UILocalSession localSession;
+
+    private static final String DATA_UNIT_DIR = "data/unit/borderNodeSide/github-issue-145/"; //$NON-NLS-1$
+
+    private static final String MODEL = "github-issue-145.ecore"; //$NON-NLS-1$
+
+    private static final String SESSION_FILE = "github-issue-145.aird"; //$NON-NLS-1$
+
+    private static final String VSM_FILE = "github-issue-145.odesign"; //$NON-NLS-1$
+
+    private static final String FILE_DIR = "/"; //$NON-NLS-1$
+
+    private static final String REPRESENTATION_DESCRIPTION_NAME = "github-issue-145"; //$NON-NLS-1$
+
+    private static final String REPRESENTATION_NAME = REPRESENTATION_DESCRIPTION_NAME;
+
+    private static final String BORDER_NODE_1 = "EClass1_1"; //$NON-NLS-1$
+
+    private static final String BORDER_NODE_2 = "EClass1_2"; //$NON-NLS-1$
+
+    private static final String BORDER_NODE_3 = "EClass1_3"; //$NON-NLS-1$
+
+    private static final String BORDER_NODE_4 = "EClass1_4"; //$NON-NLS-1$
+
+    private static final String SUB_CONTAINER = "SubEPackage1"; //$NON-NLS-1$
+
+    @Override
+    protected void onSetUpBeforeClosingWelcomePage() throws Exception {
+        copyFileToTestProject(Activator.PLUGIN_ID, DATA_UNIT_DIR, MODEL, SESSION_FILE, VSM_FILE);
+    }
+
+    @Override
+    protected void onSetUpAfterOpeningDesignerPerspective() throws Exception {
+        sessionAirdResource = new UIResource(designerProject, FILE_DIR, SESSION_FILE);
+        localSession = designerPerspective.openSessionFromFile(sessionAirdResource);
+        editor = (SWTBotSiriusDiagramEditor) openRepresentation(localSession.getOpenedSession(), REPRESENTATION_DESCRIPTION_NAME, REPRESENTATION_NAME, DDiagram.class);
+    }
+
+    /**
+     * Drag and drop of an element with unpinned linked border nodes should arrange these linked border nodes according
+     * to the other border nodes to which they are linked.
+     */
+    public void testDnDSubContainerWithLinkedBorderNodes() {
+        SWTBotGefEditPart subPackageEP = editor.getEditPart(SUB_CONTAINER, DNodeContainer2EditPart.class);
+        editor.clickCentered(subPackageEP);
+        bot.waitUntil(new CheckSelectedCondition(editor, SUB_CONTAINER, DNodeContainer2EditPart.class));
+
+        dragAndDropSubContainer("EPackage1"); //$NON-NLS-1$
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_1), PositionConstants.NORTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_2), PositionConstants.EAST);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_3), PositionConstants.SOUTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_4), PositionConstants.WEST);
+
+        dragAndDropSubContainer("EPackage6"); //$NON-NLS-1$
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_1), PositionConstants.WEST);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_2), PositionConstants.SOUTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_3), PositionConstants.SOUTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_4), PositionConstants.WEST);
+
+        dragAndDropSubContainer("EPackage7"); //$NON-NLS-1$
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_1), PositionConstants.NORTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_2), PositionConstants.NORTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_3), PositionConstants.WEST);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_4), PositionConstants.WEST);
+
+        dragAndDropSubContainer("EPackage8"); //$NON-NLS-1$
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_1), PositionConstants.NORTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_2), PositionConstants.EAST);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_3), PositionConstants.EAST);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_4), PositionConstants.NORTH);
+
+        dragAndDropSubContainer("EPackage9"); //$NON-NLS-1$
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_1), PositionConstants.EAST);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_2), PositionConstants.EAST);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_3), PositionConstants.SOUTH);
+        checkBorderNodePosition(getSubContainerBounds(SUB_CONTAINER), getBorderNodeBounds(BORDER_NODE_4), PositionConstants.SOUTH);
+    }
+
+    private void dragAndDropSubContainer(String targetName) {
+        Point subEPackage1Center = getSubContainerBounds(SUB_CONTAINER).getCenter().getCopy();
+        Point targetCenter = getContainerBounds(targetName).getCenter().getCopy();
+        CheckEditPartMoved movedCondition = new CheckEditPartMoved(editor, SUB_CONTAINER, DNodeContainer2EditPart.class, getSubContainerBounds(SUB_CONTAINER).getLocation());
+        editor.drag(subEPackage1Center, targetCenter);
+        bot.waitUntil(movedCondition);
+    }
+
+    private Rectangle getBorderNodeBounds(String borderNodeName) {
+        return editor.getBounds(editor.getEditPart(borderNodeName, AbstractDiagramBorderNodeEditPart.class));
+    }
+
+    private Rectangle getSubContainerBounds(String containerName) {
+        return editor.getBounds(editor.getEditPart(containerName, DNodeContainer2EditPart.class));
+    }
+
+    private Rectangle getContainerBounds(String containerName) {
+        return editor.getBounds(editor.getEditPart(containerName, DNodeContainerEditPart.class));
+    }
+
+    /**
+     * Checks that a border node is on the correct side of its bordered node. Magic numbers are used here, corresponding
+     * to the delta between the border of the bordered node and the closest border of the border node.
+     * 
+     * @param borderedNodeBounds
+     *            the bordered node rectangle
+     * @param borderNodeBounds
+     *            the border node rectangle
+     * @param expectedSide
+     *            the side where the border node is expected among {@code PositionConstants.NORTH},
+     *            {@code PositionConstants.EAST}, {@code PositionConstants.SOUTH}, {@code PositionConstants.WEST}.
+     */
+    private static void checkBorderNodePosition(Rectangle borderedNodeBounds, Rectangle borderNodeBounds, int expectedSide) {
+        switch (expectedSide) {
+        case PositionConstants.NORTH:
+            assertEquals(borderedNodeBounds.getTop().y, borderNodeBounds.getBottom().y - OFFSET_BORDER_NORTH, SAFETY_MARGIN);
+            break;
+        case PositionConstants.EAST:
+            assertEquals(borderedNodeBounds.getRight().x, borderNodeBounds.getLeft().x + OFFSET_BORDER_EAST, SAFETY_MARGIN);
+            break;
+        case PositionConstants.SOUTH:
+            assertEquals(borderedNodeBounds.getBottom().y, borderNodeBounds.getTop().y + OFFSET_BORDER_SOUTH, SAFETY_MARGIN);
+            break;
+        case PositionConstants.WEST:
+            assertEquals(borderedNodeBounds.getLeft().x, borderNodeBounds.getRight().x - OFFSET_BORDER_WEST, SAFETY_MARGIN);
+            break;
+        }
+
+    }
+}

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
@@ -496,6 +496,7 @@ public class AllTestSuite extends TestCase {
         suite.addTestSuite(RectilinearNoteAttachmentWithTextTest.class);
         suite.addTestSuite(RemoveBendpointsRectilinearNoteAttachmentTest.class);
         suite.addTestSuite(RectilinearNoteAttachmentWithOneBendpointTest.class);
+        suite.addTestSuite(LinkedBorderNodeLocationTest.class);
     }
 
     /**


### PR DESCRIPTION
See issue #145
When a node with linked border node is updated (drag and drop, refresh unsynchronized element, custom creation tool...), its linked border nodes is not properly laid out. An "Arrange" command is executed but border nodes are not arranged.

Scenario in the image: Drag and drop "SubEPackage1" from EPackage6 to EPackage1.
Before fix:
![image](https://github.com/eclipse-sirius/sirius-desktop/assets/33932970/7ec5503d-8e15-4de4-bb2b-d08b58206d7a)


After fix: 
![image](https://github.com/eclipse-sirius/sirius-desktop/assets/33932970/89cb1d3e-9b0a-40a2-add0-2736ef1a9e7c)
