### PR TITLE
[9] Fix a regression detected by TabBarTest

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/TabbarPasteFormatMenuManager.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/TabbarPasteFormatMenuManager.java
@@ -69,6 +69,7 @@ public class TabbarPasteFormatMenuManager extends PasteFormatMenuManager {
     @Override
     public void dispose() {
         removeAll();
+        actionHistory = null;
         super.dispose();
     }
 


### PR DESCRIPTION
The org.eclipse.sirius.tests.swtbot.tabbar.TabBarTest allowed to detect that the new field actionHistory, in TabbarPasteFormatMenuManager, is not correctly cleaned during the dispose of the menu manager.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/9