### PR TITLE
[321] Add custom feature on the paste style to avoid undo on refresh

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/BasicSiriusStyleApplicator.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/BasicSiriusStyleApplicator.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2024 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.sirius.diagram.ui.tools.api.format;
+
+/**
+ * This class use the default implementation of the interface and no more, so there is no code in this class.
+ * 
+ * See {@link SiriusStyleApplicator} for more information about the default implementation.
+ * 
+ * @see SiriusStyleApplicator
+ * 
+ * @author Séraphin Costa
+ *
+ */
+public final class BasicSiriusStyleApplicator implements SiriusStyleApplicator {
+    /** The singleton instance. */
+    public static final BasicSiriusStyleApplicator INSTANCE = new BasicSiriusStyleApplicator();
+
+    private BasicSiriusStyleApplicator() {
+    }
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/SiriusStyleApplicator.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/SiriusStyleApplicator.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2024 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.tools.api.format;
+
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.sirius.diagram.ContainerStyle;
+import org.eclipse.sirius.diagram.DDiagramElementContainer;
+import org.eclipse.sirius.diagram.DEdge;
+import org.eclipse.sirius.diagram.DNode;
+import org.eclipse.sirius.diagram.DNodeListElement;
+import org.eclipse.sirius.diagram.EdgeStyle;
+import org.eclipse.sirius.diagram.NodeStyle;
+import org.eclipse.sirius.tools.internal.SiriusCopierHelper;
+import org.eclipse.sirius.viewpoint.DSemanticDecorator;
+import org.eclipse.sirius.viewpoint.Style;
+import org.eclipse.sirius.viewpoint.ViewpointPackage;
+
+/**
+ * 
+ * This class contains methods for applying any style to any Sirius element. However, implementations may decide to
+ * apply certain styles only to certain nodes. The default implementation applies styles only if the style type matches
+ * the node type:
+ * <ul>
+ * <li><code>NodeStyle</code> on <code>DNode</code> or <code>DNodeList</code>,</li>
+ * <li><code>ContainerStyle</code> on <code>DDiagramElementContainer</code>,</li>
+ * <li>and <code>EdgeStyle</code> on <code>DEdge</code>.</li>
+ * </ul>
+ * 
+ * @author Séraphin Costa
+ * 
+ */
+public interface SiriusStyleApplicator {
+
+    /**
+     * Apply the Sirius style contained in <code>formatData</code> on the <code>semanticDecorator</code>.
+     * 
+     * @param semanticDecorator
+     *            The Sirius element ({@link DSemanticDecorator}) on which to apply the style.
+     * @param siriusStyle
+     *            The sirius style to apply
+     */
+    default void applySiriusStyle(DSemanticDecorator semanticDecorator, Style siriusStyle) {
+        // Make a copy of the style to allow several Paste with the same FormatData.
+        Style copyOfSiriusStyle = SiriusCopierHelper.copyWithNoUidDuplication(siriusStyle);
+        if ((semanticDecorator instanceof DNode || semanticDecorator instanceof DNodeListElement) && copyOfSiriusStyle instanceof NodeStyle) {
+            if (semanticDecorator instanceof DNode) {
+                computeCustomFeatures(((DNode) semanticDecorator).getOwnedStyle(), copyOfSiriusStyle);
+                ((DNode) semanticDecorator).setOwnedStyle((NodeStyle) copyOfSiriusStyle);
+            } else {
+                computeCustomFeatures(((DNodeListElement) semanticDecorator).getOwnedStyle(), copyOfSiriusStyle);
+                ((DNodeListElement) semanticDecorator).setOwnedStyle((NodeStyle) copyOfSiriusStyle);
+            }
+        } else if (semanticDecorator instanceof DDiagramElementContainer && copyOfSiriusStyle instanceof ContainerStyle) {
+            if (((DDiagramElementContainer) semanticDecorator).getOwnedStyle() != null) {
+                computeCustomFeatures(((DDiagramElementContainer) semanticDecorator).getOwnedStyle(), copyOfSiriusStyle);
+            }
+            ((DDiagramElementContainer) semanticDecorator).setOwnedStyle((ContainerStyle) copyOfSiriusStyle);
+        } else if (semanticDecorator instanceof DEdge && copyOfSiriusStyle instanceof EdgeStyle) {
+            computeCustomFeatures(((DEdge) semanticDecorator).getOwnedStyle(), copyOfSiriusStyle);
+            ((DEdge) semanticDecorator).setOwnedStyle((EdgeStyle) copyOfSiriusStyle);
+        }
+    }
+
+    /**
+     * Check for each attribute of newStyle if it is the same in oldStyle. On the other hand, this attribute is added to
+     * the custom features of the newStyle.
+     * 
+     * @param oldStyle
+     *            The old style to compare with
+     * @param newStyle
+     *            The new style in which to add custom features.
+     */
+    default void computeCustomFeatures(Style oldStyle, Style newStyle) {
+        for (EAttribute attribute : newStyle.eClass().getEAllAttributes()) {
+            if (!ViewpointPackage.Literals.CUSTOMIZABLE__CUSTOM_FEATURES.equals(attribute)) {
+                EAttribute attributeOfOldStyle = getCorrespondingEAttribute(attribute, oldStyle);
+                if (attributeOfOldStyle != null) {
+                    if (newStyle.eIsSet(attribute)) {
+                        if (!newStyle.eGet(attribute).equals(oldStyle.eGet(attributeOfOldStyle))) {
+                            newStyle.getCustomFeatures().add(attributeOfOldStyle.getName());
+                        }
+                    } else if (oldStyle.eIsSet(attributeOfOldStyle)) {
+                        newStyle.getCustomFeatures().add(attributeOfOldStyle.getName());
+                    }
+                }
+            }
+        }
+    }
+
+    private EAttribute getCorrespondingEAttribute(EAttribute attribute, Style style) {
+        EAttribute result = null;
+        if (style.eClass().getFeatureID(attribute) != -1) {
+            result = attribute;
+        } else {
+            // This attribute does not exist in the style. Check specific
+            // mapping cases.
+            EStructuralFeature structuralFeature = style.eClass().getEStructuralFeature(attribute.getName());
+            if (structuralFeature instanceof EAttribute) {
+                result = (EAttribute) structuralFeature;
+            } else if ("color".equals(attribute.getName())) { //$NON-NLS-1$
+                structuralFeature = style.eClass().getEStructuralFeature("backgroundColor"); //$NON-NLS-1$
+                if (structuralFeature instanceof EAttribute) {
+                    result = (EAttribute) structuralFeature;
+                }
+            } else if ("backgroundColor".equals(attribute.getName())) { //$NON-NLS-1$
+                structuralFeature = style.eClass().getEStructuralFeature("color"); //$NON-NLS-1$
+                if (structuralFeature instanceof EAttribute) {
+                    result = (EAttribute) structuralFeature;
+                }
+            } else if ("width".equals(attribute.getName())) { //$NON-NLS-1$
+                structuralFeature = style.eClass().getEStructuralFeature("horizontalDiameter"); //$NON-NLS-1$
+                if (structuralFeature instanceof EAttribute) {
+                    result = (EAttribute) structuralFeature;
+                }
+            } else if ("horizontalDiameter".equals(attribute.getName())) { //$NON-NLS-1$
+                structuralFeature = style.eClass().getEStructuralFeature("width"); //$NON-NLS-1$
+                if (structuralFeature instanceof EAttribute) {
+                    result = (EAttribute) structuralFeature;
+                }
+            } else if ("height".equals(attribute.getName())) { //$NON-NLS-1$
+                structuralFeature = style.eClass().getEStructuralFeature("verticalDiameter"); //$NON-NLS-1$
+                if (structuralFeature instanceof EAttribute) {
+                    result = (EAttribute) structuralFeature;
+                }
+            } else if ("verticalDiameter".equals(attribute.getName())) { //$NON-NLS-1$
+                structuralFeature = style.eClass().getEStructuralFeature("height"); //$NON-NLS-1$
+                if (structuralFeature instanceof EAttribute) {
+                    result = (EAttribute) structuralFeature;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/copyAppearance/490444.aird
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/copyAppearance/490444.aird
@@ -4,7 +4,7 @@
     <semanticResources>490444.ecore</semanticResources>
     <ownedViews xmi:type="viewpoint:DView" uid="_4t7qoPWKEeW_qZJJi9_oUw">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_BIyRMa4oEe6M8uo1HSBx4A" name=" package entities" repPath="#_43sDkPWKEeW_qZJJi9_oUw" changeId="1704719934892">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_BIyRMa4oEe6M8uo1HSBx4A" name=" package entities" repPath="#_43sDkPWKEeW_qZJJi9_oUw" changeId="1710242495113">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']"/>
         <target xmi:type="ecore:EPackage" href="490444.ecore#/"/>
       </ownedRepresentationDescriptors>
@@ -76,6 +76,42 @@
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_8w6-8fWKEeW_qZJJi9_oUw" fontName="Cantarell" fontHeight="8"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8w6-8vWKEeW_qZJJi9_oUw" x="744" y="228"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Z-v9gOBiEe6QMJUUKI55wA" type="2003" element="_Z-KusOBiEe6QMJUUKI55wA">
+          <children xmi:type="notation:Node" xmi:id="_Z-wkkOBiEe6QMJUUKI55wA" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_Z-xLoOBiEe6QMJUUKI55wA" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Z-xLoeBiEe6QMJUUKI55wA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Z-xLouBiEe6QMJUUKI55wA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Z-v9geBiEe6QMJUUKI55wA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Z-v9guBiEe6QMJUUKI55wA" x="34" y="34"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ah7jEOBiEe6QMJUUKI55wA" type="2003" element="_ahZXkOBiEe6QMJUUKI55wA">
+          <children xmi:type="notation:Node" xmi:id="_ah7jE-BiEe6QMJUUKI55wA" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_ah7jFOBiEe6QMJUUKI55wA" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_ah7jFeBiEe6QMJUUKI55wA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_ah7jFuBiEe6QMJUUKI55wA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ah7jEeBiEe6QMJUUKI55wA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ah7jEuBiEe6QMJUUKI55wA" x="25" y="96"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_gPuMUOBiEe6QMJUUKI55wA" type="2003" element="_gPoswOBiEe6QMJUUKI55wA">
+          <children xmi:type="notation:Node" xmi:id="_gPuMU-BiEe6QMJUUKI55wA" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_gPuMVOBiEe6QMJUUKI55wA" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_gPuMVeBiEe6QMJUUKI55wA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_gPuMVuBiEe6QMJUUKI55wA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_gPuMUeBiEe6QMJUUKI55wA" fontName="Segoe UI" fontHeight="8" fillColor="13750737"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gPuMUuBiEe6QMJUUKI55wA" x="25" y="228"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_lJNq0OBiEe6QMJUUKI55wA" type="2003" element="_lJIyUOBiEe6QMJUUKI55wA">
+          <children xmi:type="notation:Node" xmi:id="_lJNq0-BiEe6QMJUUKI55wA" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_lJNq1OBiEe6QMJUUKI55wA" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_lJNq1eBiEe6QMJUUKI55wA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_lJNq1uBiEe6QMJUUKI55wA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_lJNq0eBiEe6QMJUUKI55wA" fontName="Segoe UI" fontHeight="8" bold="true" italic="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lJNq0uBiEe6QMJUUKI55wA" x="34" y="165"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_4310kvWKEeW_qZJJi9_oUw"/>
         <edges xmi:type="notation:Edge" xmi:id="_eQ5P0K4oEe6M8uo1HSBx4A" type="4001" element="_eQWdQK4oEe6M8uo1HSBx4A" source="_8MqbUPWKEeW_qZJJi9_oUw" target="_8YdboPWKEeW_qZJJi9_oUw">
@@ -184,6 +220,43 @@
         <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_eQtCka4oEe6M8uo1HSBx4A" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_Z-KusOBiEe6QMJUUKI55wA" name="NewEnum1">
+      <target xmi:type="ecore:EEnum" href="490444.ecore#//NewEnum1"/>
+      <semanticElements xmi:type="ecore:EEnum" href="490444.ecore#//NewEnum1"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Z-KuseBiEe6QMJUUKI55wA" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom" backgroundColor="255,245,181" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EEnum']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EEnum']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ahZXkOBiEe6QMJUUKI55wA" name="NewDataType2">
+      <target xmi:type="ecore:EDataType" href="490444.ecore#//NewDataType2"/>
+      <semanticElements xmi:type="ecore:EDataType" href="490444.ecore#//NewDataType2"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ahZXkeBiEe6QMJUUKI55wA" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom" backgroundColor="194,239,255" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EDataType']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EDataType']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_gPoswOBiEe6QMJUUKI55wA" name="NewDataType3">
+      <target xmi:type="ecore:EDataType" href="490444.ecore#//NewDataType3"/>
+      <semanticElements xmi:type="ecore:EDataType" href="490444.ecore#//NewDataType3"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_gPosweBiEe6QMJUUKI55wA" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom" backgroundColor="209,209,209">
+        <customFeatures>backgroundColor</customFeatures>
+        <customFeatures>foregroundColor</customFeatures>
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EDataType']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EDataType']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_lJIyUOBiEe6QMJUUKI55wA" name="NewEnum2">
+      <target xmi:type="ecore:EEnum" href="490444.ecore#//NewEnum2"/>
+      <semanticElements xmi:type="ecore:EEnum" href="490444.ecore#//NewEnum2"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lJIyUeBiEe6QMJUUKI55wA" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom" backgroundColor="255,245,181" foregroundColor="255,255,255">
+        <customFeatures>labelFormat</customFeatures>
+        <labelFormat>italic</labelFormat>
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EEnum']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EEnum']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.ecore.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']"/>
     <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_43sDk_WKEeW_qZJJi9_oUw"/>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/copyAppearance/490444.ecore
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/copyAppearance/490444.ecore
@@ -11,4 +11,8 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass5"/>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass6"/>
+  <eClassifiers xsi:type="ecore:EEnum" name="NewEnum1"/>
+  <eClassifiers xsi:type="ecore:EDataType" name="NewDataType2" instanceTypeName="newDataType2"/>
+  <eClassifiers xsi:type="ecore:EDataType" name="NewDataType3" instanceTypeName="newDataType3"/>
+  <eClassifiers xsi:type="ecore:EEnum" name="NewEnum2"/>
 </ecore:EPackage>


### PR DESCRIPTION
The commit also create SiriusStyleApplicator to share the style application with the semantic paste style while keeping the API for the semantic paste style and allowing code extensibility for paste style.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/321