### PR TITLE
[176] Adapt SiriusDiagramActionBarContributor to avoid memory leak

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/plugin.xml
+++ b/plugins/org.eclipse.sirius.diagram.ui/plugin.xml
@@ -40,7 +40,7 @@
          default="true"
          class="org.eclipse.sirius.diagram.ui.tools.internal.editor.DDiagramEditorImpl"
          matchingStrategy="org.eclipse.sirius.diagram.ui.part.SiriusMatchingStrategy"
-         contributorClass="org.eclipse.sirius.diagram.ui.part.SiriusDiagramActionBarContributor">
+         contributorClass="org.eclipse.sirius.diagram.ui.part.DDiagramEditorActionBarContributor">
       </editor>
    </extension>
 

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/part/DDiagramEditorActionBarContributor.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/part/DDiagramEditorActionBarContributor.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.part;
+
+import org.eclipse.sirius.diagram.ui.tools.internal.editor.DDiagramEditorImpl;
+
+/**
+ * Specific ActionBarContributor for {@link DDiagramEditorImpl} instance to avoid potential leaks on actions for action
+ * bar of this editor.
+ * 
+ * @author Laurent Redor
+ */
+public class DDiagramEditorActionBarContributor extends SiriusDiagramActionBarContributor {
+    @Override
+    protected Class<?> getEditorClass() {
+        return DDiagramEditorImpl.class;
+    }
+}

--- a/plugins/org.eclipse.sirius.sample.ecore.design/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.sirius.sample.ecore.design/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Eclipse-LazyStart: true
 Bundle-Activator: org.eclipse.sirius.ecore.design.service.EcoreSamplePlugin
 Export-Package: org.eclipse.sirius.ecore.design.service;version="3.0.0",
  org.eclipse.sirius.sample.ecore.design.action;version="3.0.0",
- org.eclipse.sirius.sample.ecore.design.editor;version="3.0.0"
+ org.eclipse.sirius.sample.ecore.design.editor;version="3.0.0",
+ org.eclipse.sirius.sample.ecore.design.editor.ui.part;version="3.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.sirius.ext.base;version="2.0.0",

--- a/plugins/org.eclipse.sirius.sample.ecore.design/plugin.xml
+++ b/plugins/org.eclipse.sirius.sample.ecore.design/plugin.xml
@@ -33,7 +33,7 @@
          point="org.eclipse.ui.editors">
       <editor
             class="org.eclipse.sirius.sample.ecore.design.editor.EcoreEntitiesReadOnlyEditor"
-            contributorClass="org.eclipse.sirius.diagram.ui.part.SiriusDiagramActionBarContributor"
+            contributorClass="org.eclipse.sirius.sample.ecore.design.editor.ui.part.EcoreEntitiesActionBarContributor"
             default="false"
             extensions="ecore"
             icon="icons/full/obj16/EcoreModelFile.gif"

--- a/plugins/org.eclipse.sirius.sample.ecore.design/src/org/eclipse/sirius/sample/ecore/design/editor/ui/part/EcoreEntitiesActionBarContributor.java
+++ b/plugins/org.eclipse.sirius.sample.ecore.design/src/org/eclipse/sirius/sample/ecore/design/editor/ui/part/EcoreEntitiesActionBarContributor.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.sample.ecore.design.editor.ui.part;
+
+import org.eclipse.sirius.diagram.ui.part.SiriusDiagramActionBarContributor;
+import org.eclipse.sirius.sample.ecore.design.editor.EcoreEntitiesReadOnlyEditor;
+
+/**
+ * Specific ActionBarContributor for {@link EcoreEntitiesReadOnlyEditor} instance to avoid potential leaks on actions
+ * for action bar of this editor.
+ * 
+ * @author Laurent Redor
+ */
+public class EcoreEntitiesActionBarContributor extends SiriusDiagramActionBarContributor {
+    @Override
+    protected Class<?> getEditorClass() {
+        return EcoreEntitiesReadOnlyEditor.class;
+    }
+}

