### PR TITLE
[18] Avoid to consider too much views as to be centered

### DIFF
--- a/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/dialect/DiagramDialectServices.java
+++ b/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/dialect/DiagramDialectServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -187,7 +187,10 @@ public class DiagramDialectServices extends AbstractRepresentationDialectService
                 // Synchronizes the GMF diagram model according to the viewpoint
                 // DSemanticDiagram model.
                 CanonicalSynchronizer canonicalSynchronizer = CanonicalSynchronizerFactory.INSTANCE.createCanonicalSynchronizer(gmfDiag);
-                canonicalSynchronizer.storeViewsToArrange(true);
+                // No reason to store views to arrange as the flag NotYetOpenedDiagramAdapter has just been added above
+                // and in this case the stored data is ignored in
+                // SiriusCanonicalLayoutHandler.launchArrangeCommand(DiagramEditPart).
+                canonicalSynchronizer.storeViewsToArrange(false);
                 canonicalSynchronizer.synchronize();
                 canonicalSynchronizer.postCreation();
                 monitor.worked(10);

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/outline/OutlineContextualMenuTest.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/outline/OutlineContextualMenuTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * Copyright (c) 2022, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.sirius.common.tools.api.util.ReflectionHelper;
 import org.eclipse.sirius.common.ui.tools.api.util.EclipseUIUtil;
 import org.eclipse.sirius.diagram.DNode;
 import org.eclipse.sirius.diagram.DSemanticDiagram;
+import org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager;
 import org.eclipse.sirius.diagram.ui.tools.internal.editor.DiagramOutlinePage;
 import org.eclipse.sirius.tests.SiriusTestsPlugin;
 import org.eclipse.sirius.tests.support.api.TestsUtil;
@@ -64,7 +65,9 @@ public class OutlineContextualMenuTest extends GenericTestCase {
         super.setUp();        
         genericSetUp(SEMANTIC_MODEL_PATH, MODELER_PATH);
         final Viewpoint vp = viewpoints.iterator().next();
+        assertTrue("The SiriusLayoutDataManager should not contain data before viewpoint selection.", SiriusLayoutDataManager.INSTANCE.getCreatedViewForInitPositionLayout().isEmpty());
         activateViewpoint(vp.getName());
+        assertTrue("The SiriusLayoutDataManager should not contain data after viewpoint selection.", SiriusLayoutDataManager.INSTANCE.getCreatedViewForInitPositionLayout().isEmpty());
     }
 
     /**


### PR DESCRIPTION
With the last commit [1] concerning this issue, too much views are considered as to be centered. This leads to a memory leak. Indeed, SiriusLayoutDataManagerImpl.addCreatedViewForInitPositionLayout(Diagram, LinkedHashSet<View>) was called, but
SiriusLayoutDataManagerImpl.removeLayoutViews(Diagram) was not call.

The condition `SiriusLayoutDataManager.INSTANCE.getData().some()` existing before the commit [1] is added again.

[1] https://github.com/eclipse-sirius/sirius-desktop/commit/b8a5c6a9d0888e4f26a99210f70bd247a9981c51

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/18