### PR TITLE
[releng] Update Sonar configuration - Improve exclusion of code coverage

### DIFF
--- a/packaging/org.eclipse.sirius.parent/pom.xml
+++ b/packaging/org.eclipse.sirius.parent/pom.xml
@@ -63,7 +63,7 @@
     <sonar.skipDesign>true</sonar.skipDesign>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.java.source>17</sonar.java.source>
-    <sonar.exclusions>plugins/*/src-gen/**/*, **/*.css,**/*.html,**/*.js</sonar.exclusions>
+    <sonar.exclusions>plugins/*/src-gen/**/*, plugins/*/xtend-gen/**/*,**/*.css,**/*.html,**/*.js</sonar.exclusions>
     <sonar.coverage.exclusions>${project.basedir}/../../plugins/org.eclipse.sirius.sample*/**/*.java,${project.basedir}/../../plugins/org.eclipse.sirius.tests*/**/*.java,</sonar.coverage.exclusions>
   </properties>
 

--- a/plugins/org.eclipse.sirius.tests.sample.component.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.component.design/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src/**/*, src-gen/**/*</sonar.coverage.exclusions>
+  </properties>
+  
   <artifactId>org.eclipse.sirius.tests.sample.component.design</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.docbook.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.docbook.design/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.sample.docbook.design</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.migration.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.migration.design/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.sample.migration.design</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.scxml.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.scxml.design/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.sample.scxml.design</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.design/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine.design</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ide/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ide/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src-gen/**/*</sonar.coverage.exclusions>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine.ide</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ui/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ui/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src-gen/**/*, xtend-gen/**/*</sonar.coverage.exclusions>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine.ui</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.coverage.exclusions>src/**/*, src-gen/**/*, xtend-gen/**/*</sonar.coverage.exclusions>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>


### PR DESCRIPTION
Tests plug-ins, which have `<packaging>eclipse-test-plugin</packaging>` in there pom.xml file, are automatically excluded from code coverage analysis (as said in SonarCloud doc [1]). So the configuration `<sonar.coverage.exclusions>...,${project.basedir}/../../plugins/org.eclipse.sirius.tests*/**/*.java</sonar.coverage.exclusions>` does not seems relevant. I left it for now. If my analysis is correct, the parameter
`<sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>` in all tests plug-ins is also to be remved (to see later).

Globally, the parameter `<sonar.coverage.exclusions>` seems to be used to exclude specific files or directories from coverage analysis, not entire modules. This would explain why all plug-in starting with "org.eclipse.sirius.sample*" are currently not excluded.

To really ignore them, this commit adds an explicit exclusion of java files of concerned plug-ins.

The parameter `<sonar.coverage.exclusions>` of pom.xml in `org.eclipse.sirius.parent` can probably be removed later.

This commit also adds `xtend-gen` as excluded (for the same reasons as for `src-gen`).