### PR TITLE
[81] Fix "Widget is Dispose" Error when closing diagram

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/TabbarToolBarManager.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/TabbarToolBarManager.java
@@ -211,11 +211,11 @@ public class TabbarToolBarManager extends ToolBarManager {
 
     @Override
     public void dispose() {
-        super.dispose();
         tabbarPart = null;
         if (fGradientBackground != null) {
             fGradientBackground.dispose();
             fGradientBackground = null;
         }
+        super.dispose();
     }
 }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/81