### PR TITLE
[fix] Fix a potential UnsupportedOperationException

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/commands/ChildrenAdjustmentCommand.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/commands/ChildrenAdjustmentCommand.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.diagram.ui.internal.edit.commands;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -289,7 +290,8 @@ public class ChildrenAdjustmentCommand extends AbstractTransactionalCommand {
                 } else {
                     // The edges linked to border nodes of the west and east
                     // sides must be adapted to only move the last segment.
-                    childrenWithEdgesToMove = resizedPartQuery.getBorderNodeEditParts(PositionConstants.WEST);
+                    childrenWithEdgesToMove = new ArrayList<>();
+                    childrenWithEdgesToMove.addAll(resizedPartQuery.getBorderNodeEditParts(PositionConstants.WEST));
                     childrenWithEdgesToMove.addAll(resizedPartQuery.getBorderNodeEditParts(PositionConstants.EAST));
                     childrenWithEdgesToMove.removeAll(childrenToMoveWithDelta.keySet());
                     if (cbr.isCenteredResize()) {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/util/EditPartQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/util/EditPartQuery.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.IFigure;
@@ -158,14 +159,15 @@ public class EditPartQuery {
      * @return the list of {@link BorderItemEditPart}s that are on the expected side.
      */
     public List<IBorderItemEditPart> getBorderNodeEditParts(final int expectedSide) {
+        List<IBorderItemEditPart> result = new ArrayList<>();
         if (part instanceof IBorderedShapeEditPart) {
-            return part.getChildren().stream()
-                    .filter(child -> child instanceof IBorderItemEditPart borderItem &&  borderItem.getBorderItemLocator().getCurrentSideOfParent() == expectedSide)
-                    .filter(IBorderItemEditPart.class::isInstance)
-                    .map(IBorderItemEditPart.class::cast)
-                    .toList();
+            part.getChildren().stream()
+                .filter(child -> child instanceof IBorderItemEditPart borderItem &&  borderItem.getBorderItemLocator().getCurrentSideOfParent() == expectedSide)
+                .filter(IBorderItemEditPart.class::isInstance)
+                .map(IBorderItemEditPart.class::cast)
+                .forEach(result::add);
         }
-        return new ArrayList<>();
+        return result;
     }
 
     /**


### PR DESCRIPTION
Since ed645ff4183ab5775fefb79867e1e434c42c8866,
EditPartQuery.getBorderNodeEditParts() returned an *immutable* list
instead of a plain ArrayList before. Some client code (notably
ChildrenAdjustmentCommand.addBorderChildrenAdjustmentCommands()) try
to mutate the result, which would result in
UnsupportedOperationException.

Revert to returning a mutable List.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
