### PR TITLE
[releng] Avoid to launch two PR jobs simultaneously

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,12 @@
+#!groovy
+
+script {
+    // Use BuildBlocker to wait for all 'sirius-pr-check' projects to finish building
+    properties([
+        [$class: 'BuildBlockerProperty', blockLevel: 'GLOBAL', blockingJobs: 'sirius-pr-check.*', scanQueueFor: 'ALL', useBuildBlocker: true]
+    ])
+}
+
 pipeline {
     agent {
         label 'centos-latest'


### PR DESCRIPTION
Just a PR to validate blocking (with PR #269)

With the previous commit 967b6e6b [1], using "Jenkins Lockable Resources Plugin" [2], a node is used to launch the PR job and then the "lock" is checked. If the lock is not available, the node is used until the lock is released.

With this new "option", find here [3] and [4], the job stays in the queue until
block condition is OK.

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/967b6e6bf73aeb1f4d4ede8b6d5195f041c16c50
[2] https://github.com/jenkinsci/lockable-resources-plugin
[3] https://stackoverflow.com/questions/66585628/how-to-use-buildblockerproperty-on-jenkins-pipeline
[4] https://copyprogramming.com/howto/deadlock-when-run-two-pipelines-parallel-in-jenkins