### PR TITLE
[releng] Avoid to launch two PR jobs simultaneously

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
 	}
 
     options {
+	  buildBlocker (useBuildBlocker: true, blockLevel: 'GLOBAL', scanQueueFor: 'ALL', blockingJobs: 'sirius-pr-check.*')
       timestamps ()
 	  lock(resource: 'sirius-desktop-tests')
     }


### PR DESCRIPTION
With the previous commit 967b6e6b [1], using "Jenkins Lockable Resources Plugin" [2], a node is used to launch the PR job and then the "lock" is checked. If the lock is not available, the node is used until the lock is released.

With this new "option", find here [3] and [4], the job stays in the queue until block condition is OK.

This commit tries to add a second blocking jobs name.

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/967b6e6bf73aeb1f4d4ede8b6d5195f041c16c50
[2] https://github.com/jenkinsci/lockable-resources-plugin
[3] https://stackoverflow.com/questions/66585628/how-to-use-buildblockerproperty-on-jenkins-pipeline
[4] https://copyprogramming.com/howto/deadlock-when-run-two-pipelines-parallel-in-jenkins