### PR TITLE
[releng] Point to the final release URLs for our dependencies

### DIFF
--- a/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_capella_2023-03" sequenceNumber="1700510735">
+<target name="sirius_capella_2023-03" sequenceNumber="1700730918">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -40,7 +40,7 @@
       <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
       <unit id="org.antlr.runtime" version="4.7.2.v20221112-0806"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.elk.sdk.feature.feature.group" version="0.0.0"/>
@@ -62,7 +62,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.23.202311200811"/>
-      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/"/>
+      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.targetplatform
+++ b/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.targetplatform
@@ -14,7 +14,7 @@ location Sirius-7.2.1 "https://download.eclipse.org/sirius/updates/releases/7.2.
 	org.eclipse.sirius.common.interpreter lazy
 }
 
-location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/" {
+location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/" {
 	org.eclipse.emf.compare.feature.group 3.3.23.202311200811
 }
 

--- a/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_headless_photon" sequenceNumber="1700510738">
+<target name="sirius_headless_photon" sequenceNumber="1700730918">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -42,7 +42,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
@@ -54,7 +54,7 @@
       <unit id="org.eclipse.acceleo.engine" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.parser" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.feature.group" version="0.0.0"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.targetplatform
+++ b/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.targetplatform
@@ -7,7 +7,7 @@ include "../modules/gmf-runtime-1.16.tpd"
 
 with source, requirements
 
-location Acceleo-3.7 "https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319" {
+location Acceleo-3.7 "https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/" {
     org.eclipse.acceleo.engine lazy
     org.eclipse.acceleo.parser lazy
     org.eclipse.acceleo.query.feature.group lazy

--- a/releng/org.eclipse.sirius.targets/modules/acceleo-3.7.tpd
+++ b/releng/org.eclipse.sirius.targets/modules/acceleo-3.7.tpd
@@ -2,7 +2,7 @@ target "acceleo-3.7"
 
 with source, requirements
 
-location Acceleo-3.7 "https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319" {
+location Acceleo-3.7 "https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/" {
     org.eclipse.acceleo.feature.group lazy
     org.eclipse.acceleo.ide.ui lazy
     org.eclipse.acceleo.ui.interpreter.feature.group lazy

--- a/releng/org.eclipse.sirius.targets/modules/aql-3.7.tpd
+++ b/releng/org.eclipse.sirius.targets/modules/aql-3.7.tpd
@@ -2,7 +2,7 @@ target "aql-3.7"
 
 with requirements
 
-location Acceleo-3.7 "https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319" {
+location Acceleo-3.7 "https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/" {
     org.eclipse.acceleo.query.feature.group lazy
     org.eclipse.acceleo.query.source.feature.group lazy
     org.eclipse.acceleo.query.ui.feature.group lazy

--- a/releng/org.eclipse.sirius.targets/modules/gmf-runtime-1.16.tpd
+++ b/releng/org.eclipse.sirius.targets/modules/gmf-runtime-1.16.tpd
@@ -6,7 +6,7 @@ location GMF-Notation-1.13.1 "https://download.eclipse.org/modeling/gmp/gmf-nota
     org.eclipse.gmf.runtime.notation.sdk.feature.group lazy
 }
 
-location GMF-Runtime-1.16.2 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/" {
+location GMF-Runtime-1.16.2 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/" {
     org.eclipse.gmf.runtime.sdk.feature.group lazy
     org.eclipse.gmf.runtime.thirdparty.feature.group lazy
 }

--- a/releng/org.eclipse.sirius.targets/sirius_2022-09.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2022-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2022-09" sequenceNumber="1700510743">
+<target name="sirius_2022-09" sequenceNumber="1700730918">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -40,7 +40,7 @@
       <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
       <unit id="org.antlr.runtime" version="4.7.2.v20221112-0806"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.eef.sdk.feature.feature.group" version="0.0.0"/>
@@ -69,7 +69,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
@@ -83,7 +83,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.23.202311200811"/>
-      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/"/>
+      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2022-09.targetplatform
+++ b/releng/org.eclipse.sirius.targets/sirius_2022-09.targetplatform
@@ -15,7 +15,7 @@ location Sirius-7.2.1 "https://download.eclipse.org/sirius/updates/releases/7.2.
 	org.eclipse.sirius.common.interpreter lazy
 }
 
-location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/" {
+location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/" {
 	org.eclipse.emf.compare.feature.group 3.3.23.202311200811
 }
 

--- a/releng/org.eclipse.sirius.targets/sirius_2022-12.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2022-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2022-12" sequenceNumber="1700510744">
+<target name="sirius_2022-12" sequenceNumber="1700730918">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -40,7 +40,7 @@
       <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
       <unit id="org.antlr.runtime" version="4.7.2.v20221112-0806"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.eef.runtime-feature.feature.group" version="1.5.1.201601141612"/>
@@ -73,7 +73,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
@@ -87,7 +87,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.23.202311200811"/>
-      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/"/>
+      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2022-12.targetplatform
+++ b/releng/org.eclipse.sirius.targets/sirius_2022-12.targetplatform
@@ -16,7 +16,7 @@ location Sirius-7.2.1 "https://download.eclipse.org/sirius/updates/releases/7.2.
 	org.eclipse.sirius.common.interpreter lazy
 }
 
-location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/" {
+location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/" {
 	org.eclipse.emf.compare.feature.group 3.3.23.202311200811
 }
 

