### PR TITLE
[test] Fix EdgeLabelsMoveFromEdgeMoveTest regression - Round 2

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeLabelsMoveFromEdgeMoveTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeLabelsMoveFromEdgeMoveTest.java
@@ -721,7 +721,7 @@ public class EdgeLabelsMoveFromEdgeMoveTest extends AbstractSiriusSwtBotGefTestC
         // location.
         edgeLabelExpectedPosition.clear();
         edgeLabelExpectedPosition.put("refToBEnd", DELTA_TO_COMPUTE_FROM_STANDARD);
-        edgeLabelExpectedPosition.put("refToBBegin", new Dimension(1, 0));
+        edgeLabelExpectedPosition.put("refToBBegin", new Dimension(0, 0));
         edgeLabelExpectedPosition.put("refToBCenter", new Dimension(0, 0));
         doTestMoveSegment(DIAGRAM_DESCRIPTION_NAME, diagramName, Arrays.asList(new Point(0, -100)), edgeLabelExpectedPosition, ZoomLevel.ZOOM_100, "A", "B", 2, false);
 


### PR DESCRIPTION
A case was missed in the previous commit 8f8e544f [1].

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/8f8e544fa49f222689e6399d0d44010279604f66