### PR TITLE
[203] Upgrade to ELK 0.9.0 fo missed target platforms

### DIFF
--- a/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_capella_2023-03" sequenceNumber="1703841900">
+<target name="sirius_capella_2023-03" sequenceNumber="1705391713">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -50,7 +50,7 @@
       <unit id="org.eclipse.elk.graphviz.feature.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.source.feature.group" version="0.0.0"/>
-      <repository id="ELK-0.7" location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
+      <repository id="ELK-0.9" location="https://download.eclipse.org/elk/updates/releases/0.9.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.targetplatform
+++ b/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.targetplatform
@@ -5,7 +5,7 @@ include "../modules/swtbot-3.1.tpd"
 include "../modules/shared-license.tpd"
 include "../modules/aql-3.7.tpd"
 include "../modules/acceleo-3.7.tpd"
-include "../modules/elk-0.7.tpd"
+include "../modules/elk-0.9.tpd"
 include "../modules/gmf-runtime-1.16.tpd"
 
 with source, requirements

--- a/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_headless_photon" sequenceNumber="1703841900">
+<target name="sirius_headless_photon" sequenceNumber="1705391713">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -26,7 +26,7 @@
       <unit id="org.eclipse.elk.graphviz.feature.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.source.feature.group" version="0.0.0"/>
-      <repository id="ELK-0.7" location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
+      <repository id="ELK-0.9" location="https://download.eclipse.org/elk/updates/releases/0.9.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.targetplatform
+++ b/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.targetplatform
@@ -1,7 +1,7 @@
 target "sirius_headless_photon"
 
 include "../modules/orbit.tpd"
-include "../modules/elk-0.7.tpd"
+include "../modules/elk-0.9.tpd"
 include "../modules/shared-license.tpd"
 include "../modules/gmf-runtime-1.16.tpd"
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/203