### PR TITLE
#313 Fix focus highlight of table in Linux.

### DIFF
--- a/plugins/org.eclipse.sirius.table.ui/src/org/eclipse/sirius/table/ui/tools/internal/editor/DTableViewerManager.java
+++ b/plugins/org.eclipse.sirius.table.ui/src/org/eclipse/sirius/table/ui/tools/internal/editor/DTableViewerManager.java
@@ -249,7 +249,10 @@ public class DTableViewerManager extends AbstractDTableViewerManager {
         treeViewer.getTree().setHeaderVisible(true);
 
         // Create a new CellFocusManager
-        final TreeViewerFocusCellManager focusCellManager = new TreeViewerFocusCellManager(treeViewer, new FocusCellOwnerDrawHighlighter(treeViewer));
+        final TreeViewerFocusCellManager focusCellManager = new TreeViewerFocusCellManager(treeViewer, 
+                // The behavior of focus highlight is really different between Windows and Linux/GTK.
+                // Windows has several focus colors for Foreground and background, GTK doesn't.
+                new FocusCellOwnerDrawHighlighter(treeViewer, !IS_GTK_OS));
         // Create a TreeViewerEditor with focusable cell
         TreeViewerEditor.create(treeViewer, focusCellManager, new DTableColumnViewerEditorActivationStrategy(treeViewer),
                 ColumnViewerEditor.TABBING_HORIZONTAL | ColumnViewerEditor.TABBING_MOVE_TO_ROW_NEIGHBOR | ColumnViewerEditor.TABBING_VERTICAL | ColumnViewerEditor.KEYBOARD_ACTIVATION);


### PR DESCRIPTION
Windows and Linux/GTK has different focus strategies. Cell highlight needs different configuration.

Linux/GTK doesn't have several colors for focus unlike Windows.
When only-cell highlight is applied, foreground of cell of same are still force to white.
For Linux, it is more readable to highlight the whole line.
<img width="512" alt="SiriusTable_linux" src="https://github.com/eclipse-sirius/sirius-desktop/assets/823389/2b98fb45-c006-4947-8fa5-9ef0dff696ad">
