### PR TITLE
[test] Revert "temporarily set Xmx to 3072m instead of 2048m" commits

### DIFF
--- a/packaging/org.eclipse.sirius.parent/pom.xml
+++ b/packaging/org.eclipse.sirius.parent/pom.xml
@@ -738,7 +738,7 @@
              <tests.swtbot.skip>false</tests.swtbot.skip>
              <tests.timeout>${tests.timeout.swtbot}</tests.timeout>
              <tests.swtbot.include>org/eclipse/sirius/tests/swtbot/suite/SWTBotPart2Suite.java</tests.swtbot.include>
-             <tests.vmargs>${jacoco.agent.ut.arg} ${tests.vmargs.mac} -Xmx3072m -XX:+HeapDumpOnOutOfMemoryError</tests.vmargs>
+             <tests.vmargs>${jacoco.agent.ut.arg} ${tests.vmargs.mac} -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</tests.vmargs>
          </properties>
      </profile>
      <profile>

--- a/packaging/org.eclipse.sirius.tests.parent/pom.xml
+++ b/packaging/org.eclipse.sirius.tests.parent/pom.xml
@@ -148,7 +148,7 @@
         <tests.swtbot.skip>false</tests.swtbot.skip>
         <tests.timeout>${tests.timeout.swtbot}</tests.timeout>
         <tests.swtbot.include>org/eclipse/sirius/tests/swtbot/suite/SWTBotPart2Suite.java</tests.swtbot.include>
-        <tests.vmargs>${jacoco.agent.ut.arg} ${tests.vmargs.mac} -Xmx3072m -XX:+HeapDumpOnOutOfMemoryError</tests.vmargs>
+        <tests.vmargs>${jacoco.agent.ut.arg} ${tests.vmargs.mac} -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</tests.vmargs>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
This reverts commits cc8dbac6af6961ce1d8f55f1e7b8203d3502f6d9 and 71ae1945233fa1d091a888e1ad051dc97e1c3883.