### PR TITLE
[releng] Generate target definition file for TP in capella and headless

### DIFF
--- a/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_capella_2023-03" sequenceNumber="1700730918">
+<target name="sirius_capella_2023-03" sequenceNumber="1703157645">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -62,7 +62,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_headless_photon" sequenceNumber="1700730918">
+<target name="sirius_headless_photon" sequenceNumber="1703159823">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -42,7 +42,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.2" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>


### PR DESCRIPTION
The target platform have been changed, but only the `.target` files have been regenerated. This PR regenerates targets `capella/sirius_2023-03.target` and `headless/sirius_2023-03.target`.