### PR TITLE
[releng] Consider all "sample" plug-ins as tests code

### DIFF
--- a/plugins/org.eclipse.sirius.sample.ecore.design/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.ecore.design/pom.xml
@@ -23,6 +23,11 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.ecore.design</artifactId>
   <version>7.4.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/plugins/org.eclipse.sirius.sample.interactions.design/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.interactions.design/pom.xml
@@ -23,6 +23,11 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.interactions.design</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.sample.interactions.edit/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.interactions.edit/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.sample.interactions.edit</artifactId>

--- a/plugins/org.eclipse.sirius.sample.interactions.editor/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.interactions.editor/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.sample.interactions.editor</artifactId>

--- a/plugins/org.eclipse.sirius.sample.interactions/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.interactions/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.sample.interactions</artifactId>

--- a/plugins/org.eclipse.sirius.sample.properties.checkbox/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.properties.checkbox/pom.xml
@@ -21,6 +21,11 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.properties.checkbox</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.sample.properties.radio/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.properties.radio/pom.xml
@@ -21,6 +21,11 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.properties.radio</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.sample.properties.textarea/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.properties.textarea/pom.xml
@@ -21,6 +21,11 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.properties.textarea</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.sample.properties/pom.xml
+++ b/plugins/org.eclipse.sirius.sample.properties/pom.xml
@@ -21,6 +21,11 @@
     <relativePath>../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
 
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.properties</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>7.4.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily.design/pom.xml
+++ b/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily.design/pom.xml
@@ -22,7 +22,12 @@
     <version>7.4.0-SNAPSHOT</version>
     <relativePath>../../../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
-  
+
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.basicfamily.design</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>1.0.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily.edit/pom.xml
+++ b/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily.edit/pom.xml
@@ -22,7 +22,12 @@
     <version>7.4.0-SNAPSHOT</version>
     <relativePath>../../../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
-  
+
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.basicfamily.edit</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>1.0.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily.editor/pom.xml
+++ b/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily.editor/pom.xml
@@ -22,7 +22,12 @@
     <version>7.4.0-SNAPSHOT</version>
     <relativePath>../../../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
-  
+
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.basicfamily.editor</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>1.0.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily/pom.xml
+++ b/plugins/org.eclipse.sirius.samples.family/samples/org.eclipse.sirius.sample.basicfamily/pom.xml
@@ -22,7 +22,12 @@
     <version>7.4.0-SNAPSHOT</version>
     <relativePath>../../../../packaging/org.eclipse.sirius.parent</relativePath>
   </parent>
-  
+
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
+  </properties>
+
   <artifactId>org.eclipse.sirius.sample.basicfamily</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>1.0.0-SNAPSHOT</version>

--- a/plugins/org.eclipse.sirius.tests.sample.benchmark/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.benchmark/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.benchmark</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.component.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.component.design/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*, src-gen/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src, src-gen</sonar.tests>
   </properties>
   
   <artifactId>org.eclipse.sirius.tests.sample.component.design</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.component/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.component/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.component</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.docbook.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.docbook.design/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.docbook.design</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.docbook.edit/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.docbook.edit/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src-gen</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.docbook.edit</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.docbook.editor/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.docbook.editor/pom.xml
@@ -24,7 +24,9 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+  <properties>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src-gen</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.docbook.editor</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.docbook/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.docbook/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.docbook</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.migration.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.migration.design/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.migration.design</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.migration/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.migration/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src-gen</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.migration</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.scxml.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.scxml.design/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.scxml.design</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.scxml/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.scxml/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.skip>true</sonar.skip>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src-gen</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.scxml</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.design/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.design/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine.design</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ide/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ide/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src-gen/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src-gen</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine.ide</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ui/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine.ui/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src-gen/**/*, xtend-gen/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src-gen,xtend-gen</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine.ui</artifactId>

--- a/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine/pom.xml
+++ b/plugins/org.eclipse.sirius.tests.sample.xtext.statemachine/pom.xml
@@ -24,7 +24,8 @@
   </parent>
 
   <properties>
-    <sonar.coverage.exclusions>src/**/*, src-gen/**/*, xtend-gen/**/*</sonar.coverage.exclusions>
+    <sonar.sources>pom.xml</sonar.sources>
+    <sonar.tests>src, src-gen, xtend-gen</sonar.tests>
   </properties>
 
   <artifactId>org.eclipse.sirius.tests.sample.xtext.statemachine</artifactId>


### PR DESCRIPTION
Before this commit, only a part of plug-ins "org.eclipse.sirius.sample*" is excluded of code coverage by Sonar.
The goal of this commit is to cosier all plug-ins
"org.eclipse.sirius.sample*" and "org.eclipse.sirius.tests.sample*" as tests code and by consequence excluded from Sonar code coverage analysis.