### PR TITLE
[362] Fix the bug in the refresh of the layer tooltip

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/AbstractMenuContributionItem.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/AbstractMenuContributionItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -168,6 +168,7 @@ public abstract class AbstractMenuContributionItem extends AbstractTabbarContrib
 
             @Override
             public void menuAboutToShow(IMenuManager manager) {
+                tooltips.clear();
                 menuShow(manager);
             }
         });


### PR DESCRIPTION
When the VSM is changed, the tooltip of all layers is updated. But the tooltip list was never cleared between two menuShow. So the first N tooltip text (with N, the number of layers) were always the same and the updated tooltip were in an unreachable position (at the end) in the list.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/362