### PR TITLE
[releng] Update sonar.exclusions parameter according to warning message

### DIFF
--- a/packaging/org.eclipse.sirius.parent/pom.xml
+++ b/packaging/org.eclipse.sirius.parent/pom.xml
@@ -64,7 +64,7 @@
     <sonar.jacoco.reportPath>${project.basedir}/../../packaging/org.eclipse.sirius.parent/target/jacoco.exec</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${project.basedir}/../../packaging/org.eclipse.sirius.parent/target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.java.source>17</sonar.java.source>
-    <sonar.exclusions>src-gen/**/*</sonar.exclusions>
+    <sonar.exclusions>plugins/*/src-gen/**/*</sonar.exclusions>
     <sonar.coverage.exclusions>${project.basedir}/../../plugins/org.eclipse.sirius.sample*/**/*.java,${project.basedir}/../../plugins/org.eclipse.sirius.tests*/**/*.java,</sonar.coverage.exclusions>
   </properties>
 


### PR DESCRIPTION
In SonarCloud [1], a message says `Specifying module-relative paths at project level in the property 'sonar.exclusions' is deprecated. To continue matching files like
'plugins/org.eclipse.sirius.diagram.formatdata/src-gen/org/eclipse/sirius/diagram/formatdata/AbstractFormatData.java', update this property so that patterns refer to project-relative paths.`

This commit tries to fix this problem.

[1] https://sonarcloud.io/code?id=org.eclipse.sirius