### PR TITLE
[114] Adapts TabbarPasteFormatMenuManager dispose to a GMF bug fix

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/TabbarPasteFormatMenuManager.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/TabbarPasteFormatMenuManager.java
@@ -67,7 +67,7 @@ public class TabbarPasteFormatMenuManager extends PasteFormatMenuManager {
     @Override
     public void dispose() {
         removeAll();
-        actionHistory.clear();
+        actionHistory = null;
         super.dispose();
     }
 


### PR DESCRIPTION
The correct code in dispose is `actionHistory = null`, not `actionHistory.clear()`. However, the GMF bug caused a premature dispose, resulting in an NPE. Now, the GMF bug has been fixed and the correct code can be restored without error.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/114

**Please do not merge this PR before the GMF 1.16.3 release (and the Sirius TP update).**