### PR TITLE
[test] Fix a potential IndexOutOfBoundsException

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/DDiagramEditorImpl.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/DDiagramEditorImpl.java
@@ -1091,7 +1091,7 @@ public class DDiagramEditorImpl extends SiriusDiagramEditor implements DDiagramE
             super.setFocus();
             var iterParts = getDiagramGraphicalViewer().getRootEditPart().getChildren().iterator();
             while (iterParts.hasNext()) {
-                final EditPart editPart = (EditPart) iterParts.next();
+                final EditPart editPart = iterParts.next();
                 if (editPart.isActive() && editPart instanceof AbstractDDiagramEditPart) {
                     Optional<DSemanticDiagram> optionalSemanticElement = getDSemanticDiagram((GraphicalEditPart) editPart);
                     if (optionalSemanticElement.isPresent() && isSemanticDiagramOK(optionalSemanticElement.get())) {
@@ -1203,7 +1203,9 @@ public class DDiagramEditorImpl extends SiriusDiagramEditor implements DDiagramE
                                 // offline mode will be supported
                                 String elementID = EMFCoreUtil.getProxyID((EObject) object);
                                 final List<IGraphicalEditPart> concernedEditParts = viewer.findEditPartsForElement(elementID, IGraphicalEditPart.class);
-                                result.add(concernedEditParts.get(0));
+                                if (!concernedEditParts.isEmpty()) {
+                                    result.add(concernedEditParts.get(0));
+                                }
                             } catch (IllegalStateException e) {
                                 // An issue has been encountered while connecting to
                                 // remote CDO server


### PR DESCRIPTION
Sometimes in CI, a IndexOutOfBoundsException is observed in org.eclipse.sirius.tests.swtbot.sequence.InteractionUseTests.testInteractionUseDeletionByInstanceRoleDeletionPossible. This commit avoids this potential problem.

The observed stack is:
```
 . Stack trace: java.lang.IndexOutOfBoundsException: Index: 0
 at java.base/java.util.Collections$EmptyList.get(Collections.java:4586)
 at org.eclipse.sirius.diagram.ui.tools.internal.editor.DDiagramEditorImpl.selectionChanged(DDiagramEditorImpl.java:1206)
 at org.eclipse.ui.internal.e4.compatibility.SelectionService.notifyListeners(SelectionService.java:266)
 at org.eclipse.ui.internal.e4.compatibility.SelectionService.handleSelectionChanged(SelectionService.java:98)
 at org.eclipse.ui.internal.e4.compatibility.SelectionService.lambda$0(SelectionService.java:72)
 ...
 at org.eclipse.ui.internal.WorkbenchPage.closeEditors(WorkbenchPage.java:1464)
 at org.eclipse.ui.internal.WorkbenchPage.closeAllEditors(WorkbenchPage.java:1341)
 at org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase.lambda$2(AbstractSiriusSwtBotGefTestCase.java:392)
 ...
```