### PR TITLE
[releng] Add Log4j in extra requirements to avoid error in CI tests

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot.support/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/pom.xml
@@ -30,4 +30,27 @@
   <artifactId>org.eclipse.sirius.tests.swtbot.support</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+            <dependency-resolution>
+                <extraRequirements>
+                    <requirement>
+                        <type>eclipse-plugin</type>
+                        <id>org.apache.log4j</id>
+                        <versionRange>0.0.0</versionRange>
+                    </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>
+

--- a/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
@@ -67,6 +67,23 @@
 
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+            <dependency-resolution>
+                <extraRequirements>
+                    <requirement>
+                        <type>eclipse-plugin</type>
+                        <id>org.apache.log4j</id>
+                        <versionRange>0.0.0</versionRange>
+                    </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>


### PR DESCRIPTION
SWTBot execution on CI fails due to
java.lang.NoClassDefFoundError: org/apache/log4j/Logger

No error in PR 
https://ci.eclipse.org/sirius/job/sirius-pr-check/job/mpo%252Freleng%252Flog4jasExttraReqForTestsCITrial/lastCompletedBuild/testReport/org.eclipse.sirius.tests.swtbot/