### PR TITLE
[releng] Remove unnecessary "sonar.coverage.exclusions" parameters

### DIFF
--- a/packaging/org.eclipse.sirius.parent/pom.xml
+++ b/packaging/org.eclipse.sirius.parent/pom.xml
@@ -68,9 +68,6 @@
     <!-- Path to exclude from the sonar analysis: quality, security, reliability... Use project relative paths (project in the Sonar sense), and not module relative paths -->
     <!-- Generated code is not supposed to be analysed, neither html&js code (problem on Eclipse side) -->
     <sonar.exclusions>plugins/*/src-gen/**/*, plugins/*/xtend-gen/**/*,**/*.css,**/*.html,**/*.js</sonar.exclusions>
-    <!-- This parameter is overridden. Indeed, it is used to exclude specific files or directories from coverage analysis, not entire modules like here.
-         It will probably be removed later. -->
-    <sonar.coverage.exclusions>${project.basedir}/../../plugins/org.eclipse.sirius.sample*/**/*.java,${project.basedir}/../../plugins/org.eclipse.sirius.tests*/**/*.java,</sonar.coverage.exclusions>
   </properties>
 
   <!--Add specific repositories, pluginRepositories and dependencies for Acceleo3 compilation. See http://wiki.eclipse.org/Acceleo/Maven for more details. -->

--- a/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
@@ -23,10 +23,6 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
-  <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
-  </properties>
-
   <artifactId>org.eclipse.sirius.tests.junit.xtext</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.junit/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit/pom.xml
@@ -23,13 +23,6 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
-  <properties>
-    <!-- I think this parameter is not necessary. Indeed, in documentation (https://docs.sonarsource.com/sonarcloud/advanced-setup/analysis-scope/#automatic-setting-for-maven-gradle-and-net),
-    "sonar.sources" and "sonar.tests" are automatically set based on project configuration. So, it is supposed to be ignore from code coverage, even without this parameter. 
-    This remark is true for all tests modules. -->   
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
-  </properties>
-
   <artifactId>org.eclipse.sirius.tests.junit</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
@@ -23,10 +23,6 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
-  <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
-  </properties>
-
   <artifactId>org.eclipse.sirius.tests.swtbot</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.tree/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.tree/pom.xml
@@ -23,10 +23,6 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
-  <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
-  </properties>
-
   <artifactId>org.eclipse.sirius.tests.tree</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
@@ -21,10 +21,6 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
-  <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
-  </properties>
-
   <artifactId>org.eclipse.sirius.tests.ui.properties</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>


### PR DESCRIPTION
This commit removes some unnecessary "sonar.coverage.exclusions" parameters. I'm not sure of this status. It will be verified at the next Sonar job.

These parameters are:
* sonar.coverage.exclusions: At the "root" level, as it is not possible to ignore a full module.
* sonar.coverage.exclusions: In each "tests" plug-in, that is supposed to be automatically ignored by Sonar.