### PR TITLE
[releng] Switch to java 17 in Sonar Analysis

### DIFF
--- a/packaging/org.eclipse.sirius.parent/pom.xml
+++ b/packaging/org.eclipse.sirius.parent/pom.xml
@@ -63,7 +63,7 @@
     <sonar.skipDesign>true</sonar.skipDesign>
     <sonar.jacoco.reportPath>${project.basedir}/../../packaging/org.eclipse.sirius.parent/target/jacoco.exec</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${project.basedir}/../../packaging/org.eclipse.sirius.parent/target/jacoco-it.exec</sonar.jacoco.itReportPath>
-    <sonar.java.source>8</sonar.java.source>
+    <sonar.java.source>17</sonar.java.source>
     <sonar.exclusions>src-gen/**/*</sonar.exclusions>
     <sonar.coverage.exclusions>${project.basedir}/../../plugins/org.eclipse.sirius.sample*/**/*.java,${project.basedir}/../../plugins/org.eclipse.sirius.tests*/**/*.java,</sonar.coverage.exclusions>
   </properties>


### PR DESCRIPTION
In console of sirius.sonar.job we can see some errors as : 20:27:27 [ERROR] Unable to parse source file :
'plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/LayoutChildrenTest.java' 20:27:27 [ERROR] Parse error at line 151 column 8: Arrow in case statement supported from Java 14 onwards only

Indeed, in the configuration, the parameter `sonar.java.source` is always 8, instead of 17 (according to the "recent" change).