### PR TITLE
#372 Avoid NPEs while closing projects from repair / migration with "other" projects opened and modified diagram editor

### DIFF
--- a/plugins/org.eclipse.sirius.ui/src/org/eclipse/sirius/ui/business/internal/session/EditingSession.java
+++ b/plugins/org.eclipse.sirius.ui/src/org/eclipse/sirius/ui/business/internal/session/EditingSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES.
+ * Copyright (c) 2007, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -271,7 +271,8 @@ public class EditingSession implements IEditingSession, ISaveablesSource, Refres
     @Override
     public int promptToSaveOnClose() {
         int choice = ISaveablePart2.DEFAULT;
-        if (saveable != null) {
+        // Do not prompt if restoreToSavePointListener is null (close with save in progress)
+        if (saveable != null && restoreToSavePointListener != null) {
             boolean stillOpenElsewhere = getSiriusEditors().size() > 1 && !closeAllDetected();
             boolean promptStandardDialog = !restoreToSavePointListener.isAllowedToReturnToSyncState();
 

--- a/plugins/org.eclipse.sirius.ui/src/org/eclipse/sirius/ui/business/internal/session/EditingSession.java
+++ b/plugins/org.eclipse.sirius.ui/src/org/eclipse/sirius/ui/business/internal/session/EditingSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2024 THALES GLOBAL SERVICES.
+ * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -533,7 +533,7 @@ public class EditingSession implements IEditingSession, ISaveablesSource, Refres
         }
 
         public boolean closeAllDetected() {
-            return closingEditors.size() == editors.size();
+            return !closingEditors.isEmpty() && closingEditors.size() == editors.size();
         }
 
         /**


### PR DESCRIPTION
Created from [Capella issue 2860](https://github.com/eclipse-capella/capella/issues/2860).

Not reproduced with Sirius alone for now.

Current steps to reproduce are listed in comment https://github.com/eclipse-capella/capella/issues/2860#issuecomment-2074824537