### PR TITLE
[419] Exclude adapted IProject elements from sessionLabelProvider calls

### DIFF
--- a/plugins/org.eclipse.sirius.ui/plugin.xml
+++ b/plugins/org.eclipse.sirius.ui/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-  Copyright (c) 2007, 2020 THALES GLOBAL SERVICES and others
+  Copyright (c) 2007, 2024 THALES GLOBAL SERVICES and others
   This program and the accompanying materials
   are made available under the terms of the Eclipse Public License 2.0
   which accompanies this distribution, and is available at
@@ -298,6 +298,7 @@
         point="org.eclipse.ui.navigator.navigatorContent">
      <navigatorContent
            activeByDefault="true"
+           appearsBefore="org.eclipse.jdt.java.ui.javaContent"
            contentProvider="org.eclipse.sirius.ui.tools.internal.views.common.navigator.SiriusCommonContentProvider"
            icon="icons/obj16/SessionResourceFile.gif"
            id="org.eclipse.sirius.ui.resource.content.session"


### PR DESCRIPTION
Do not look for elements adapted as IProject in calls to sessionLabelProvider::getText/getImage
PossibleChildren / TriggerPoint expressions evaluation change with 2023-03 for some JDT elements
See result of
org.eclipse.ui.internal.navigator.extensions.NavigatorContentDescriptorManager.findDescriptors for org.eclipse.jdt.internal.core.PackageFragmentRoot or org.eclipse.jdt.internal.core.JrtPackageFragmentRoot which are now adaptable into IProject and are displayed in a EcoreModelingProject for example: src folder, JRE System library modules.

Re-add " appearsBefore="org.eclipse.jdt.java.ui.javaContent" to have "*" displayed in project text for ModelingProject with dirty session status when org.eclipse.sirius.ui.business.api.preferences.SiriusUIPreferencesKeys.PREF_SAVE_WHEN_NO_EDITOR is set to false. See
org.eclipse.sirius.ui.business.api.preferences.SiriusUIPreferencesKeys.PREF_SAVE_WHEN_NO_EDITOR

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/419