### PR TITLE
[releng] Remove disableConcurrentBuilds option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
 
     options {
       timestamps ()
-      disableConcurrentBuilds()
 	  lock(resource: 'sirius-desktop-tests')
     }
 


### PR DESCRIPTION
This option has been added in commit 5b7db7fe [1] to try to disable concurrent executions of pull request's jobs. In fact, it only avoids the concurrent execution of two jobs of the same PR, which was not the desired objective. Another solution was found (via commit 967b6e6b [2]). This option can therefore be removed.

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/5b7db7fefafd964e3b6f95ac32cd376a2caa670f
[2] https://github.com/eclipse-sirius/sirius-desktop/commit/967b6e6bf73aeb1f4d4ede8b6d5195f041c16c50