### PR TITLE
[test] Fix undo/redo label menu problem caused by new target platform

### DIFF
--- a/plugins/org.eclipse.sirius.tests.junit.support/src/org/eclipse/sirius/tests/support/api/TestsUtil.java
+++ b/plugins/org.eclipse.sirius.tests.junit.support/src/org/eclipse/sirius/tests/support/api/TestsUtil.java
@@ -61,6 +61,8 @@ public final class TestsUtil {
 
     private static final String UI_WORKBENCH_202303_START = "3.128";
 
+    private static final String UI_WORKBENCH_202309_START = "3.130";
+
     private static final String CREATE_REPRESENTATATION_IN_SEPARATE_RESOURCE = "createLocalRepresentationInSeparateResource";
 
     /**
@@ -338,6 +340,15 @@ public final class TestsUtil {
      */
     public static boolean is202303Platform() {
         return checkUiWorkbenchVersion(Version.parseVersion(UI_WORKBENCH_202303_START), null);
+    }
+
+    /**
+     * Tells if the current platform corresponds to 2023-09 or later.
+     *
+     * @return true if the current platform corresponds to 2023-09 or later, false otherwise.
+     */
+    public static boolean is202309Platform() {
+        return checkUiWorkbenchVersion(Version.parseVersion(UI_WORKBENCH_202309_START), null);
     }
 
     /**

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LabelFontModificationsTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LabelFontModificationsTest.java
@@ -46,6 +46,7 @@ import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 import org.eclipse.swtbot.swt.finder.results.VoidResult;
 import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotButton;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToggleButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarToggleButton;
@@ -729,7 +730,11 @@ public class LabelFontModificationsTest extends AbstractFontModificationTest {
         }
 
         // Undo the change
-        bot.menu("Edit").menu("Undo ").click();
+        if (TestsUtil.is202309Platform()) {
+            bot.menu("Edit").menu("Undo").click();
+        } else {
+            bot.menu("Edit").menu("Undo ").click();
+        }
         // Wait all UI events to ensure that the tabbar is correctly refreshed.
         SWTBotUtils.waitAllUiEvents();
 
@@ -739,7 +744,11 @@ public class LabelFontModificationsTest extends AbstractFontModificationTest {
         }
 
         // Redo the change
-        bot.menu("Edit").menu("Redo ").click();
+        if (TestsUtil.is202309Platform()) {
+            bot.menu("Edit").menu("Redo").click();
+        } else {
+            bot.menu("Edit").menu("Redo ").click();
+        }
         // Wait all UI events to ensure that the tabbar is correctly refreshed.
         SWTBotUtils.waitAllUiEvents();
 


### PR DESCRIPTION
Since Eclipse 202309, the Undo/Redo label is no longer followed by a space. I have not succeed to understand why.

The values have not been changed in properties file in [1] and [2], but it seems that somewhere the value is changed.

[1] https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/bundles/org.eclipse.ui.workbench/Eclipse%20UI/org/eclipse/ui/internal/messages.properties#L85C23-L85C23
[2] https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/bundles/org.eclipse.ui.workbench/Eclipse%20UI/org/eclipse/ui/internal/messages.properties#L824