### PR TITLE
DDiagramEditorImpl-LeakHunt: dereferencing editor from TestObjects during teardown.

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
@@ -1933,6 +1933,9 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         // org.eclipse.ui.internal.statushandlers.StatusHandlerRegistry.<init>
         // on close.
         ResourcesPlugin.getWorkspace().save(true, null);
+        
+        if (editor!=null) editor.close();
+        editor = null;
     }
 
     // CHECKSTYLE:OFF

--- a/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
@@ -1934,8 +1934,10 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         // on close.
         ResourcesPlugin.getWorkspace().save(true, null);
         
-        if (editor!=null) editor.close();
-        editor = null;
+        if (editor != null) {
+            editor.close();
+            editor = null;
+        }
     }
 
     // CHECKSTYLE:OFF

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/AbstractHideRevealDiagramElementsLabelTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/AbstractHideRevealDiagramElementsLabelTest.java
@@ -21,7 +21,6 @@ import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.DDiagramElement;
 import org.eclipse.sirius.diagram.business.api.helper.display.DisplayServiceManager;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.sirius.tests.swtbot.support.utils.SWTBotCommonHelper;
@@ -99,10 +98,6 @@ public class AbstractHideRevealDiagramElementsLabelTest extends AbstractSiriusSw
     private static final String DATA_UNIT_DIR = "data/unit/tools/hide-reveal/tc-2330/";
 
     protected String FILE_DIR = "/";
