### PR TITLE
[141] Fix a bug in "Move Pinned Elements" with elements not to be moved

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/query/EditPartQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/query/EditPartQuery.java
@@ -34,7 +34,6 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.AbstractDNodeContainerC
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.AbstractDNodeListCompartmentEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.NoteEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.SiriusNoteEditPart;
-import org.eclipse.sirius.diagram.ui.tools.internal.actions.layout.MovePinnedElementsAction;
 import org.eclipse.sirius.ext.base.Option;
 
 /**
@@ -107,8 +106,7 @@ public final class EditPartQuery {
         boolean isMovableByAutomaticLayout = true;
         if (!(editPart instanceof SiriusNoteEditPart)) {
             if (editPart.resolveSemanticElement() instanceof DDiagramElement) {
-                DDiagramElement dDiagramElement = (DDiagramElement) editPart.resolveSemanticElement();
-                isMovableByAutomaticLayout = MovePinnedElementsAction.getValue() || !(new PinHelper().isPinned(dDiagramElement) || (elementsToNotMove != null && elementsToNotMove.contains(editPart)));
+                isMovableByAutomaticLayout = !(isPinned() || (elementsToNotMove != null && elementsToNotMove.contains(editPart)));
             }
         } else {
             if (!Platform.getPreferencesService().getBoolean(DiagramPlugin.ID, SiriusDiagramPreferencesKeys.PREF_MOVE_NOTES_DURING_LATOUT.name(), false, null)) {


### PR DESCRIPTION
This commit fixes a bug in feature "Move Pinned Elements". Feature "Move Pinned Elements" must allow - during the layout algorithm - to move elements even if they are pinned, but must still leave fixed the elements indicated as fixed in the algorithm parameters.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/141