### PR TITLE
[test] Fix testSimpleEdgeSourceReconnectionWithObliqueStyleRouting

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/commands/StraightenToCommand.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/commands/StraightenToCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2016, 2023 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -147,14 +147,18 @@ public class StraightenToCommand extends AbstractTransactionalCommand {
         super(edgeEditPart.getEditingDomain(), StraightenToAction.getLabel(straightenType), null);
         this.straightenType = straightenType;
         for (AbstractDiagramEdgeEditPart selectedEdgeEditPart : selectedEdgeEditParts) {
-            StraightenToCommandData straightenToCommandData = new StraightenToCommandData();
-            if (selectedEdgeEditPart.getSource() instanceof IGraphicalEditPart) {
-                straightenToCommandData.sourceEditPart = (IGraphicalEditPart) selectedEdgeEditPart.getSource();
+            if (!(selectedEdgeEditPart.getSource() == null && selectedEdgeEditPart.getTarget() == null)) {
+                // Edge without source nor target is ignored. This case was seen in an automatic test (but not in "real
+                // life").
+                StraightenToCommandData straightenToCommandData = new StraightenToCommandData();
+                if (selectedEdgeEditPart.getSource() instanceof IGraphicalEditPart) {
+                    straightenToCommandData.sourceEditPart = (IGraphicalEditPart) selectedEdgeEditPart.getSource();
+                }
+                if (selectedEdgeEditPart.getTarget() instanceof IGraphicalEditPart) {
+                    straightenToCommandData.targetEditPart = (IGraphicalEditPart) selectedEdgeEditPart.getTarget();
+                }
+                edgeEditParts.put(selectedEdgeEditPart, straightenToCommandData);
             }
-            if (selectedEdgeEditPart.getTarget() instanceof IGraphicalEditPart) {
-                straightenToCommandData.targetEditPart = (IGraphicalEditPart) selectedEdgeEditPart.getTarget();
-            }
-            edgeEditParts.put(selectedEdgeEditPart, straightenToCommandData);
         }
     }
 

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/policies/SiriusBaseItemSemanticEditPolicy.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/policies/SiriusBaseItemSemanticEditPolicy.java
@@ -183,6 +183,11 @@ public class SiriusBaseItemSemanticEditPolicy extends SemanticEditPolicy {
                     if (!permissionAuthority.canEditInstance(viewPointElement.getTarget())) {
                         return UnexecutableCommand.INSTANCE;
                     }
+                    if (this.getHost().getViewer() == null) {
+                        // Case seen in automatic test
+                        // (org.eclipse.sirius.tests.swtbot.EdgeReconnectionTests.testSimpleEdgeSourceReconnectionWithObliqueStyleRouting())
+                        return null;
+                    }
                     DDiagramEditor diagramEditor = (DDiagramEditor) this.getHost().getViewer().getProperty(DDiagramEditor.EDITOR_ID);
                     Object adapter = diagramEditor.getAdapter(IDiagramCommandFactoryProvider.class);
                     IDiagramCommandFactoryProvider cmdFactoryProvider = (IDiagramCommandFactoryProvider) (adapter);


### PR DESCRIPTION
Fix the NPE from
org.eclipse.sirius.tests.swtbot.EdgeReconnectionTests.testSimpleEdgeSourceReconnectionWithObliqueStyleRouting()

It's strange, but this NPE is here since the commit 1e150a9b [1] (2022-07-06) for bugzilla 476523. It is only visible in automatic test (not when the end-user does the same action).

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/1e150a9b90341029a9147a281606ffbfbd5507c8
[2] https://bugs.eclipse.org/bugs/show_bug.cgi?id=476523