### PR TITLE
[releng] Disable concurrent executions of the sirius-pr-check jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,8 @@ pipeline {
 
     options {
       timestamps ()
+      disableConcurrentBuilds()
+      timeout(time: 1, unit: 'HOURS')
     }
 
     stages {


### PR DESCRIPTION
It looks like concurrent executions of the job combined with parallel sub-stages can cause deadlocks when too many PRs are checked in parallel for the limited number of executors we have.
