### PR TITLE
[152] Open the color popup if no previous color is set

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/ColorPropertyContributionItem.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/ColorPropertyContributionItem.java
@@ -233,6 +233,9 @@ public class ColorPropertyContributionItem extends PropertyChangeContributionIte
             } else { // on icon button
                 if (lastColor != null) {
                     runWithEvent(e);
+                } else {
+                    // No previous color? Open the popup.
+                    invokeColorPalettePopup(toolItem);
                 }
             }
         }


### PR DESCRIPTION
Otherwise the first time the user clicks on the button (which seems
like the most obvious thing to do to change a color) does nothing at
all.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/152
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>