### PR TITLE
[205] Complete anti NPEs fix

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/actions/layout/PasteStylePureGraphicalAction.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/actions/layout/PasteStylePureGraphicalAction.java
@@ -41,7 +41,6 @@ import org.eclipse.sirius.ecore.extender.business.api.permission.ISimpleAuthorit
 import org.eclipse.sirius.ecore.extender.business.api.permission.PermissionAuthorityRegistry;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.PlatformUI;
 
 /**
  * Pastes the style of the copied element. Also works for semantically and graphically different element types.
@@ -88,7 +87,9 @@ public class PasteStylePureGraphicalAction extends Action implements IDisposable
     public void init() {
         if (isDisposed) {
             IWorkbenchPage page = EclipseUIUtil.getActivePage();
-            page.addSelectionListener(this.onChangeSelection);
+            if (page != null) {
+                page.addSelectionListener(this.onChangeSelection);
+            }
             updateActionState(getTargetEditParts());
             SiriusStyleClipboard.getInstance().addListener(onChangeClipboard);
             changeListenerOpt.ifPresent(changeListener -> {
@@ -193,8 +194,13 @@ public class PasteStylePureGraphicalAction extends Action implements IDisposable
     }
 
     private List<IGraphicalEditPart> getTargetEditParts() {
-        ISelection selection = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getSelection();
-        return getTargetEditParts(selection);
+        IWorkbenchPage page = EclipseUIUtil.getActivePage();
+        if (page != null) {
+            return getTargetEditParts(page.getSelection());
+        } else {
+            return List.of();
+        }
+
     }
 
     private List<IGraphicalEditPart> getTargetEditParts(ISelection selection) {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/actions/pinning/PinElementsAction.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/actions/pinning/PinElementsAction.java
@@ -82,11 +82,14 @@ public final class PinElementsAction extends Action implements Disposable {
         setId(ActionIds.PIN_ELEMENTS);
 
         IWorkbenchPage page = EclipseUIUtil.getActivePage();
-        page.addSelectionListener(this.onChangeSelection);
+        if (page != null) {
+            page.addSelectionListener(this.onChangeSelection);
+        }
         updateActionState(getCurrentSelection());
 
         isDisposed = false;
     }
+
     // factories
     /**
      * Create the pin elements action for toolbar (with image and tooltip).
@@ -99,6 +102,7 @@ public final class PinElementsAction extends Action implements Disposable {
         action.setImageDescriptor(DiagramUIPlugin.Implementation.getBundledImageDescriptor(DiagramImagesPath.PIN_ELEMENTS_ICON));
         return action;
     }
+
     /**
      * Create the pin elements action for menu (without image and tooltip).
      * 
@@ -197,6 +201,7 @@ public final class PinElementsAction extends Action implements Disposable {
             }
         }
     }
+
     /**
      * Remove the listener of the pin/unpin feature of the last selected element selection (selectionLastElement) if
      * present.
@@ -306,7 +311,6 @@ public final class PinElementsAction extends Action implements Disposable {
         }
         return result;
     }
-
 
     // utility
     private Optional<DDiagramElement> getAny(final Collection<DDiagramElement> elements) {


### PR DESCRIPTION
A first preventive fix was made in commit
2ccb31c44715da9c89af6ed080b1e671d845f260 by changing listeners of PinElementsAction and PasteStylePureGraphicalAction to update their action state with a displaySyncExec call instead of a displayAsyncExec in order to prevent the action from being disposed of due to an asynchronous call.

In the commit complete the preventive with a better handling of potentially null active page.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/205
Change-Id: I04232b9626c7fb2a0cbf992fad8339bd2fdd5da0