### PR TITLE
[cleanup] Fix the 9 Sonar Critical bugs

### DIFF
--- a/plugins/org.eclipse.sirius.common/src/org/eclipse/sirius/common/tools/api/util/StringMatcher.java
+++ b/plugins/org.eclipse.sirius.common/src/org/eclipse/sirius/common/tools/api/util/StringMatcher.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2005 IBM Corporation and others.
+ * Copyright (c) 2002, 2024 IBM Corporation and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -251,45 +251,46 @@ public class StringMatcher {
 		if (bound < 0)
 			return false;
 		int i = 0;
-		String current = fSegments[i];
-		int segLength = current.length();
+        if (segCount > 0) {
+            String current = fSegments[i];
+            int segLength = current.length();
 
-		/* process first segment */
-		if (!fHasLeadingStar) {
-			if (!regExpRegionMatches(text, start, current, 0, segLength)) {
-				return false;
-			} else {
-				++i;
-				tCurPos = tCurPos + segLength;
-			}
-		}
-		if ((fSegments.length == 1) && (!fHasLeadingStar)
-			&& (!fHasTrailingStar)) {
-			// only one segment to match, no wildcards specified
-			return tCurPos == end;
-		}
-		/* process middle segments */
-		while (i < segCount) {
-			current = fSegments[i];
-			int currentMatch;
-			int k = current.indexOf(fSingleWildCard);
-			if (k < 0) {
-				currentMatch = textPosIn(text, tCurPos, end, current);
-				if (currentMatch < 0)
-					return false;
-			} else {
-				currentMatch = regExpPosIn(text, tCurPos, end, current);
-				if (currentMatch < 0)
-					return false;
-			}
-			tCurPos = currentMatch + current.length();
-			i++;
-		}
+            /* process first segment */
+            if (!fHasLeadingStar) {
+                if (!regExpRegionMatches(text, start, current, 0, segLength)) {
+                    return false;
+                } else {
+                    ++i;
+                    tCurPos = tCurPos + segLength;
+                }
+            }
+            if ((fSegments.length == 1) && (!fHasLeadingStar) && (!fHasTrailingStar)) {
+                // only one segment to match, no wildcards specified
+                return tCurPos == end;
+            }
+            /* process middle segments */
+            while (i < segCount) {
+                current = fSegments[i];
+                int currentMatch;
+                int k = current.indexOf(fSingleWildCard);
+                if (k < 0) {
+                    currentMatch = textPosIn(text, tCurPos, end, current);
+                    if (currentMatch < 0)
+                        return false;
+                } else {
+                    currentMatch = regExpPosIn(text, tCurPos, end, current);
+                    if (currentMatch < 0)
+                        return false;
+                }
+                tCurPos = currentMatch + current.length();
+                i++;
+            }
 
-		/* process final segment */
-		if (!fHasTrailingStar && tCurPos != end) {
-			int clen = current.length();
-			return regExpRegionMatches(text, end - clen, current, 0, clen);
+            /* process final segment */
+            if (!fHasTrailingStar && tCurPos != end) {
+                int clen = current.length();
+                return regExpRegionMatches(text, end - clen, current, 0, clen);
+            }
 		}
 		return i == segCount;
 	}

--- a/plugins/org.eclipse.sirius.model/src/org/eclipse/sirius/model/business/internal/query/EObjectQuery.java
+++ b/plugins/org.eclipse.sirius.model/src/org/eclipse/sirius/model/business/internal/query/EObjectQuery.java
@@ -218,7 +218,7 @@ public class EObjectQuery {
                 // throw new RuntimeException(MessageFormat.format(Messages.EObjectQuery_valuesErrorMsg, ref.getName(),
                 // rawValue.getClass()));
             }
-            if (rawValue != null) {
+            if (rawValue != null && (!((EList<?>) rawValue).isEmpty() && ((EList<?>) rawValue).get(0) instanceof EObject)) {
                 result = new ArrayList<EObject>((EList<EObject>) rawValue);
             }
         } else {

--- a/plugins/org.eclipse.sirius.table.ui/src-paperclips/org/eclipse/sirius/table/ui/tools/internal/paperclips/grid/internal/GridIterator.java
+++ b/plugins/org.eclipse.sirius.table.ui/src-paperclips/org/eclipse/sirius/table/ui/tools/internal/paperclips/grid/internal/GridIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007 Matthew Hall and others.
+ * Copyright (c) 2007, 2024 Matthew Hall and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -589,7 +589,10 @@ public class GridIterator implements PrintIterator {
 			int columnIndex = weightedCols[weightedColIndex];
 
 			int columnWeight = columns[columnIndex].weight;
-			int addWidth = (int) ((long) extraWidth * columnWeight / totalWeight);
+			int addWidth = 0;
+			if (totalWeight != 0) {
+			    addWidth = (int) ((long) extraWidth * columnWeight / totalWeight);
+			}
 
 			colSizes[columnIndex] += addWidth;
 

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/api/session/DAnalysisSessionTests.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/api/session/DAnalysisSessionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -395,20 +395,23 @@ public class DAnalysisSessionTests extends SiriusDiagramTestCase {
     }
 
     public void testCreateWrongSession() throws Exception {
+        int beforeSize = 0;
+        int afterSize = 0;
         try {
-            final int beforeSize = SessionManager.INSTANCE.getSessions().size();
+            beforeSize = SessionManager.INSTANCE.getSessions().size();
             URI sessionResourceURI = session.getSessionResource().getURI();
             URI semanticResourceURI = session.getSemanticResources().iterator().next().getURI();
             session = SessionFactory.INSTANCE.createSession(sessionResourceURI, new NullProgressMonitor());
             session.addSemanticResource(semanticResourceURI, new NullProgressMonitor());
-            final int afterSize = SessionManager.INSTANCE.getSessions().size();
-            Assert.assertEquals(beforeSize, afterSize);
+            afterSize = SessionManager.INSTANCE.getSessions().size();
         } catch (final Exception e) {
             // Wanted behavior : Session initialization is not possible with
             // null analysis.
         } catch (AssertionError ae) {
             // We may also fail with an assertion error if they are enabled.
         }
+        Assert.assertEquals(beforeSize, afterSize);
+
     }
 
     public void testCreateSessionFromEcoreResource() throws Exception {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramMouseZoomTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/DiagramMouseZoomTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 THALES GLOBAL SERVICES.
+ * Copyright (c) 2016, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -192,7 +192,7 @@ public class DiagramMouseZoomTest extends AbstractSiriusSwtBotGefTestCase {
         Point mouseZoomAbsoluteLocationBeforeZoom = zoomTargetPart.getFigure().getBounds().getCopy().getLocation();
         zoomTargetPart.getFigure().translateToAbsolute(mouseZoomAbsoluteLocationBeforeZoom);
 
-        assertNotEquals(new Rectangle(0, 0, 0, 0), zoomTargetPart);
+        assertNotEquals(new Rectangle(0, 0, 0, 0), zoomTargetPart.getFigure().getBounds());
 
         // We do the zoom algorithm part that computes the expected viewport
         // location after zoom to have the expected viewport location that we

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/CombinedFragmentsDisabledTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/CombinedFragmentsDisabledTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -275,7 +275,7 @@ public class CombinedFragmentsDisabledTests extends AbstractCombinedFragmentSequ
 
         // Undo
         undo();
-        Assert.assertEquals(2, firstCombinedFragment.getOwnedOperands());
+        Assert.assertEquals(2, firstCombinedFragment.getOwnedOperands().size());
 
         Assert.assertEquals(e1Bounds, editor.getBounds(e1Bot));
         Assert.assertEquals(e2Bounds, editor.getBounds(e2Bot));
@@ -290,7 +290,7 @@ public class CombinedFragmentsDisabledTests extends AbstractCombinedFragmentSequ
 
         // Redo
         redo();
-        Assert.assertEquals(3, firstCombinedFragment.getOwnedOperands());
+        Assert.assertEquals(3, firstCombinedFragment.getOwnedOperands().size());
 
         Assert.assertEquals(e1Bounds, editor.getBounds(e1Bot));
         Assert.assertEquals(e2Bounds, editor.getBounds(e2Bot));

--- a/plugins/org.eclipse.sirius.ui/src/org/eclipse/sirius/ui/tools/api/actions/export/ExportAction.java
+++ b/plugins/org.eclipse.sirius.ui/src/org/eclipse/sirius/ui/tools/api/actions/export/ExportAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -154,9 +154,9 @@ public class ExportAction extends WorkspaceModifyOperation {
             }
         } finally {
             monitor.done();
-            if (monitor.isCanceled()) {
-                throw new InterruptedException(Messages.ExportAction_exportDiagramsAsImagesCancelled);
-            }
+        }
+        if (monitor.isCanceled()) {
+            throw new InterruptedException(Messages.ExportAction_exportDiagramsAsImagesCancelled);
         }
     }
 


### PR DESCRIPTION
* AirXYLayoutEditPolicy: Fix this call that leads to an illegal type cast.
* CombinedFragmentsDisabledTests and DiagramMouseZoomTest: Change the assertion arguments to not compare dissimilar types.
* DAnalysisSessionTests: Don't use assertEquals() inside a try-catch catching an AssertionError.
* EObjectQuery: Fix this illegal type cast.
* ExportAction: Remove this throw statement from this finally block.
* GridIterator: Make sure "totalWeight" can't be zero before doing this division.
* StringMatcher: Fix this access on a collection that may trigger an 'ArrayIndexOutOfBoundsException'.