### PR TITLE
[test] Fix RefreshWithCustomizedStyleTests

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/condition/OperationDoneCondition.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/condition/OperationDoneCondition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010, 2021 THALES GLOBAL SERVICES
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,8 @@ import org.eclipse.core.commands.operations.OperationHistoryEvent;
  */
 public class OperationDoneCondition extends AbstractOperationCondition {
 
+    String operationName;
+
     /**
      * Default constructor.
      */
@@ -29,10 +31,25 @@ public class OperationDoneCondition extends AbstractOperationCondition {
         super(OperationHistoryEvent.DONE);
     }
 
+    /**
+     * Default constructor with an operation name.
+     * 
+     * @param operationName
+     *            The name of the operation to be done
+     */
+    public OperationDoneCondition(String operationName) {
+        super(OperationHistoryEvent.DONE);
+        this.operationName = operationName;
+    }
+
     @Override
     public String getFailureMessage() {
         super.getFailureMessage();
-        return "operation execution failed";
+        String failureMessage = "Operation execution failed";
+        if (operationName != null) {
+            failureMessage += " for \"" + operationName + "\"";
+        }
+        return failureMessage;
     }
 
 }


### PR DESCRIPTION
Tests from RefreshWithCustomizedStyleTests fail on some CI servers. It seems that the field is not "validated" and the model/session is not modified.

This commit adds several conditions to make tests more reliable:
- a "traverse" call for text fields to force the validation for this kind of field,
- the Properties view is maximized before setting fields. At least the modification of a combo box can be problematic on Linux if the field is not "visible",
- a condition, OperationDoneCondition, has been added. This allows to have a better feedback in case of failure,
- several "SWTBotUtils.waitAllUiEvents();" have been added.