### PR TITLE
[releng] Remove global 1 hour timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     options {
       timestamps ()
       disableConcurrentBuilds()
-      timeout(time: 1, unit: 'HOURS')
     }
 
     stages {


### PR DESCRIPTION
When several PRs are pushed simultaneously, each PR can occupy part of the 4 free slots. So parallel sub-stages can take several minutes to actually start (even if the timeout starts at the start of the "parent" stage).
FYI, a timeout already exists individually on each sub-stage (currently set at 2 hours).