### PR TITLE
[releng] Update TPs to gmf-runtime milestone S202401081627

### DIFF
--- a/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/capella/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_capella_2023-03" sequenceNumber="1705391713">
+<target name="sirius_capella_2023-03" sequenceNumber="1707401172">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -59,7 +59,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/headless/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_headless_photon" sequenceNumber="1705391713">
+<target name="sirius_headless_photon" sequenceNumber="1707401172">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -39,7 +39,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/modules/gmf-runtime-1.16.tpd
+++ b/releng/org.eclipse.sirius.targets/modules/gmf-runtime-1.16.tpd
@@ -6,7 +6,7 @@ location GMF-Notation-1.13.1 "https://download.eclipse.org/modeling/gmp/gmf-nota
     org.eclipse.gmf.runtime.notation.sdk.feature.group lazy
 }
 
-location GMF-Runtime-1.16.3 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/" {
+location GMF-Runtime-1.16.3 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/" {
     org.eclipse.gmf.runtime.sdk.feature.group lazy
     org.eclipse.gmf.runtime.thirdparty.feature.group lazy
 }

--- a/releng/org.eclipse.sirius.targets/sirius_2022-09.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2022-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2022-09" sequenceNumber="1704213419">
+<target name="sirius_2022-09" sequenceNumber="1707401172">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -66,7 +66,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2022-12.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2022-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2022-12" sequenceNumber="1704213416">
+<target name="sirius_2022-12" sequenceNumber="1707401172">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -70,7 +70,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2023-03.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2023-03" sequenceNumber="1704213413">
+<target name="sirius_2023-03" sequenceNumber="1707401172">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -70,7 +70,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2023-06.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-06.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2023-06" sequenceNumber="1704213409">
+<target name="sirius_2023-06" sequenceNumber="1707401175">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -70,7 +70,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.sirius.targets/sirius_2023-09.target
+++ b/releng/org.eclipse.sirius.targets/sirius_2023-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="sirius_2023-09" sequenceNumber="1704213408">
+<target name="sirius_2023-09" sequenceNumber="1707401176">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.easymock" version="0.0.0"/>
@@ -70,7 +70,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.gmf.runtime.thirdparty.feature.group" version="0.0.0"/>
-      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/"/>
+      <repository id="GMF-Runtime-1.16.3" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202401081627/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>


### PR DESCRIPTION
It contains dependency to repackaged batik that prevent loading too much bundle (remove "Eclipse-BuddyPolicy: dependent" usage)

Change-Id: If9f67198854b97fc343729ec27ea884dda3a98b5