### PR TITLE
[releng] Try to enable Timestamp on console

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
 	}
 
     options {
-      timeout(time: 2, unit: 'HOURS')
       timestamps ()
     }
 
@@ -26,9 +25,11 @@ pipeline {
                         label 'migration'
                     }
                     steps {
-                        script {
-                            wrap([$class: 'Xvnc', takeScreenshot: true, useXauthority: true]) {
-                                sh "mvn -B -Dplatform-version-name=2023-03 -f packaging/org.eclipse.sirius.parent/pom.xml -P headless,full,gerrit-junit integration-test"
+                        timeout(time: 2, unit: 'HOURS') {
+                            script {
+                                wrap([$class: 'Xvnc', takeScreenshot: true, useXauthority: true]) {
+                                    sh "mvn -B -Dplatform-version-name=2023-03 -f packaging/org.eclipse.sirius.parent/pom.xml -P headless,full,gerrit-junit integration-test"
+                                }
                             }
                         }
                     }
@@ -47,21 +48,23 @@ pipeline {
                         label 'migration'
                     }
                     steps {
-                        script {
-                            wrap([$class: 'Xvnc', takeScreenshot: true, useXauthority: true]) {
-                                sh '''
-                                rm -rf "$WORKSPACE/plugins/org.eclipse.sirius.tests.swtbot/screenshots"
-                                xrandr -s 1440x900
-                                xsetroot -solid grey
-                                vncconfig -iconic &
-                                xhost +
-                                sleep 2
-                                metacity --replace --sm-disable --display=${DISPLAY} &
-                                sleep 2
-                                rm -f plugins/org.eclipse.sirius.tests*/org_eclipse_sirius_tests_*.txt
+                        timeout(time: 2, unit: 'HOURS') {
+                            script {
+                                wrap([$class: 'Xvnc', takeScreenshot: true, useXauthority: true]) {
+                                    sh '''
+                                    rm -rf "$WORKSPACE/plugins/org.eclipse.sirius.tests.swtbot/screenshots"
+                                    xrandr -s 1440x900
+                                    xsetroot -solid grey
+                                    vncconfig -iconic &
+                                    xhost +
+                                    sleep 2
+                                    metacity --replace --sm-disable --display=${DISPLAY} &
+                                    sleep 2
+                                    rm -f plugins/org.eclipse.sirius.tests*/org_eclipse_sirius_tests_*.txt
 
-                                mvn -B -Dplatform-version-name=2023-03 -f packaging/org.eclipse.sirius.parent/pom.xml -P headless,full,gerrit-swtbot integration-test
-                                '''
+                                    mvn -B -Dplatform-version-name=2023-03 -f packaging/org.eclipse.sirius.parent/pom.xml -P headless,full,gerrit-swtbot integration-test
+                                    '''
+                                }
                             }
                         }
                     }
@@ -80,21 +83,23 @@ pipeline {
                         label 'migration'
                     }
                     steps {
-                        script {
-                            wrap([$class: 'Xvnc', takeScreenshot: true, useXauthority: true]) {
-                                sh '''
-                                rm -rf "$WORKSPACE/plugins/org.eclipse.sirius.tests.swtbot/screenshots"
-                                xrandr -s 1440x900
-                                xsetroot -solid grey
-                                vncconfig -iconic &
-                                xhost +
-                                sleep 2
-                                metacity --replace --sm-disable --display=${DISPLAY} &
-                                sleep 2
-                                rm -f plugins/org.eclipse.sirius.tests*/org_eclipse_sirius_tests_*.txt
+                        timeout(time: 2, unit: 'HOURS') {
+                            script {
+                                wrap([$class: 'Xvnc', takeScreenshot: true, useXauthority: true]) {
+                                    sh '''
+                                    rm -rf "$WORKSPACE/plugins/org.eclipse.sirius.tests.swtbot/screenshots"
+                                    xrandr -s 1440x900
+                                    xsetroot -solid grey
+                                    vncconfig -iconic &
+                                    xhost +
+                                    sleep 2
+                                    metacity --replace --sm-disable --display=${DISPLAY} &
+                                    sleep 2
+                                    rm -f plugins/org.eclipse.sirius.tests*/org_eclipse_sirius_tests_*.txt
                                 
-                                mvn -B -Dplatform-version-name=2023-03 -f packaging/org.eclipse.sirius.parent/pom.xml -P headless,full,gerrit-swtbot-sequence integration-test
-                                '''
+                                    mvn -B -Dplatform-version-name=2023-03 -f packaging/org.eclipse.sirius.parent/pom.xml -P headless,full,gerrit-swtbot-sequence integration-test
+                                    '''
+                                }
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
 
     options {
       timeout(time: 2, unit: 'HOURS')
+      timestamps ()
     }
 
     stages {


### PR DESCRIPTION
The option "timestamps" is available only if Timestamper plugin [1] is installed on Jenkins.
This commit allows to verify that it is installed or not.

[1] https://plugins.jenkins.io/timestamper/