### PR TITLE
[144][test] Fix a memory leak regarding tests failures

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
@@ -1708,6 +1708,9 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
             setErrorCatchActive(false);
             setWarningCatchActive(false);
 
+            // All tearDown tasks have been done, now all fields can be safely clear (before below final checks).
+            new TestCaseCleaner(this).clearAllFields();
+
             crossRefDetector.assertNoCrossReferenceAdapterFound();
             checkLogs();
         }
@@ -1923,8 +1926,6 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
     @Override
     protected void tearDown() throws Exception {
         failureTearDown();
-
-        new TestCaseCleaner(this).clearAllFields();
 
         super.tearDown();
         setErrorCatchActive(false);


### PR DESCRIPTION
During an execution of a suite, if some fail during the failureTearDown method execution, all the data used by these tests leak until the end of the suite execution.
This can be problematic in case of long suite with several failures and lot of data. It increases the risk of OutOfMemory error.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/144