--- a/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
@@ -78,6 +78,7 @@
             <org.eclipse.sirius.tests.skipLongTests>${tests.skipLongTests}</org.eclipse.sirius.tests.skipLongTests>
             <org.eclipse.sirius.tests.skipUnreliableTests>${tests.skipUnreliableTests}</org.eclipse.sirius.tests.skipUnreliableTests>
             <createLocalRepresentationInSeparateResource>${createLocalRepresentationInSeparateResource}</createLocalRepresentationInSeparateResource>
+            <sun.awt.datatransfer.timeout>100</sun.awt.datatransfer.timeout>
           </systemProperties>
           <skipTests>${tests.junit.skip}</skipTests>
           <includes>

--- a/plugins/org.eclipse.sirius.tests.junit/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit/pom.xml
@@ -82,6 +82,7 @@
             <org.eclipse.sirius.tests.skipLongTests>${tests.skipLongTests}</org.eclipse.sirius.tests.skipLongTests>
             <org.eclipse.sirius.tests.skipUnreliableTests>${tests.skipUnreliableTests}</org.eclipse.sirius.tests.skipUnreliableTests>
             <createLocalRepresentationInSeparateResource>${createLocalRepresentationInSeparateResource}</createLocalRepresentationInSeparateResource>
+            <sun.awt.datatransfer.timeout>100</sun.awt.datatransfer.timeout>
           </systemProperties>
           <skipTests>${tests.junit.skip}</skipTests>
           <includes>

--- a/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
@@ -100,6 +100,7 @@
             <org.eclipse.sirius.tests.skipUnreliableTests>${tests.skipUnreliableTests}</org.eclipse.sirius.tests.skipUnreliableTests>
             <org.eclipse.swtbot.screenshots.dir>${project.build.directory}/screenshots</org.eclipse.swtbot.screenshots.dir>
             <createLocalRepresentationInSeparateResource>${createLocalRepresentationInSeparateResource}</createLocalRepresentationInSeparateResource>
+            <sun.awt.datatransfer.timeout>100</sun.awt.datatransfer.timeout>
           </systemProperties>
           <skipTests>${tests.swtbot.skip}</skipTests>
           <includes>

--- a/plugins/org.eclipse.sirius.tests.tree/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.tree/pom.xml
@@ -109,6 +109,7 @@
           <systemProperties>
             <org.eclipse.sirius.tests.skipLongTests>${tests.skipLongTests}</org.eclipse.sirius.tests.skipLongTests>
             <org.eclipse.sirius.tests.skipUnreliableTests>${tests.skipUnreliableTests}</org.eclipse.sirius.tests.skipUnreliableTests>
+            <sun.awt.datatransfer.timeout>100</sun.awt.datatransfer.timeout>
           </systemProperties>
           <skipTests>${tests.junit.skip}</skipTests>
           <includes>

--- a/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
@@ -81,6 +81,7 @@
             <org.eclipse.sirius.tests.skipLongTests>${tests.skipLongTests}</org.eclipse.sirius.tests.skipLongTests>
             <org.eclipse.sirius.tests.skipUnreliableTests>${tests.skipUnreliableTests}</org.eclipse.sirius.tests.skipUnreliableTests>
             <createLocalRepresentationInSeparateResource>${createLocalRepresentationInSeparateResource}</createLocalRepresentationInSeparateResource>
+            <sun.awt.datatransfer.timeout>100</sun.awt.datatransfer.timeout>
           </systemProperties>
           <skipTests>${tests.junit.skip}</skipTests>
           <includes>


### PR DESCRIPTION
This PR follows PR #175.

Create a specific ActionBarContributor for each specific implementation of SiriusDiagramEditor to avoid a duplication of ActionRegistry: one for "SiriusDiagramEditor.class" and one for real implementation ("DDiagramEditorImpl.class" or "EcoreEntitiesReadOnlyEditor.class"). Indeed, only one of the ActionRegistry is correctly cleaned at the closing of the editor.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/176