### PR TITLE
[203] Fix test according to upgrade of ELK to 0.9.0 version

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/editor/vsm/LayoutOptionsTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/editor/vsm/LayoutOptionsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Obeo
+ * Copyright (c) 2018, 2024 Obeo
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -133,7 +133,7 @@ public class LayoutOptionsTests extends AbstractSiriusSwtBotGefTestCase {
         SWTBot optionOverrideBot = bot.activeShell().bot();
         SWTBotTable table = optionOverrideBot.table(0);
 
-        assertEquals("Not all layout options are available", 108, table.rowCount());
+        assertEquals("Not all layout options are available", 124, table.rowCount());
 
         SWTBotTableItem tableItem = table.getTableItem(1);
         tableItem.check();


### PR DESCRIPTION
The test org.eclipse.sirius.tests.swtbot.editor.vsm.LayoutOptionsTests.testLayoutOptionModifications() has an hardcoded value of the number of options. As the ELK version has been changed, it is expected to have new options.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/203