### PR TITLE
[152] Compute the location of the ColorPalettePopup

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/ColorPaletteComposite.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/ColorPaletteComposite.java
@@ -196,9 +196,11 @@ public class ColorPaletteComposite extends Composite {
      */
     private void refreshColorButtons() {
         if (colors.isEmpty()) {
-            ((GridLayout) getLayout()).marginBottom = 25;
+            ((GridLayout) getLayout()).marginBottom = BUTTON_SIZE;
+            ((GridLayout) getLayout()).marginRight = BUTTON_SIZE * numberOfColumns + BUTTONS_HORIZONTAL_SPACING * (numberOfColumns - 1);
         } else {
             ((GridLayout) getLayout()).marginBottom = 0;
+            ((GridLayout) getLayout()).marginRight = 0;
         }
         if (colors.size() < buttonMap.size()) {
             // If some colors have been removed, we should removed all buttons to recreate them after.

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/ColorPalettePopup.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/ColorPalettePopup.java
@@ -32,6 +32,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -41,7 +42,9 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.ToolItem;
 
 /**
  * This class define the popup invoked when a button to change the colors is clicked. This {@link ColorPalettePopup}
@@ -62,6 +65,16 @@ import org.eclipse.swt.widgets.Shell;
  * @author <a href="mailto:glenn.plouhinec@obeo.fr">Glenn Plouhinec</a>
  */
 public class ColorPalettePopup {
+
+    /**
+     * The height of the popup used to compute its location to open it.
+     */
+    private static final int POPUP_HEIGHT = 192;
+
+    /**
+     * The width of the popup used to compute its location to open it.
+     */
+    private static final int POPUP_WIDTH = 343;
 
     /**
      * The maximum number of colors to display for each category.
@@ -416,6 +429,78 @@ public class ColorPalettePopup {
             }
             colorCategoryManager.setSuggestedColors(suggestedCategoryDialog.getDisplayedColors());
         }
+    }
+
+    /**
+     * Used to get a valid location to open the {@link ColorPalettePopup} using a {@link MenuItem}.
+     * 
+     * @param menuItem
+     *            the clicked {@link MenuItem}.
+     * @return the top-left location to open the {@link ColorPalettePopup}.
+     */
+    public static Point getValidPopupLocation(MenuItem menuItem) {
+        Point location = new Point(0, 0);
+        location = Display.getCurrent().getCursorLocation();
+        Rectangle screenBounds = Display.getCurrent().getBounds();
+        if (!screenBounds.contains(location.x + POPUP_WIDTH, location.y + POPUP_HEIGHT)) {
+            location = new Point(location.x - POPUP_WIDTH, location.y - POPUP_HEIGHT);
+        }
+        return location;
+    }
+
+    /**
+     * Used to get a valid location to open the {@link ColorPalettePopup} using a {@link ToolItem}.
+     * 
+     * @param toolItem
+     *            the clicked {@link ToolItem}.
+     * @return the top-left location to open the {@link ColorPalettePopup}.
+     */
+    public static Point getValidPopupLocation(ToolItem toolItem) {
+        Rectangle itemBounds = toolItem.getBounds();
+        Point itemLocation = toolItem.getParent().toDisplay(itemBounds.x, itemBounds.y);
+        return getValidPopupLocation(itemBounds, itemLocation);
+    }
+
+    /**
+     * Used to get a valid location to open the {@link ColorPalettePopup} using a {@link Button}.
+     * 
+     * @param button
+     *            the clicked {@link Button}.
+     * @return the top-left location to open the {@link ColorPalettePopup}.
+     */
+    public static Point getValidPopupLocation(Button button) {
+        Rectangle buttonBounds = button.getBounds();
+        Point buttonLocation = button.getParent().toDisplay(buttonBounds.x, buttonBounds.y);
+        return getValidPopupLocation(buttonBounds, buttonLocation);
+    }
+
+    /**
+     * Used to get a valid location to open the {@link ColorPalettePopup} basing on the location of the clicked button.
+     * 
+     * @param buttonBounds
+     *            the bounds of the clicked button.
+     * @param buttonLocation
+     *            the location of the button
+     * @return the top-left location to open the {@link ColorPalettePopup}.
+     */
+    public static Point getValidPopupLocation(Rectangle buttonBounds, Point buttonLocation) {
+        Point location = new Point(0, 0);
+        Rectangle eclipseShellBounds = Display.getCurrent().getActiveShell().getBounds();
+        int locationX = buttonLocation.x;
+        int locationY = buttonLocation.y + buttonBounds.height;
+        int shellMargin = 7;
+        Point expectedRightBottomPopup = new Point(buttonLocation.x + POPUP_WIDTH, buttonLocation.y + POPUP_HEIGHT);
+        if (!eclipseShellBounds.contains(expectedRightBottomPopup)) {
+            Point rightBottomShell = new Point(eclipseShellBounds.x + eclipseShellBounds.width, eclipseShellBounds.y + eclipseShellBounds.height);
+            if (expectedRightBottomPopup.x > rightBottomShell.x) {
+                locationX = rightBottomShell.x - POPUP_WIDTH - shellMargin;
+            }
+            if (expectedRightBottomPopup.y > rightBottomShell.y) {
+                locationY = rightBottomShell.y - POPUP_HEIGHT - shellMargin;
+            }
+        }
+        location = new Point(locationX, locationY);
+        return location;
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/ColorPropertyContributionItem.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/ColorPropertyContributionItem.java
@@ -27,7 +27,6 @@ import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
@@ -261,23 +260,9 @@ public class ColorPropertyContributionItem extends PropertyChangeContributionIte
      *            the item clicked on the tabbar.
      */
     private void invokeColorPalettePopup(Item item) {
-        Point location = new Point(0, 0);
-        if (item instanceof ToolItem toolItem) {
-            Rectangle r = toolItem.getBounds();
-            location = toolItem.getParent().toDisplay(r.x, r.y);
-            location = new Point(location.x, location.y + r.height);
-        } else if (item instanceof MenuItem menuItem) {
-            location = Display.getCurrent().getCursorLocation();
-            Rectangle screenBounds = Display.getCurrent().getBounds();
-            int popupWidth = 343;
-            int popupHeight = 192;
-            if (!screenBounds.contains(location.x + popupWidth, location.y + popupHeight)) {
-                location = new Point(location.x - popupWidth, location.y - popupHeight);
-            }
-        }
         final ColorPalettePopup popup = new ColorPalettePopup(Display.getCurrent().getActiveShell(), ((DDiagramEditor) getWorkbenchPart()).getSession(), getOperationSet(), getPropertyId());
         popup.init();
-        popup.open(location);
+        popup.open(computePopupLocation(item));
 
         final RGB rgb = popup.getSelectedColor();
         if (rgb != null) {
@@ -293,6 +278,16 @@ public class ColorPropertyContributionItem extends PropertyChangeContributionIte
             lastColor = FigureUtilities.RGBToInteger(rgb);
             runWithEvent(null);
         }
+    }
+
+    private Point computePopupLocation(Item item) {
+        Point location = new Point(0, 0);
+        if (item instanceof ToolItem toolItem) {
+            location = ColorPalettePopup.getValidPopupLocation(toolItem);
+        } else if (item instanceof MenuItem menuItem) {
+            location =  ColorPalettePopup.getValidPopupLocation(menuItem);
+        }
+        return location;
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramColorAndFontPropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramColorAndFontPropertySection.java
@@ -66,9 +66,7 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -123,10 +121,8 @@ public class DiagramColorAndFontPropertySection extends DiagramColorsAndFontsPro
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
             ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
-            final Rectangle r = button.getBounds();
-            final Point location = button.getParent().toDisplay(r.x, r.y);
             popup.setPreviousColor(previousColor);
-            popup.open(new Point(location.x, location.y + r.height));
+            popup.open(ColorPalettePopup.getValidPopupLocation(button));
 
             // selectedColor should be null if we are to use the default color
             final RGB selectedColor = popup.getSelectedColor();

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramConnectionAppearancePropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramConnectionAppearancePropertySection.java
@@ -58,9 +58,7 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -114,10 +112,8 @@ public class DiagramConnectionAppearancePropertySection extends ConnectionAppear
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
             ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
-            final Rectangle r = button.getBounds();
-            final Point location = button.getParent().toDisplay(r.x, r.y);
             popup.setPreviousColor(previousColor);
-            popup.open(new Point(location.x, location.y + r.height));
+            popup.open(ColorPalettePopup.getValidPopupLocation(button));
 
             // selectedColor should be null if we are to use the default color
             final RGB selectedColor = popup.getSelectedColor();

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramShapeColorAndFontPropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramShapeColorAndFontPropertySection.java
@@ -79,9 +79,7 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -137,10 +135,8 @@ public class DiagramShapeColorAndFontPropertySection extends ShapeColorsAndFonts
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
             ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
-            final Rectangle r = button.getBounds();
-            final Point location = button.getParent().toDisplay(r.x, r.y);
             popup.setPreviousColor(previousColor);
-            popup.open(new Point(location.x, location.y + r.height));
+            popup.open(ColorPalettePopup.getValidPopupLocation(button));
 
             // selectedColor should be null if we are to use the default color
             final RGB selectedColor = popup.getSelectedColor();

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/LabelColorAndFontPropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/LabelColorAndFontPropertySection.java
@@ -55,9 +55,7 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -98,10 +96,8 @@ public class LabelColorAndFontPropertySection extends ColorsAndFontsPropertySect
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
             ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
-            final Rectangle r = button.getBounds();
-            final Point location = button.getParent().toDisplay(r.x, r.y);
             popup.setPreviousColor(previousColor);
-            popup.open(new Point(location.x, location.y + r.height));
+            popup.open(ColorPalettePopup.getValidPopupLocation(button));
 
             // selectedColor should be null if we are to use the default color
             final RGB selectedColor = popup.getSelectedColor();


### PR DESCRIPTION
- The top-left location of the ColorPalettePopup is computed to fully display the popup when buttons from the toolbar or appearance tab are close to the edge of the window.
- Set a default width for the ColorPaletteComposite when it is empty

Change-Id: I1246641707437ab3574546d31b5da38d55fcef0a