--- a/releng/org.eclipse.sirius.targets/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2023-03" sequenceNumber="1700510742">
+<target name="sirius_2023-03" sequenceNumber="1700730918">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -40,7 +40,7 @@
       <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
       <unit id="org.antlr.runtime" version="4.7.2.v20221112-0806"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.eef.runtime-feature.feature.group" version="1.5.1.201601141612"/>
@@ -73,7 +73,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
@@ -87,7 +87,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.23.202311200811"/>
-      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/"/>
+      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2023-03.targetplatform
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-03.targetplatform
@@ -16,7 +16,7 @@ location Sirius-7.2.1 "https://download.eclipse.org/sirius/updates/releases/7.2.
 	org.eclipse.sirius.common.interpreter lazy
 }
 
-location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/" {
+location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/" {
 	org.eclipse.emf.compare.feature.group 3.3.23.202311200811
 }
 

--- a/releng/org.eclipse.sirius.targets/sirius_2023-06.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-06.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2023-06" sequenceNumber="1700510745">
+<target name="sirius_2023-06" sequenceNumber="1700730918">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -40,7 +40,7 @@
       <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
       <unit id="org.antlr.runtime" version="4.7.2.v20221112-0806"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.eef.runtime-feature.feature.group" version="1.5.1.201601141612"/>
@@ -73,7 +73,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
@@ -87,7 +87,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.23.202311200811"/>
-      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/"/>
+      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2023-06.targetplatform
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-06.targetplatform
@@ -16,7 +16,7 @@ location Sirius-7.2.1 "https://download.eclipse.org/sirius/updates/releases/7.2.
 	org.eclipse.sirius.common.interpreter lazy
 }
 
-location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/" {
+location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/" {
 	org.eclipse.emf.compare.feature.group 3.3.23.202311200811
 }
 

--- a/releng/org.eclipse.sirius.targets/sirius_2023-09.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2023-09" sequenceNumber="1700510746">
+<target name="sirius_2023-09" sequenceNumber="1700730918">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -40,7 +40,7 @@
       <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
       <unit id="org.antlr.runtime" version="4.7.2.v20221112-0806"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.eef.runtime-feature.feature.group" version="1.5.1.201601141612"/>
@@ -73,7 +73,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
@@ -87,7 +87,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.23.202311200811"/>
-      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/"/>
+      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2023-09.targetplatform
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-09.targetplatform
@@ -16,7 +16,7 @@ location Sirius-7.2.1 "https://download.eclipse.org/sirius/updates/releases/7.2.
 	org.eclipse.sirius.common.interpreter lazy
 }
 
-location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/" {
+location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/" {
 	org.eclipse.emf.compare.feature.group 3.3.23.202311200811
 }
 

--- a/releng/org.eclipse.sirius.targets/sirius_2023-12.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2023-12" sequenceNumber="1700510747">
+<target name="sirius_2023-12" sequenceNumber="1700731066">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -40,7 +40,7 @@
       <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
       <unit id="org.antlr.runtime" version="4.7.2.v20221112-0806"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319"/>
+      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202311201319/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.eef.runtime-feature.feature.group" version="1.5.1.201601141612"/>
@@ -77,17 +77,17 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/"/>
+      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.draw2d.sdk.feature.group" version="0.0.0"/>
-      <repository id="GEF-Classic" location="https://download.eclipse.org/tools/gef/classic/latest"/>
+      <repository id="GEF-Classic" location="https://download.eclipse.org/tools/gef/classic/releases/3.18.0RC1"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.23.202311200811"/>
-      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/"/>
+      <repository id="EMF-Compare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2023-12.targetplatform
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-12.targetplatform
@@ -20,18 +20,18 @@ location GMF-Notation-1.13.1 "https://download.eclipse.org/modeling/gmp/gmf-nota
     org.eclipse.gmf.runtime.notation.sdk.feature.group lazy
 }
 
-location GMF-Runtime-1.16.2 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907/" {
+location GMF-Runtime-1.16.2 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/" {
     org.eclipse.gmf.runtime.sdk.feature.group lazy
     org.eclipse.gmf.runtime.thirdparty.feature.group lazy
 }
 
-location GEF-Classic  "https://download.eclipse.org/tools/gef/classic/latest" {
+location GEF-Classic  "https://download.eclipse.org/tools/gef/classic/releases/3.18.0RC1" {
     org.eclipse.gef.feature.group lazy
     org.eclipse.gef.sdk.feature.group lazy
     org.eclipse.draw2d.sdk.feature.group lazy
 }
 
-location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/" {
+location EMF-Compare "https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202311200811/" {
 	org.eclipse.emf.compare.feature.group 3.3.23.202311200811
 }
 


### PR DESCRIPTION
Only GEF Classic 3.18.0 (used only in the 2023-12 target platform) is
still pointing to a non-final location as they are still in RC1 at the
moment.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