-
-    protected UIResource sessionAirdResource;
-
-    protected UILocalSession localSession;
 
     protected String previousPollDelay;
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ContextMenuInDiagramTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ContextMenuInDiagramTest.java
@@ -141,4 +141,11 @@ public class ContextMenuInDiagramTest extends AbstractSiriusSwtBotGefTestCase {
         EditPart selectedEditPart = (EditPart) ((IStructuredSelection) editor.getSelection()).getFirstElement();
         assertEquals("Wrong selected object after right clicking on it", expectedSelectedEditPart, selectedEditPart);
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ContextMenuInDiagramTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ContextMenuInDiagramTest.java
@@ -19,7 +19,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.ext.gmf.runtime.editparts.GraphicalHelper;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.sirius.tests.swtbot.support.utils.SWTBotUtils;
@@ -49,12 +48,6 @@ public class ContextMenuInDiagramTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String VSM_FILE = "contextMenu.odesign";
 
     private static final String DATA_UNIT_DIR = "/data/unit/contextMenu/";
-
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
 
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
@@ -140,12 +133,5 @@ public class ContextMenuInDiagramTest extends AbstractSiriusSwtBotGefTestCase {
     private void checkSelectedPart(EditPart expectedSelectedEditPart) {
         EditPart selectedEditPart = (EditPart) ((IStructuredSelection) editor.getSelection()).getFirstElement();
         assertEquals("Wrong selected object after right clicking on it", expectedSelectedEditPart, selectedEditPart);
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramMouseZoomTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramMouseZoomTest.java
@@ -135,7 +135,9 @@ public class DiagramMouseZoomTest extends AbstractSiriusSwtBotGefTestCase {
         // Go to the origin to avoid scroll bar
         editor.scrollTo(0, 0);
         SWTBotUtils.waitAllUiEvents();
+        editor.close();
         super.tearDown();
+        editor = null;
     }
 
     private void openDiagram(String descriptionName, String instanceName, ZoomLevel zoomLevel) {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramMouseZoomTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramMouseZoomTest.java
@@ -28,7 +28,6 @@ import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.ui.tools.internal.graphical.edit.part.DDiagramRootEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation.ZoomLevel;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckDiagramSelected;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -106,12 +105,6 @@ public class DiagramMouseZoomTest extends AbstractSiriusSwtBotGefTestCase {
 
     private static final String DATA_UNIT_DIR = "data/unit/mouseZoom/";
 
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
         copyFileToTestProject(Activator.PLUGIN_ID, DATA_UNIT_DIR, MODEL_FILE, SESSION_FILE, VSM_FILE);
@@ -135,9 +128,7 @@ public class DiagramMouseZoomTest extends AbstractSiriusSwtBotGefTestCase {
         // Go to the origin to avoid scroll bar
         editor.scrollTo(0, 0);
         SWTBotUtils.waitAllUiEvents();
-        editor.close();
         super.tearDown();
-        editor = null;
     }
 
     private void openDiagram(String descriptionName, String instanceName, ZoomLevel zoomLevel) {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramZoomTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramZoomTest.java
@@ -211,4 +211,11 @@ public class DiagramZoomTest extends AbstractSiriusSwtBotGefTestCase {
         SWTBotUtils.waitAllUiEvents();
         return diagramPart;
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramZoomTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramZoomTest.java
@@ -29,7 +29,6 @@ import org.eclipse.sirius.tests.support.api.ICondition;
 import org.eclipse.sirius.tests.support.api.TestsUtil;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation.ZoomLevel;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckDiagramSelected;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -68,12 +67,6 @@ public class DiagramZoomTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String VSM_FILE = "VSMForMouseZoomTest.odesign";
 
     private static final String DATA_UNIT_DIR = "data/unit/mouseZoom/";
-
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
 
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
@@ -210,12 +203,5 @@ public class DiagramZoomTest extends AbstractSiriusSwtBotGefTestCase {
         assertTrue("The synchronization decorator is missing.", diagramSynchronizeStatusFigure.isPresent());
         SWTBotUtils.waitAllUiEvents();
         return diagramPart;
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromControlledResourceTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromControlledResourceTest.java
@@ -137,7 +137,13 @@ public class DragAndDropFromControlledResourceTest extends AbstractSiriusSwtBotG
     public void tearDown() throws Exception {
         // Reopen outline
         new DesignerViews(bot).openOutlineView();
+        editor.close();
 
         super.tearDown();
+        
+        editor = null;
+        
+        ecoreEcoreResource = null;
+        semanticResourceNode = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromControlledResourceTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromControlledResourceTest.java
@@ -21,7 +21,6 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.DDiagramElement;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.OperationDoneCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -59,12 +58,6 @@ public class DragAndDropFromControlledResourceTest extends AbstractSiriusSwtBotG
     private static final String DATA_UNIT_DIR = "data/unit/vp-2692/";
 
     private static final String FILE_DIR = "/";
-
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
 
     private UIResource ecoreEcoreResource;
 
@@ -137,13 +130,8 @@ public class DragAndDropFromControlledResourceTest extends AbstractSiriusSwtBotG
     public void tearDown() throws Exception {
         // Reopen outline
         new DesignerViews(bot).openOutlineView();
-        editor.close();
-
-        super.tearDown();
-        
-        editor = null;
-        
         ecoreEcoreResource = null;
         semanticResourceNode = null;
+        super.tearDown();
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromTableAndTreeToDiagramTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromTableAndTreeToDiagramTest.java
@@ -24,7 +24,6 @@ import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.tests.support.api.EclipseTestsSupportHelper;
 import org.eclipse.sirius.tests.support.api.TestsUtil;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UITableRepresentation;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UITreeRepresentation;
@@ -55,12 +54,6 @@ public class DragAndDropFromTableAndTreeToDiagramTest extends AbstractSiriusSwtB
     private static final String FILE_DIR = "/";
 
     private UITableRepresentation table;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     private UITreeRepresentation tree;
 
@@ -184,8 +177,6 @@ public class DragAndDropFromTableAndTreeToDiagramTest extends AbstractSiriusSwtB
     protected void tearDown() throws Exception {
         // Reopen outline
         designerViews.openOutlineView();
-        editor.close();
         super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromTableAndTreeToDiagramTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DragAndDropFromTableAndTreeToDiagramTest.java
@@ -184,6 +184,8 @@ public class DragAndDropFromTableAndTreeToDiagramTest extends AbstractSiriusSwtB
     protected void tearDown() throws Exception {
         // Reopen outline
         designerViews.openOutlineView();
+        editor.close();
         super.tearDown();
+        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeCreationTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeCreationTest.java
@@ -158,4 +158,11 @@ public class EdgeCreationTest extends AbstractSiriusSwtBotGefTestCase {
         result.translate(new Dimension((int) xOffest, (int) yOffset));
         return result;
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeCreationTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeCreationTest.java
@@ -26,7 +26,6 @@ import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefConnectionEditPart;
@@ -55,12 +54,6 @@ public class EdgeCreationTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String DATA_UNIT_DIR = "data/unit/edgeCreation/";
 
     private static final String REPRESENTATION_DESC_2298_NAME = "Diag2298";
-
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
 
     private ILogListener listener;
 
@@ -157,12 +150,5 @@ public class EdgeCreationTest extends AbstractSiriusSwtBotGefTestCase {
         long yOffset = Math.round(bounds.height * proportions.preciseY());
         result.translate(new Dimension((int) xOffest, (int) yOffset));
         return result;
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeSelectionTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeSelectionTest.java
@@ -19,7 +19,6 @@ import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramEdgeEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNode4EditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation.ZoomLevel;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -70,12 +69,6 @@ public class EdgeSelectionTest extends AbstractSiriusSwtBotGefTestCase {
 
     private static final String DATA_UNIT_DIR = "data/unit/edgeSelection/";
 
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
         copyFileToTestProject(Activator.PLUGIN_ID, DATA_UNIT_DIR, MODEL_FILE, SESSION_FILE, VSM_FILE);
@@ -94,9 +87,7 @@ public class EdgeSelectionTest extends AbstractSiriusSwtBotGefTestCase {
         if (editor != null) {
             editor.zoom(ZoomLevel.ZOOM_100);
         }
-        editor.close();
         super.tearDown();
-        editor = null;
     }
     
     private void openDiagram(String descriptionName, String instanceName, ZoomLevel zoomLevel) {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeSelectionTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeSelectionTest.java
@@ -94,9 +94,11 @@ public class EdgeSelectionTest extends AbstractSiriusSwtBotGefTestCase {
         if (editor != null) {
             editor.zoom(ZoomLevel.ZOOM_100);
         }
+        editor.close();
         super.tearDown();
+        editor = null;
     }
-
+    
     private void openDiagram(String descriptionName, String instanceName, ZoomLevel zoomLevel) {
         editor = (SWTBotSiriusDiagramEditor) openRepresentation(localSession.getOpenedSession(), descriptionName, instanceName, DDiagram.class);
         editor.zoom(zoomLevel);

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeWithMultipleLabelsTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeWithMultipleLabelsTest.java
@@ -1364,4 +1364,11 @@ public class EdgeWithMultipleLabelsTest extends AbstractSiriusSwtBotGefTestCase 
             deleteMenu.click();
         }
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeWithMultipleLabelsTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeWithMultipleLabelsTest.java
@@ -1,5 +1,4 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,7 +27,6 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeEndNameEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeNameEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckEdgeLabelVisibility;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -73,12 +71,6 @@ public class EdgeWithMultipleLabelsTest extends AbstractSiriusSwtBotGefTestCase 
     private static final String EDGE_RB_CREATION_TOOL_NAME = "Create EReference RB";
 
     private static final String EDGE_EB_CREATION_TOOL_NAME = "Create EReference EB";
-
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
 
     private ILogListener listener;
 
@@ -1363,12 +1355,5 @@ public class EdgeWithMultipleLabelsTest extends AbstractSiriusSwtBotGefTestCase 
         if (deleteMenu.isEnabled()) {
             deleteMenu.click();
         }
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LockedAppearanceTabTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LockedAppearanceTabTest.java
@@ -59,12 +59,6 @@ public class LockedAppearanceTabTest extends AbstractSiriusSwtBotGefTestCase {
 
     private static final String FONTS_AND_COLORS = "Fonts and Colors:";
 
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
-
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
         copyFileToTestProject(Activator.PLUGIN_ID, DATA_UNIT_DIR, MODEL, SESSION_FILE, VSM_FILE);
@@ -226,12 +220,5 @@ public class LockedAppearanceTabTest extends AbstractSiriusSwtBotGefTestCase {
             SWTBotCCombo combo = propertiesBot.ccomboBoxInGroup(FONTS_AND_COLORS, i);
             assertEnabled(combo, enabled);
         }
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LockedAppearanceTabTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/LockedAppearanceTabTest.java
@@ -75,7 +75,7 @@ public class LockedAppearanceTabTest extends AbstractSiriusSwtBotGefTestCase {
         sessionAirdResource = new UIResource(designerProject, FILE_DIR, SESSION_FILE);
         localSession = designerPerspective.openSessionFromFile(sessionAirdResource);
 
-        // Open the editor
+        // Open the editor1
         editor = (SWTBotSiriusDiagramEditor) openRepresentation(localSession.getOpenedSession(), "Entities", "aaaa package entities", DDiagram.class);
     }
 
@@ -226,5 +226,12 @@ public class LockedAppearanceTabTest extends AbstractSiriusSwtBotGefTestCase {
             SWTBotCCombo combo = propertiesBot.ccomboBoxInGroup(FONTS_AND_COLORS, i);
             assertEnabled(combo, enabled);
         }
+    }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeBorderLabelPositionStabilityTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeBorderLabelPositionStabilityTest.java
@@ -191,5 +191,12 @@ public class NodeBorderLabelPositionStabilityTest extends AbstractSiriusSwtBotGe
         assertEquals("The label is not at the expected X position", labelUpperLeftLocation.x, dnepUpperLeftLocation.x + dnepDimension.width, 5);
         assertEquals("The label is not at the expected Y position", labelCenterLocation.y, dnepUpperLeftLocation.y + dnepDimension.height / 2, 5);
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeBorderLabelPositionStabilityTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeBorderLabelPositionStabilityTest.java
@@ -20,7 +20,6 @@ import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramBorderNodeEdit
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNameEditPart;
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNodeEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -47,12 +46,6 @@ public class NodeBorderLabelPositionStabilityTest extends AbstractSiriusSwtBotGe
     private static final String FILE_DIR = "/";
 
     private static final String LONG_LABEL = "loooooooooooong name is very long";
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     /**
      * {@inheritDoc}
@@ -190,13 +183,6 @@ public class NodeBorderLabelPositionStabilityTest extends AbstractSiriusSwtBotGe
         labelCenterLocation = new Point(labelUpperLeftLocation.x + labelDimension.width / 2, labelUpperLeftLocation.y + labelDimension.height / 2);
         assertEquals("The label is not at the expected X position", labelUpperLeftLocation.x, dnepUpperLeftLocation.x + dnepDimension.width, 5);
         assertEquals("The label is not at the expected Y position", labelCenterLocation.y, dnepUpperLeftLocation.y + dnepDimension.height / 2, 5);
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PopupMenuTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PopupMenuTest.java
@@ -596,4 +596,11 @@ public class PopupMenuTest extends AbstractSiriusSwtBotGefTestCase {
             fail("The action actionMenu4 of the menu myMenu4 should be restored");
         }
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PopupMenuTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PopupMenuTest.java
@@ -29,7 +29,6 @@ import org.eclipse.sirius.diagram.ui.tools.internal.editor.tabbar.Tabbar;
 import org.eclipse.sirius.diagram.ui.tools.internal.menu.LocationURI;
 import org.eclipse.sirius.diagram.ui.tools.internal.menu.PopupMenuContribution;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.swt.widgets.ToolBar;
@@ -58,12 +57,6 @@ public class PopupMenuTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String DATA_UNIT_DIR = "data/unit/popupMenu/";
 
     private static final String FILE_DIR = "/";
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     /**
      * {@inheritDoc}
@@ -595,12 +588,5 @@ public class PopupMenuTest extends AbstractSiriusSwtBotGefTestCase {
         } catch (WidgetNotFoundException e) {
             fail("The action actionMenu4 of the menu myMenu4 should be restored");
         }
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PortsOnNodePositionStabilityTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PortsOnNodePositionStabilityTest.java
@@ -29,7 +29,6 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNode2EditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNode3EditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNode4EditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -68,12 +67,6 @@ public class PortsOnNodePositionStabilityTest extends AbstractSiriusSwtBotGefTes
     private static final String DATA_UNIT_DIR = "data/unit/portPositionStability/tc_viewpoint_1283/";
 
     private static final String FILE_DIR = "/";
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     /**
      * {@inheritDoc}
@@ -1310,9 +1303,7 @@ public class PortsOnNodePositionStabilityTest extends AbstractSiriusSwtBotGefTes
     @Override
     protected void tearDown() throws Exception {
         editor.restore();
-        editor.close();
         super.tearDown();
-        editor = null;
     }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PortsOnNodePositionStabilityTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/PortsOnNodePositionStabilityTest.java
@@ -1310,7 +1310,9 @@ public class PortsOnNodePositionStabilityTest extends AbstractSiriusSwtBotGefTes
     @Override
     protected void tearDown() throws Exception {
         editor.restore();
+        editor.close();
         super.tearDown();
+        editor = null;
     }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/RefreshAfterUndoDragNDropTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/RefreshAfterUndoDragNDropTest.java
@@ -20,7 +20,6 @@ import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDDiagramEditPart;
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramContainerEditPart;
 import org.eclipse.sirius.diagram.ui.graphical.edit.policies.SiriusContainerDropPolicy;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
@@ -53,10 +52,6 @@ public class RefreshAfterUndoDragNDropTest extends AbstractSiriusSwtBotGefTestCa
     private static final String DROP_TARGET_NAME = "EClass3";
 
     private static final String REFRESH_CONTEXTUAL_MENU_NAME = "Refresh";
-
-    UILocalSession localSession;
-
-    SWTBotSiriusDiagramEditor editor;
 
     /**
      * {@inheritDoc}

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/RoutingStyleTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/RoutingStyleTest.java
@@ -16,7 +16,6 @@ import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeEditPart;
 import org.eclipse.sirius.diagram.ui.tools.api.preferences.SiriusDiagramUiPreferencesKeys;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -65,12 +64,6 @@ public class RoutingStyleTest extends AbstractSiriusSwtBotGefTestCase {
 
     private static final String FILE_DIR = "/";
 
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
-
     /**
      * {@inheritDoc}
      */
@@ -111,13 +104,6 @@ public class RoutingStyleTest extends AbstractSiriusSwtBotGefTestCase {
     public void testRoutingStyleWithMultiSelection() throws Exception {
         // Use "All" contextual menu to select all elements of the diagram.
         changeRoutingStyle("All", false);
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 
     private void changeRoutingStyle(String contextualMenuName, boolean checkPropertiesView) {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/RoutingStyleTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/RoutingStyleTest.java
@@ -112,6 +112,13 @@ public class RoutingStyleTest extends AbstractSiriusSwtBotGefTestCase {
         // Use "All" contextual menu to select all elements of the diagram.
         changeRoutingStyle("All", false);
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 
     private void changeRoutingStyle(String contextualMenuName, boolean checkPropertiesView) {
         // Reveal the edge named "ref"

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SelectAllAndDeselectionTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SelectAllAndDeselectionTest.java
@@ -34,7 +34,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.AbstractDiagramElementContainerNameEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckDiagramSelected;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
@@ -101,10 +100,6 @@ public class SelectAllAndDeselectionTest extends AbstractSiriusSwtBotGefTestCase
         LOCATIONS.put(CLASS_3_NAME, new Point(376, 172));
         LOCATIONS.put(CLASS_4_NAME, new Point(110, 195));
     }
-
-    UILocalSession localSession;
-
-    SWTBotSiriusDiagramEditor editor;
 
     private Map<Point, SWTBotGefEditPart> locationToEditParts = new HashMap<>();
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SessionSaveableTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SessionSaveableTest.java
@@ -83,10 +83,6 @@ public class SessionSaveableTest extends AbstractSiriusSwtBotGefTestCase {
 
     private UICallBack uiCallBack;
 
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
-
     private boolean oldValuePrefPromptWhenSaveableStillOpen;
 
     @Override
@@ -107,9 +103,7 @@ public class SessionSaveableTest extends AbstractSiriusSwtBotGefTestCase {
     protected void tearDown() throws Exception {
         // Restore original Call back
         SiriusEditPlugin.getPlugin().setUiCallback(uiCallBack);
-        editor.close();
         super.tearDown();
-        editor = null;
     }
 
     /**

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SessionSaveableTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SessionSaveableTest.java
@@ -107,7 +107,9 @@ public class SessionSaveableTest extends AbstractSiriusSwtBotGefTestCase {
     protected void tearDown() throws Exception {
         // Restore original Call back
         SiriusEditPlugin.getPlugin().setUiCallback(uiCallBack);
+        editor.close();
         super.tearDown();
+        editor = null;
     }
 
     /**

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SpecificClosedOrNotClosedEditorTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SpecificClosedOrNotClosedEditorTest.java
@@ -115,8 +115,6 @@ public class SpecificClosedOrNotClosedEditorTest extends AbstractSiriusSwtBotGef
 
     private static final String FILE_DIR = "/";
 
-    private SWTBotSiriusDiagramEditor editor;
-
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
         copyFileToTestProject(Activator.PLUGIN_ID, DATA_UNIT_DIR, MODEL, MODEL_1854, SESSION_FILE, SESSION_FILE_1854, VSM, VSM_1854);
@@ -405,13 +403,6 @@ public class SpecificClosedOrNotClosedEditorTest extends AbstractSiriusSwtBotGef
             return notifiedEditors;
         }
 
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SpecificClosedOrNotClosedEditorTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/SpecificClosedOrNotClosedEditorTest.java
@@ -406,5 +406,12 @@ public class SpecificClosedOrNotClosedEditorTest extends AbstractSiriusSwtBotGef
         }
 
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ToolCreationPositionTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ToolCreationPositionTest.java
@@ -22,7 +22,6 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainer2EditPart
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
@@ -74,12 +73,6 @@ public class ToolCreationPositionTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String DATA_UNIT_DIR = "data/unit/nodeCreation/2444/";
 
     private static final String FILE_DIR = "/";
-
-    private SWTBotSiriusDiagramEditor editor;
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
 
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
@@ -313,13 +306,6 @@ public class ToolCreationPositionTest extends AbstractSiriusSwtBotGefTestCase {
         ep.getFigure().translateToAbsolute(((GraphicalEditPart) editPart.part()).getFigure().getBounds());
         assertEquals(creationPosition.x + position * SiriusLayoutDataManager.PADDING, ep.getFigure().getBounds().x, 1);
         assertEquals(creationPosition.y + position * SiriusLayoutDataManager.PADDING, ep.getFigure().getBounds().y, 1);
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ToolCreationPositionTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/ToolCreationPositionTest.java
@@ -314,5 +314,12 @@ public class ToolCreationPositionTest extends AbstractSiriusSwtBotGefTestCase {
         assertEquals(creationPosition.x + position * SiriusLayoutDataManager.PADDING, ep.getFigure().getBounds().x, 1);
         assertEquals(creationPosition.y + position * SiriusLayoutDataManager.PADDING, ep.getFigure().getBounds().y, 1);
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/VSMAndDiagramEditorSynchronisationTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/VSMAndDiagramEditorSynchronisationTest.java
@@ -22,7 +22,6 @@ import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramListEditPart;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusHelper;
@@ -88,12 +87,6 @@ public class VSMAndDiagramEditorSynchronisationTest extends AbstractSiriusSwtBot
 
     /** Current diagram. */
     protected UIDiagramRepresentation diagram;
-
-    /** Session. */
-    private UIResource sessionAirdResource;
-
-    /** Local Session. */
-    private UILocalSession localSession;
 
     /**
      * {@inheritDoc}
@@ -273,9 +266,6 @@ public class VSMAndDiagramEditorSynchronisationTest extends AbstractSiriusSwtBot
     @Override
     protected void tearDown() throws Exception {
         diagram = null;
-        editor = null;
-        sessionAirdResource = null;
-        localSession = null;
         super.tearDown();
     }
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/LockedTabBarTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/LockedTabBarTest.java
@@ -38,7 +38,6 @@ import org.eclipse.sirius.ecore.extender.business.internal.permission.ReadOnlyPe
 import org.eclipse.sirius.ecore.extender.business.internal.permission.descriptors.StandalonePermissionProviderDescriptor;
 import org.eclipse.sirius.tests.swtbot.Activator;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -101,12 +100,6 @@ public class LockedTabBarTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String DELETE_FROM_MODEL = "Delete from Model";
 
     private static final String SELECTED_PACKAGE = "0";
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     private PermissionProviderDescriptor permissionProviderDescriptor;
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/NotInvisibleTabBarTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/NotInvisibleTabBarTest.java
@@ -224,4 +224,11 @@ public class NotInvisibleTabBarTest extends AbstractSiriusSwtBotGefTestCase {
         checkEnabledDropDownButton(SELECT_ALL);
         checkEnabledDropDownButton(ALIGN_LEFT);
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/NotInvisibleTabBarTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/NotInvisibleTabBarTest.java
@@ -19,7 +19,6 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeEditPart;
 import org.eclipse.sirius.diagram.ui.tools.api.preferences.SiriusDiagramUiPreferencesKeys;
 import org.eclipse.sirius.tests.swtbot.Activator;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
@@ -67,12 +66,6 @@ public class NotInvisibleTabBarTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String SELECT_ALL = "Select &All";
 
     private static final String ALIGN_LEFT = "Align Left";
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
@@ -223,12 +216,5 @@ public class NotInvisibleTabBarTest extends AbstractSiriusSwtBotGefTestCase {
         selectDiagram();
         checkEnabledDropDownButton(SELECT_ALL);
         checkEnabledDropDownButton(ALIGN_LEFT);
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/ResetToDefaultFiltersActionTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/ResetToDefaultFiltersActionTests.java
@@ -29,7 +29,6 @@ import org.eclipse.sirius.tests.swtbot.Activator;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
-import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
 import org.eclipse.sirius.tests.swtbot.support.utils.SWTBotUtils;
 import org.eclipse.sirius.viewpoint.DRepresentation;
 import org.eclipse.swt.widgets.MenuItem;
@@ -67,8 +66,6 @@ public class ResetToDefaultFiltersActionTests extends AbstractSiriusSwtBotGefTes
     private static final String DIAGRAM_DESCRIPTION_WITHOUT_CONCERN = "Bug490384_DiagWithoutConcern";
 
     private SWTBotTreeItem modelElementItem;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     @Override
     protected void onSetUpBeforeClosingWelcomePage() throws Exception {
@@ -215,9 +212,7 @@ public class ResetToDefaultFiltersActionTests extends AbstractSiriusSwtBotGefTes
     
     @Override
     protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
         modelElementItem = null;
+        super.tearDown();
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/ResetToDefaultFiltersActionTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/ResetToDefaultFiltersActionTests.java
@@ -212,4 +212,12 @@ public class ResetToDefaultFiltersActionTests extends AbstractSiriusSwtBotGefTes
             }
         }));
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+        modelElementItem = null;
+    }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/TabBarTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/TabBarTest.java
@@ -41,7 +41,6 @@ import org.eclipse.sirius.tests.support.api.TestsUtil;
 import org.eclipse.sirius.tests.swtbot.Activator;
 import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation;
-import org.eclipse.sirius.tests.swtbot.support.api.business.UILocalSession;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckToolIsActivated;
@@ -118,12 +117,6 @@ public class TabBarTest extends AbstractSiriusSwtBotGefTestCase {
     private static final String TABBAR_EXTENSION_ON_DIAGRAM_ELEMENT = "Action on DDiagramElement (F5)";
 
     private static final String TABBAR_EXTENSION_ON_DIAGRAM = "Action on DDiagram (F5)";
-
-    private UIResource sessionAirdResource;
-
-    private UILocalSession localSession;
-
-    private SWTBotSiriusDiagramEditor editor;
 
     /**
      * {@inheritDoc}
@@ -596,12 +589,5 @@ public class TabBarTest extends AbstractSiriusSwtBotGefTestCase {
             });
             assertTrue("Tool button `" + item.getToolTipText() + "` is outside the visible part of the toolbar.", itemIsInside);
         }
-    }
-    
-    @Override
-    protected void tearDown() throws Exception {
-        editor.close();
-        super.tearDown();
-        editor = null;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/TabBarTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/TabBarTest.java
@@ -597,4 +597,11 @@ public class TabBarTest extends AbstractSiriusSwtBotGefTestCase {
             assertTrue("Tool button `" + item.getToolTipText() + "` is outside the visible part of the toolbar.", itemIsInside);
         }
     }
+    
+    @Override
+    protected void tearDown() throws Exception {
+        editor.close();
+        super.tearDown();
+        editor = null;
+    }
 }


### PR DESCRIPTION
To avoid keeping a significant amount of data after each test, the 'editor' reference should be closed & nulled during teardown.