### PR TITLE
[releng] Disable running multiple PR jobs at the same time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     options {
       timestamps ()
       disableConcurrentBuilds()
+	  lock(resource: 'sirius-desktop-tests')
     }
 
     stages {


### PR DESCRIPTION
I'm not sure if @pcdavid checks this configuration and it's difficult to see the different tests on PR #246.
But according to [this](https://github.com/jenkinsci/lockable-resources-plugin/blob/master/src/doc/examples/locking-multiple-stages-in-declarative-pipeline.md), it seems possible.