### PR TITLE
[test] Clear FormatDataManager after using Copy/Paste actions

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
@@ -70,6 +70,7 @@ import org.eclipse.sirius.diagram.tools.internal.preferences.SiriusDiagramIntern
 import org.eclipse.sirius.diagram.ui.business.internal.dialect.DiagramDialectUIServices;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
+import org.eclipse.sirius.diagram.ui.tools.api.format.SiriusFormatDataManagerForSemanticElementsFactory;
 import org.eclipse.sirius.diagram.ui.tools.api.preferences.SiriusDiagramUiPreferencesKeys;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.ResetStylePropertiesToDefaultValuesAction;
 import org.eclipse.sirius.diagram.ui.tools.internal.preferences.SiriusDiagramUiInternalPreferencesKeys;
@@ -2086,5 +2087,12 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
                 }
             }
         });
+    }
+
+    /**
+     * Clear the FormatDataManager cache, to avoid side effects on following tests.
+     */
+    protected void clearFormatDataManager() {
+        SiriusFormatDataManagerForSemanticElementsFactory.getInstance().getSiriusFormatDataManager().clearFormatData();
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeLabelStabilityTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeLabelStabilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -178,6 +178,7 @@ public class EdgeLabelStabilityTest extends AbstractSiriusSwtBotGefTestCase {
         localSession = null;
         editor = null;
         diagram = null;
+        clearFormatDataManager();
         super.tearDown();
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/BorderedNodeCopyPasteFormatTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/BorderedNodeCopyPasteFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -190,6 +190,7 @@ public class BorderedNodeCopyPasteFormatTest extends AbstractSiriusSwtBotGefTest
         expectedAList = null;
         expectedNonCollapsedNodeList = null;
         expectedCollapsedNodeList = null;
+        clearFormatDataManager();
         super.tearDown();
     }
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/ContainerAndNodeCopyPasteFormatTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/ContainerAndNodeCopyPasteFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 THALES GLOBAL SERVICES.
+ * Copyright (c) 2016, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -214,6 +214,7 @@ public class ContainerAndNodeCopyPasteFormatTest extends AbstractSiriusSwtBotGef
     protected void tearDown() throws Exception {
         diagramEditorSrc = null;
         diagramEditorTgt = null;
+        clearFormatDataManager();
         super.tearDown();
     }
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/EdgeCopyPasteFormatTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/EdgeCopyPasteFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -153,6 +153,7 @@ public class EdgeCopyPasteFormatTest extends AbstractSiriusSwtBotGefTestCase {
         diagram2 = null;
         diagram3 = null;
         diagram4 = null;
+        clearFormatDataManager();
         super.tearDown();
     }
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/EdgeStabilityOnCopyPasteLayoutTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/EdgeStabilityOnCopyPasteLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 THALES GLOBAL SERVICES.
+ * Copyright (c) 2014, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -75,6 +75,12 @@ public class EdgeStabilityOnCopyPasteLayoutTest extends AbstractSiriusSwtBotGefT
     protected void onSetUpAfterOpeningDesignerPerspective() throws Exception {
         sessionAirdResource = new UIResource(designerProject, SESSION_FILE);
         localSession = designerPerspective.openSessionFromFile(sessionAirdResource, true);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        clearFormatDataManager();
+        super.tearDown();
     }
 
     /**

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/PasteStylePureGraphicalTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/tabbar/PasteStylePureGraphicalTest.java
@@ -95,6 +95,12 @@ public class PasteStylePureGraphicalTest extends AbstractSiriusSwtBotGefTestCase
         localSession = designerPerspective.openSessionFromFile(sessionAirdResource);
     }
 
+    @Override
+    protected void tearDown() throws Exception {
+        clearFormatDataManager();
+        super.tearDown();
+    }
+
     void openDiagramSimple() {
         editor = (SWTBotSiriusDiagramEditor) openRepresentation(localSession.getOpenedSession(), "Entities", " package entities", DDiagram.class);
     }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteFormatOfLabelOfBorderedNodeTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteFormatOfLabelOfBorderedNodeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,12 @@ import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
  * @author lredor
  */
 public class CopyPasteFormatOfLabelOfBorderedNodeTest extends AbstractUmlDragAndDropTest {
+    @Override
+    protected void tearDown() throws Exception {
+        clearFormatDataManager();
+        super.tearDown();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteLayoutOfPortsWithConflictWithNotPastedPortsTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteLayoutOfPortsWithConflictWithNotPastedPortsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -46,6 +46,12 @@ public class CopyPasteLayoutOfPortsWithConflictWithNotPastedPortsTest extends Ab
      * BorderItemLocator).
      */
     private static final double MAX_POSITION_DELTA = 11;
+
+    @Override
+    protected void tearDown() throws Exception {
+        clearFormatDataManager();
+        super.tearDown();
+    }
 
     /**
      * {@inheritDoc}

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteLayoutOfPortsWithConflictWithPastedPortsTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteLayoutOfPortsWithConflictWithPastedPortsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,12 @@ import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEdi
  * @author lredor
  */
 public class CopyPasteLayoutOfPortsWithConflictWithPastedPortsTest extends AbstractUmlDragAndDropTest {
+    @Override
+    protected void tearDown() throws Exception {
+        clearFormatDataManager();
+        super.tearDown();
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Some tests do not clear the FormatDataManager after using Copy/Paste actions. This causes some side effects on other tests (tests from TabBarTest for example).