### PR TITLE
[releng] Explicitly set tests code for Sonar analysis

### DIFF
--- a/plugins/org.eclipse.sirius.tests.junit.support/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit.support/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.junit.support</artifactId>

--- a/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.junit.xtext</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.junit/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.junit</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.swtbot.support/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.swtbot.support</artifactId>

--- a/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.swtbot</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.tree/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.tree/pom.xml
@@ -23,6 +23,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.tree</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
@@ -21,6 +21,10 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.tests.ui.properties</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>


### PR DESCRIPTION
The last commit [1], `[releng] Remove unnecessary
"sonar.coverage.exclusions" parameters`, reveals that these parameters were useful. Indeed, the code of tests is now wrongly considered in coverage result.

This commit tries to disable this, by using explicit "sonar.tests" parameter. I thought that it is automatically set according to "<packaging>eclipse-test-plugin</packaging>" parameter as shown in documentation [2].

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/d8577f7dd7e06675fc9d070e15a43ac742d0b026
[2] https://docs.sonarsource.com/sonarcloud/advanced-setup/analysis-scope/#automatic-setting-for-maven-gradle-and-net