### PR TITLE
[test] Temporarily set Xmx to 3072m instead of 2048m

### DIFF
--- a/packaging/org.eclipse.sirius.tests.parent/pom.xml
+++ b/packaging/org.eclipse.sirius.tests.parent/pom.xml
@@ -148,7 +148,7 @@
         <tests.swtbot.skip>false</tests.swtbot.skip>
         <tests.timeout>${tests.timeout.swtbot}</tests.timeout>
         <tests.swtbot.include>org/eclipse/sirius/tests/swtbot/suite/SWTBotPart2Suite.java</tests.swtbot.include>
-        <tests.vmargs>${jacoco.agent.ut.arg} ${tests.vmargs.mac} -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</tests.vmargs>
+        <tests.vmargs>${jacoco.agent.ut.arg} ${tests.vmargs.mac} -Xmx3072m -XX:+HeapDumpOnOutOfMemoryError</tests.vmargs>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
This commit sets Xmx to 3072m instead of 2048m for the swtbot-part2 suite. It is to see if the result is better on Eclipse Sirius CI server (to avoid the OOM Killer as explained in [1]).

[1] https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3798