### PR TITLE
[346] Make "Paste Style" colorize fully the gradient style

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/SiriusStyleApplicator.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/SiriusStyleApplicator.java
@@ -182,7 +182,7 @@ public interface SiriusStyleApplicator {
                 if (structuralFeature instanceof EAttribute) {
                     result = (EAttribute) structuralFeature;
                 }
-            } else if ("backgroundColor".equals(attribute.getName())) { //$NON-NLS-1$
+            } else if ("backgroundColor".equals(attribute.getName()) || "foregroundColor".equals(attribute.getName())) { //$NON-NLS-1$ //$NON-NLS-2$
                 structuralFeature = style.eClass().getEStructuralFeature("color"); //$NON-NLS-1$
                 if (structuralFeature instanceof EAttribute) {
                     result = (EAttribute) structuralFeature;

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/PasteStylePureGraphicalTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/PasteStylePureGraphicalTest.java
@@ -789,7 +789,7 @@ public class PasteStylePureGraphicalTest extends AbstractSiriusSwtBotGefTestCase
         SWTBotUtils.waitAllUiEvents();
 
         assertNodeStyle("NewEClass6", DNodeEditPart.class, new ExpectedNodeStyle(new ExpectedFontStyle(false, true, false, false, BLACK), GREY));
-        assertContainerStyle("newPackage2", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(false, true, false, false, BLACK), GREY, LIGHT_GREY));
+        assertContainerStyle("newPackage2", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(false, true, false, false, BLACK), GREY, GREY));
     }
 
     public void testCopyStylishNodeToDefaultContainer() {
@@ -804,7 +804,7 @@ public class PasteStylePureGraphicalTest extends AbstractSiriusSwtBotGefTestCase
         SWTBotUtils.waitAllUiEvents();
 
         assertNodeStyle("NewEClass3", DNodeEditPart.class, new ExpectedNodeStyle(new ExpectedFontStyle(true, true, false, false, BLACK), GREY));
-        assertContainerStyle("newPackage2", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(true, true, false, false, BLACK), GREY, LIGHT_GREY));
+        assertContainerStyle("newPackage2", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(true, true, false, false, BLACK), GREY, GREY));
     }
 
     public void testCopyStylishNodeToStylishContainer() {
@@ -819,7 +819,7 @@ public class PasteStylePureGraphicalTest extends AbstractSiriusSwtBotGefTestCase
         SWTBotUtils.waitAllUiEvents();
 
         assertNodeStyle("NewEClass3", DNodeEditPart.class, new ExpectedNodeStyle(new ExpectedFontStyle(true, true, false, false, BLACK), GREY));
-        assertContainerStyle("newPackage1", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(true, true, false, false, BLACK), GREY, LIGHT_GREY));
+        assertContainerStyle("newPackage1", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(true, true, false, false, BLACK), GREY, GREY));
     }
 
     public void testCopyDefaultNodeToStylishContainer() {
@@ -834,7 +834,7 @@ public class PasteStylePureGraphicalTest extends AbstractSiriusSwtBotGefTestCase
         SWTBotUtils.waitAllUiEvents();
 
         assertNodeStyle("NewEClass6", DNodeEditPart.class, new ExpectedNodeStyle(new ExpectedFontStyle(false, true, false, false, BLACK), GREY));
-        assertContainerStyle("newPackage1", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(false, true, false, false, BLACK), GREY, LIGHT_GREY));
+        assertContainerStyle("newPackage1", DNodeContainerEditPart.class, new ExpectedContainerStyle(new ExpectedFontStyle(false, true, false, false, BLACK), GREY, GREY));
     }
 
     // Container -> Node


### PR DESCRIPTION
When copying the style from a node to a container with gradient style, now, the foreground and the background colors are changed.

https://github.com/eclipse-sirius/sirius-desktop/issues/346