### PR TITLE
[9] Fix an NPE caused by setting a variable to null in dispose

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/TabbarPasteFormatMenuManager.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/TabbarPasteFormatMenuManager.java
@@ -24,8 +24,6 @@ import org.eclipse.gmf.runtime.diagram.ui.actions.DiagramAction;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionItem;
-import org.eclipse.jface.util.IPropertyChangeListener;
-import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.sirius.common.ui.tools.api.util.EclipseUIUtil;
@@ -69,7 +67,7 @@ public class TabbarPasteFormatMenuManager extends PasteFormatMenuManager {
     @Override
     public void dispose() {
         removeAll();
-        actionHistory = null;
+        actionHistory.clear();
         super.dispose();
     }
 
@@ -126,7 +124,6 @@ public class TabbarPasteFormatMenuManager extends PasteFormatMenuManager {
 
     private void safeAdd(String actionId, IWorkbenchPage page) {
         if (getAction(actionId).isEmpty()) { // add action only if it not already present
-            IAction action;
             if (ActionIds.PASTE_FORMAT.equals(actionId)) {
                 add(new PasteFormatAction(page));
             } else if (ActionIds.PASTE_STYLE.equals(actionId)) {
@@ -134,13 +131,8 @@ public class TabbarPasteFormatMenuManager extends PasteFormatMenuManager {
             } else if (ActionIds.PASTE_LAYOUT.equals(actionId)) {
                 add(new PasteLayoutAction(page));
             } else if (ActionIds.PASTE_IMAGE.equals(actionId)) {
-                action = new PasteImageAction();
-                action.addPropertyChangeListener(new IPropertyChangeListener() {
-                    @Override
-                    public void propertyChange(PropertyChangeEvent event) {
-                        update();
-                    }
-                });
+                var action = new PasteImageAction();
+                action.onChangeState(Optional.of(e -> update()));
                 add(action);
             } else {
                 throw new IllegalArgumentException(String.format("Unexpected action id '%s'", actionId)); //$NON-NLS-1$


### PR DESCRIPTION
This fix replace a null affectation with clear list, this fix should be temporary because the null affectation in dispose should be correct. The real bug is in another place.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/9