### PR TITLE
[368] Fix model explorer labels for JDT elements

### DIFF
--- a/plugins/org.eclipse.sirius.ui/plugin.xml
+++ b/plugins/org.eclipse.sirius.ui/plugin.xml
@@ -298,7 +298,6 @@
         point="org.eclipse.ui.navigator.navigatorContent">
      <navigatorContent
            activeByDefault="true"
-           appearsBefore="org.eclipse.jdt.java.ui.javaContent"
            contentProvider="org.eclipse.sirius.ui.tools.internal.views.common.navigator.SiriusCommonContentProvider"
            icon="icons/obj16/SessionResourceFile.gif"
            id="org.eclipse.sirius.ui.resource.content.session"


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/368
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
