### PR TITLE
[releng] Explicitly set source code for Sonar analysis of tests plug-ins

### DIFF
--- a/plugins/org.eclipse.sirius.tests.junit.support/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit.support/pom.xml
@@ -24,6 +24,7 @@
   </parent>
 
   <properties>
+    <sonar.sources>pom.xml</sonar.sources>
     <sonar.tests>src</sonar.tests>
   </properties>
 

--- a/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit.xtext/pom.xml
@@ -24,6 +24,7 @@
   </parent>
 
   <properties>
+    <sonar.sources>pom.xml</sonar.sources>
     <sonar.tests>src</sonar.tests>
   </properties>
 

--- a/plugins/org.eclipse.sirius.tests.junit/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.junit/pom.xml
@@ -24,6 +24,7 @@
   </parent>
 
   <properties>
+    <sonar.sources>pom.xml</sonar.sources>
     <sonar.tests>src</sonar.tests>
   </properties>
 

--- a/plugins/org.eclipse.sirius.tests.swtbot.support/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/pom.xml
@@ -24,6 +24,7 @@
   </parent>
 
   <properties>
+    <sonar.sources>pom.xml</sonar.sources>
     <sonar.tests>src</sonar.tests>
   </properties>
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.swtbot/pom.xml
@@ -24,6 +24,7 @@
   </parent>
 
   <properties>
+    <sonar.sources>pom.xml</sonar.sources>
     <sonar.tests>src</sonar.tests>
   </properties>
 

--- a/plugins/org.eclipse.sirius.tests.tree/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.tree/pom.xml
@@ -24,6 +24,7 @@
   </parent>
 
   <properties>
+    <sonar.sources>pom.xml</sonar.sources>
     <sonar.tests>src</sonar.tests>
   </properties>
 

--- a/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.ui.properties/pom.xml
@@ -22,6 +22,7 @@
   </parent>
 
   <properties>
+    <sonar.sources>pom.xml</sonar.sources>
     <sonar.tests>src</sonar.tests>
   </properties>
 


### PR DESCRIPTION
The last commit, [1], explicitly sets the tests code. In this commit, the parameter "sonar.sources" is also set, because without that, the default value is "pom.xml, src" and an error is logged: "Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.10.0.2594:sonar (default-cli) on project sirius-parent: File
plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/SiriusTestsPlugin.java can't be indexed twice. Please check that inclusion/exclusion patterns produce disjoint sets for main and test files".

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/7286b4386ce60c75aacaa4ecf8d284a12b4dcebc