### PR TITLE
[426] Improve GMFHelper.getAbsoluteBounds method

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.model/src/org/eclipse/sirius/diagram/model/business/internal/query/DDiagramElementContainerExperimentalQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.model/src/org/eclipse/sirius/diagram/model/business/internal/query/DDiagramElementContainerExperimentalQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2013, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.sirius.diagram.model.business.internal.query;
 
+import java.util.Optional;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.diagram.DDiagramElementContainer;
 import org.eclipse.sirius.diagram.DNodeContainer;
 import org.eclipse.sirius.diagram.FlatContainerStyle;
 import org.eclipse.sirius.diagram.description.style.FlatContainerStyleDescription;
-import org.eclipse.sirius.ext.base.Option;
-import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.sirius.viewpoint.description.style.LabelBorderStyleDescription;
 import org.eclipse.sirius.viewpoint.description.style.StyleDescription;
 
@@ -92,16 +92,16 @@ public class DDiagramElementContainerExperimentalQuery {
     /**
      * Get the label border style of the current {@link DDiagramElementContainer} if it exists.
      * 
-     * @return an {@link Option} with the found label border style if it exists.
+     * @return an {@link Optional} with the found label border style if it exists.
      */
-    public Option<LabelBorderStyleDescription> getLabelBorderStyle() {
+    public Optional<LabelBorderStyleDescription> getLabelBorderStyle() {
         if (container.getStyle() instanceof FlatContainerStyle) {
             StyleDescription description = container.getStyle().getDescription();
             if (description instanceof FlatContainerStyleDescription) {
                 FlatContainerStyleDescription fcsd = (FlatContainerStyleDescription) description;
-                return Options.newSome(fcsd.getLabelBorderStyle());
+                return Optional.ofNullable(fcsd.getLabelBorderStyle());
             }
         }
-        return Options.newNone();
+        return Optional.empty();
     }
 }

--- a/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/query/SequenceNodeQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/query/SequenceNodeQuery.java
@@ -64,7 +64,7 @@ public class SequenceNodeQuery {
                 result = CacheHelper.getViewToRangeCache().get(node);
             }
             if (result == null) {
-                Rectangle absoluteBounds = GMFHelper.getAbsoluteBounds(node);
+                Rectangle absoluteBounds = GMFHelper.getAbsoluteBounds(node, false, false, false, true);
                 int y = absoluteBounds.y;
                 int height = absoluteBounds.height;
                 // GMFHelper.getAbsoluteBounds() use default

--- a/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/refresh/FixBendpointsOnCreationCommand.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/refresh/FixBendpointsOnCreationCommand.java
@@ -152,7 +152,7 @@ public class FixBendpointsOnCreationCommand extends RecordingCommand {
 
     private void computeEdgeDataWithoutEdgeLayoutData() {
         Point firstClick = new Point(0, 0);
-        Rectangle sourceBounds = GMFHelper.getAbsoluteBounds((Node) source);
+        Rectangle sourceBounds = GMFHelper.getAbsoluteBounds((Node) source, false, false, false, true);
         if (source.getElement() instanceof AbstractDNode) {
             AbstractDNode sourceDNode = (AbstractDNode) source.getElement();
             if (sourceDNode.eContainer() instanceof AbstractDNode) {
@@ -181,7 +181,7 @@ public class FixBendpointsOnCreationCommand extends RecordingCommand {
         sourceTerminal = "(" + sourceRelativeLocation.preciseX() + "," + sourceRelativeLocation.preciseY() + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
         Point secondClick = new Point(0, 0);
-        Rectangle targetBounds = GMFHelper.getAbsoluteBounds((Node) target);
+        Rectangle targetBounds = GMFHelper.getAbsoluteBounds((Node) target, false, false, false, true);
 
         if (target.getElement() instanceof AbstractDNode) {
             AbstractDNode targetDNode = (AbstractDNode) target.getElement();

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/NodeQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/NodeQuery.java
@@ -30,14 +30,7 @@ import org.eclipse.sirius.diagram.DNode;
 import org.eclipse.sirius.diagram.business.api.query.DDiagramElementQuery;
 import org.eclipse.sirius.diagram.business.api.query.DNodeQuery;
 import org.eclipse.sirius.diagram.ui.edit.internal.part.PortLayoutHelper;
-import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNode2EditPart;
-import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNode4EditPart;
-import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainer2EditPart;
-import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerEditPart;
-import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeList2EditPart;
-import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListEditPart;
 import org.eclipse.sirius.diagram.ui.internal.refresh.GMFHelper;
-import org.eclipse.sirius.diagram.ui.part.SiriusVisualIDRegistry;
 import org.eclipse.sirius.diagram.ui.tools.api.layout.LayoutUtils;
 import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.ext.base.Options;
@@ -51,7 +44,7 @@ import com.google.common.collect.Iterables;
  * 
  * @author lredor
  */
-public class NodeQuery {
+public class NodeQuery extends ViewQuery {
 
     private Node node;
 
@@ -62,6 +55,7 @@ public class NodeQuery {
      *            the starting point.
      */
     public NodeQuery(Node node) {
+        super(node);
         this.node = node;
     }
 
@@ -167,32 +161,11 @@ public class NodeQuery {
     }
 
     /**
-     * Tests whether the queried Node corresponds to a bordered node.
-     * 
-     * @return <code>true</code> if the queried View corresponds to a bordered node.
-     */
-    public boolean isBorderedNode() {
-        int type = SiriusVisualIDRegistry.getVisualID(this.node.getType());
-        boolean result = type == DNode2EditPart.VISUAL_ID || type == DNode4EditPart.VISUAL_ID;
-        return result;
-    }
-
-    /**
-     * Tests whether the queried Node corresponds to a container (list or not).
-     * 
-     * @return <code>true</code> if the queried View corresponds to a container node.
-     */
-    public boolean isContainer() {
-        int type = SiriusVisualIDRegistry.getVisualID(this.node.getType());
-        boolean result = type == DNodeContainer2EditPart.VISUAL_ID || type == DNodeContainerEditPart.VISUAL_ID || type == DNodeList2EditPart.VISUAL_ID || type == DNodeListEditPart.VISUAL_ID;
-        return result;
-    }
-
-    /**
      * Return the compartment of the GMF node container with "free form" layout.
      * 
      * @return the compartment or Optional.empty if view is not container or compartment not found
      */
+    @Override
     public Optional<Node> getFreeFormContainerCompartment() {
         if (new ViewQuery(this.node).isFreeFormContainer()) {
             List<View> children = this.node.getChildren();

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/NodeQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/NodeQuery.java
@@ -274,7 +274,7 @@ public class NodeQuery extends ViewQuery {
      * @return The rectangle used for handles
      */
     public Rectangle getHandleBounds() {
-        return GMFHelper.getAbsoluteBounds(node, true, true);
+        return GMFHelper.getAbsoluteBounds(node, true, true, false, false);
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/ViewQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/ViewQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2012, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,8 +61,11 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerViewNodeC
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeList2EditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListEditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListElementEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListName2EditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListNameEditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListViewNodeListCompartment2EditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListViewNodeListCompartmentEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.NotationViewIDs;
 import org.eclipse.sirius.diagram.ui.part.SiriusVisualIDRegistry;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
@@ -381,6 +384,31 @@ public class ViewQuery {
     }
 
     /**
+     * Return if this GMF node is associated to DNodeList Sirius diagram element.
+     */
+    public boolean isListContainer() {
+        int type = SiriusVisualIDRegistry.getVisualID(this.view.getType());
+        return type == DNodeListEditPart.VISUAL_ID || type == DNodeList2EditPart.VISUAL_ID;
+    }
+
+    /**
+     * Return if this GMF node is compartment of node corresponding to a Sirius list container.
+     */
+    public boolean isListCompartment() {
+        int type = SiriusVisualIDRegistry.getVisualID(this.view.getType());
+        return type == DNodeListViewNodeListCompartmentEditPart.VISUAL_ID //
+                || type == DNodeListViewNodeListCompartment2EditPart.VISUAL_ID;
+    }
+
+    /**
+     * Return if this GMF node is a list item.
+     */
+    public boolean isListItem() {
+        int type = SiriusVisualIDRegistry.getVisualID(this.view.getType());
+        return type == DNodeListElementEditPart.VISUAL_ID;
+    }
+
+    /**
      * Return if this GMF node have vertical/horizontal stack layout.
      */
     public boolean isRegionContainer() {
@@ -416,7 +444,7 @@ public class ViewQuery {
      * 
      * @return the compartment or Optional.empty if view is not container or compartment not found
      */
-    public Optional<View> getFreeFormContainerCompartment() {
+    public Optional<? extends View> getFreeFormContainerCompartment() {
         if (this.isFreeFormContainer()) {
             List<View> children = this.view.getChildren();
             return children.stream() //

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/ViewQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/ViewQuery.java
@@ -32,6 +32,7 @@ import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.JumpLinkStatus;
 import org.eclipse.gmf.runtime.notation.JumpLinkType;
+import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.Style;
@@ -40,10 +41,12 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.DDiagramElement;
+import org.eclipse.sirius.diagram.DDiagramElementContainer;
 import org.eclipse.sirius.diagram.LabelPosition;
 import org.eclipse.sirius.diagram.NodeStyle;
 import org.eclipse.sirius.diagram.business.api.query.ContainerMappingQuery;
 import org.eclipse.sirius.diagram.description.ContainerMapping;
+import org.eclipse.sirius.diagram.model.business.internal.query.DDiagramElementContainerExperimentalQuery;
 import org.eclipse.sirius.diagram.tools.api.DiagramPlugin;
 import org.eclipse.sirius.diagram.tools.api.preferences.SiriusDiagramCorePreferences;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeBeginNameEditPart;
@@ -409,12 +412,62 @@ public class ViewQuery {
     }
 
     /**
+     * Return if this GMF node is a region.
+     */
+    public boolean isRegion() {
+        return this.view.getElement() instanceof DDiagramElementContainer ddec //
+                && new DDiagramElementContainerExperimentalQuery(ddec).isRegion();
+    }
+
+    /**
+     * Return if this GMF node is contained in a vertical stack layout container.
+     */
+    public boolean isVerticalRegion() {
+        return view.eContainer() instanceof View container && new ViewQuery(container).isVerticalRegionContainerCompartment();
+    }
+
+    /**
      * Return if this GMF node have vertical/horizontal stack layout.
      */
     public boolean isRegionContainer() {
         return this.view.getElement() instanceof DDiagramElement element //
                 && element.getDiagramElementMapping() instanceof ContainerMapping mapping //
                 && new ContainerMappingQuery(mapping).isRegionContainer();
+    }
+
+    /**
+     * Return if this GMF node have vertical stack layout.
+     */
+    public boolean isVerticalRegionContainer() {
+        return this.view.getElement() instanceof DDiagramElement element //
+                && element.getDiagramElementMapping() instanceof ContainerMapping mapping //
+                && new ContainerMappingQuery(mapping).isVerticalStackContainer();
+    }
+
+    /**
+     * Return if this GMF node is a compartment of a container having vertical stack layout.
+     */
+    public boolean isVerticalRegionContainerCompartment() {
+        if (isFreeFormCompartment()) {
+            if (view.eContainer() instanceof Node container) {
+                return new ViewQuery(container).isVerticalRegionContainer();
+            }
+
+        }
+        return false;
+    }
+
+    /**
+     * Return if this GMF node is a compartment of a container having an horizontal or a vertical stack layout.
+     */
+    public boolean isRegionContainerCompartment() {
+        if (isFreeFormCompartment()) {
+            if (view.eContainer() instanceof Node container) {
+                return new ViewQuery(container).isRegionContainer();
+            }
+
+        }
+        return false;
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/ViewQuery.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/api/query/ViewQuery.java
@@ -458,6 +458,34 @@ public class ViewQuery {
     }
 
     /**
+     * Return if this GMF node is contained in an horizontal stack layout container.
+     */
+    public boolean isHorizontalRegion() {
+        return view.eContainer() instanceof View container && new ViewQuery(container).isHorizontalRegionContainerCompartment();
+    }
+
+    /**
+     * Return if this GMF node have horizontal stack layout.
+     */
+    public boolean isHorizontalRegionContainer() {
+        return this.view.getElement() instanceof DDiagramElement element //
+                && element.getDiagramElementMapping() instanceof ContainerMapping mapping //
+                && new ContainerMappingQuery(mapping).isHorizontalStackContainer();
+    }
+
+    /**
+     * Return if this GMF node is a compartment of a container having horizontal stack layout.
+     */
+    public boolean isHorizontalRegionContainerCompartment() {
+        if (isFreeFormCompartment()) {
+            if (view.eContainer() instanceof Node container) {
+                return new ViewQuery(container).isHorizontalRegionContainer();
+            }
+        }
+        return false;
+    }
+    
+    /**
      * Return if this GMF node is a compartment of a container having an horizontal or a vertical stack layout.
      */
     public boolean isRegionContainerCompartment() {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/command/TreeLayoutSetConnectionAnchorsCommand.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/command/TreeLayoutSetConnectionAnchorsCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2012, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *    Obeo - initial API and implementation
  *******************************************************************************/
 package org.eclipse.sirius.diagram.ui.business.internal.command;
+
+import java.util.Optional;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.IAdaptable;
@@ -33,7 +35,6 @@ import org.eclipse.gmf.runtime.notation.NotationFactory;
 import org.eclipse.sirius.diagram.ui.internal.refresh.GMFHelper;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
 import org.eclipse.sirius.diagram.ui.tools.internal.util.GMFNotationUtilities;
-import org.eclipse.sirius.ext.base.Option;
 
 /**
  * Controls the movement of source and target edge anchor. Use to move vertical
@@ -92,8 +93,8 @@ public class TreeLayoutSetConnectionAnchorsCommand extends SetConnectionAnchorsC
                 } else {
                     // We are in reconnection (compute the sourceRefPoint using
                     // GMF model data)
-                    Option<Rectangle> optionalSourceBounds = GMFHelper.getAbsoluteBounds(edge.getSource());
-                    if (optionalSourceBounds.some()) {
+                    Optional<Rectangle> optionalSourceBounds = GMFHelper.getAbsoluteBounds(edge.getSource());
+                    if (optionalSourceBounds.isPresent()) {
                         sourceBounds = optionalSourceBounds.get();
                     }
                 }
@@ -117,8 +118,8 @@ public class TreeLayoutSetConnectionAnchorsCommand extends SetConnectionAnchorsC
                 } else {
                     // We are in reconnection (compute the sourceRefPoint using
                     // GMF model data)
-                    Option<Rectangle> optionalTargetBounds = GMFHelper.getAbsoluteBounds(edge.getTarget());
-                    if (optionalTargetBounds.some()) {
+                    Optional<Rectangle> optionalTargetBounds = GMFHelper.getAbsoluteBounds(edge.getTarget());
+                    if (optionalTargetBounds.isPresent()) {
                         targetBounds = optionalTargetBounds.get();
                     }
                 }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/migration/DiagramRepresentationsFileMigrationParticipantV670.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/migration/DiagramRepresentationsFileMigrationParticipantV670.java
@@ -174,7 +174,7 @@ public class DiagramRepresentationsFileMigrationParticipantV670 {
                     Location location = (Location) layoutConstraint;
                     constraint = new Rectangle(location.getX(), location.getY(), -1, -1);
                 }
-                Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode);
+                Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode, false, false);
                 constraint.translate(parentAbsoluteLocation.x, parentAbsoluteLocation.y);
                 final Point realLocation = borderItemLocator.getValidLocation(constraint, node, otherBorderedNodesToIgnore);
                 final Dimension d = realLocation.getDifference(parentAbsoluteLocation);
@@ -215,7 +215,7 @@ public class DiagramRepresentationsFileMigrationParticipantV670 {
                     LayoutConstraint layoutConstraint = node.getLayoutConstraint();
                     if (layoutConstraint instanceof Bounds) {
                         Bounds bounds = (Bounds) layoutConstraint;
-                        Rectangle rectBounds = GMFHelper.getAbsoluteBounds(node);
+                        Rectangle rectBounds = GMFHelper.getAbsoluteBounds(node, false, false, false, true);
                         // The GMF node size must be stored in collapse
                         // filter (to can set this size
                         // when this node is expanded).
@@ -287,6 +287,7 @@ public class DiagramRepresentationsFileMigrationParticipantV670 {
      * </UL>
      */
     private static class IsStandardDiagramPredicate implements Predicate<Diagram> {
+        @Override
         public boolean apply(Diagram input) {
             boolean apply = false;
             if (input.getElement() instanceof DDiagram) {
@@ -311,6 +312,7 @@ public class DiagramRepresentationsFileMigrationParticipantV670 {
      */
     private static class IsBorderedNodePredicate implements Predicate<Node> {
 
+        @Override
         public boolean apply(Node input) {
             // Is this node the main view of a DNode and a border
             // node ?
@@ -327,6 +329,7 @@ public class DiagramRepresentationsFileMigrationParticipantV670 {
      */
 
     private static class IsDirectlyCollapsedNodePredicate implements Predicate<Node> {
+        @Override
         public boolean apply(Node input) {
             boolean apply = false;
 

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/api/part/AbstractDiagramContainerEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/api/part/AbstractDiagramContainerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2022 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.diagram.ui.edit.api.part;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.draw2d.IFigure;
@@ -59,7 +60,6 @@ import org.eclipse.sirius.diagram.ui.provider.Messages;
 import org.eclipse.sirius.diagram.ui.tools.api.layout.LayoutUtils;
 import org.eclipse.sirius.diagram.ui.tools.api.policy.CompoundEditPolicy;
 import org.eclipse.sirius.diagram.ui.tools.internal.ui.NoCopyDragEditPartsTrackerEx;
-import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.ext.gmf.runtime.diagram.ui.tools.RubberbandDragTracker;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.LabelBorderStyleIds;
 import org.eclipse.sirius.viewpoint.description.style.LabelBorderStyleDescription;
@@ -267,8 +267,8 @@ public abstract class AbstractDiagramContainerEditPart extends AbstractDiagramEl
     private boolean hasFullLabelBorder() {
         EObject element = resolveSemanticElement();
         if (element instanceof DDiagramElementContainer) {
-            Option<LabelBorderStyleDescription> labelBorderStyle = new DDiagramElementContainerExperimentalQuery((DDiagramElementContainer) element).getLabelBorderStyle();
-            return labelBorderStyle.some() && LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
+            Optional<LabelBorderStyleDescription> labelBorderStyle = new DDiagramElementContainerExperimentalQuery((DDiagramElementContainer) element).getLabelBorderStyle();
+            return labelBorderStyle.isPresent() && LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
         }
         return false;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/api/part/AbstractDiagramElementContainerEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/api/part/AbstractDiagramElementContainerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2022 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package org.eclipse.sirius.diagram.ui.edit.api.part;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -95,8 +96,6 @@ import org.eclipse.sirius.diagram.ui.tools.internal.figure.RegionRoundedGradient
 import org.eclipse.sirius.diagram.ui.tools.internal.layout.LayoutUtil;
 import org.eclipse.sirius.diagram.ui.tools.internal.util.EditPartQuery;
 import org.eclipse.sirius.diagram.ui.tools.internal.util.NotificationQuery;
-import org.eclipse.sirius.ext.base.Option;
-import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.AlphaDropShadowBorder;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.SiriusDefaultSizeNodeFigure;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.SiriusWrapLabel;
@@ -183,7 +182,7 @@ public abstract class AbstractDiagramElementContainerEditPart extends AbstractBo
         EditPart editPart = this;
         //@formatter:off
             @SuppressWarnings("unchecked")
-            List<AbstractDiagramElementContainerEditPart> regionParts = (List<AbstractDiagramElementContainerEditPart>) getParent().getChildren().stream()
+            List<AbstractDiagramElementContainerEditPart> regionParts = getParent().getChildren().stream()
                     .filter(ed -> ed instanceof AbstractDiagramElementContainerEditPart && !ed.equals(editPart))
                     .map(AbstractDiagramElementContainerEditPart.class::cast)
                     .collect(Collectors.toList());
@@ -491,6 +490,7 @@ public abstract class AbstractDiagramElementContainerEditPart extends AbstractBo
      * @return the default figure dimension of this edit part
      * @deprecated Only here as security if user activates {@link LayoutUtil#isArrangeAtOpeningChangesDisabled()}.
      */
+    @Deprecated
     public Dimension oldGetDefaultDimension() {
         DDiagramElement dde = resolveDiagramElement();
         Dimension defaultSize = LayoutUtils.NEW_DEFAULT_CONTAINER_DIMENSION;
@@ -513,8 +513,8 @@ public abstract class AbstractDiagramElementContainerEditPart extends AbstractBo
         NodeFigure result;
         DDiagramElement dde = resolveDiagramElement();
         Dimension defaultSize = getDefaultDimension();
-        Option<LabelBorderStyleDescription> getLabelBorderStyle = getLabelBorderStyle(dde);
-        if (getLabelBorderStyle.some()) {
+        Optional<LabelBorderStyleDescription> getLabelBorderStyle = getLabelBorderStyle(dde);
+        if (getLabelBorderStyle.isPresent()) {
             result = new ContainerWithTitleBlockFigure(getMapMode().DPtoLP(defaultSize.width), getMapMode().DPtoLP(defaultSize.height), dde, getLabelBorderStyle.get());
         } else {
             result = new SiriusDefaultSizeNodeFigure(getMapMode().DPtoLP(defaultSize.width), getMapMode().DPtoLP(defaultSize.height));
@@ -523,11 +523,11 @@ public abstract class AbstractDiagramElementContainerEditPart extends AbstractBo
         return result;
     }
 
-    private Option<LabelBorderStyleDescription> getLabelBorderStyle(DStylizable viewNode) {
+    private Optional<LabelBorderStyleDescription> getLabelBorderStyle(DStylizable viewNode) {
         if (viewNode instanceof DDiagramElementContainer) {
             return new DDiagramElementContainerExperimentalQuery((DDiagramElementContainer) viewNode).getLabelBorderStyle();
         }
-        return Options.newNone();
+        return Optional.empty();
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/commands/StraightenToCommand.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/commands/StraightenToCommand.java
@@ -667,7 +667,7 @@ public class StraightenToCommand extends AbstractTransactionalCommand {
             // the move. It should be the same as the one stored in GMF but
             // sometimes, probably caused by some bugs, it could be wrong in
             // GMF.
-            Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode);
+            Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode, false, true);
             Rectangle initialAsboluteConstraint = initialRelativeConstraint.getTranslated(parentAbsoluteLocation);
             Point validInitialAbsoluteLocation = borderItemLocator.getValidLocation(initialAsboluteConstraint, node, new ArrayList<Node>(Arrays.asList(node)));
             Rectangle validInitialAbsoluteConstraint = initialAsboluteConstraint.getCopy();

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/AbstractDNodeContainerCompartmentEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/AbstractDNodeContainerCompartmentEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2009, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -221,8 +221,8 @@ public abstract class AbstractDNodeContainerCompartmentEditPart extends ShapeCom
      */
     protected void configureBorder(ResizableCompartmentFigure rcf) {
         boolean shouldHaveBorder = isRegionContainerCompartment();
-        Option<LabelBorderStyleDescription> labelBorderStyle = getLabelBorderStyle();
-        if (labelBorderStyle.some()) {
+        Optional<LabelBorderStyleDescription> labelBorderStyle = getLabelBorderStyle();
+        if (labelBorderStyle.isPresent()) {
             shouldHaveBorder = shouldHaveBorder || LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
         }
 
@@ -266,8 +266,8 @@ public abstract class AbstractDNodeContainerCompartmentEditPart extends ShapeCom
         }
 
         boolean fullLabelBorder = false;
-        Option<LabelBorderStyleDescription> labelBorderStyle = getLabelBorderStyle();
-        if (labelBorderStyle.some()) {
+        Optional<LabelBorderStyleDescription> labelBorderStyle = getLabelBorderStyle();
+        if (labelBorderStyle.isPresent()) {
             fullLabelBorder = LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
         }
 
@@ -319,12 +319,12 @@ public abstract class AbstractDNodeContainerCompartmentEditPart extends ShapeCom
         return style == null ? false : style.isCollapsed();
     }
 
-    private Option<LabelBorderStyleDescription> getLabelBorderStyle() {
+    private Optional<LabelBorderStyleDescription> getLabelBorderStyle() {
         EObject element = resolveSemanticElement();
         if (element instanceof DDiagramElementContainer) {
             return new DDiagramElementContainerExperimentalQuery((DDiagramElementContainer) element).getLabelBorderStyle();
         }
-        return Options.newNone();
+        return Optional.empty();
     }
 
     @Override

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/AbstractDNodeListCompartmentEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/AbstractDNodeListCompartmentEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -68,7 +68,6 @@ import org.eclipse.sirius.diagram.ui.internal.edit.policies.DNodeListViewNodeLis
 import org.eclipse.sirius.diagram.ui.internal.edit.policies.RegionCollapseAwarePropertyHandlerEditPolicy;
 import org.eclipse.sirius.diagram.ui.internal.operation.ComparisonHelper;
 import org.eclipse.sirius.diagram.ui.tools.api.requests.RequestConstants;
-import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.LabelBorderStyleIds;
 import org.eclipse.sirius.viewpoint.DRepresentationElement;
 import org.eclipse.sirius.viewpoint.description.RepresentationElementMapping;
@@ -214,8 +213,8 @@ public abstract class AbstractDNodeListCompartmentEditPart extends ListCompartme
     private boolean hasLabelBorderStyle() {
         EObject element = resolveSemanticElement();
         if (element instanceof DDiagramElementContainer) {
-            Option<LabelBorderStyleDescription> labelBorderStyle = new DDiagramElementContainerExperimentalQuery((DDiagramElementContainer) element).getLabelBorderStyle();
-            return labelBorderStyle.some() && !LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
+            Optional<LabelBorderStyleDescription> labelBorderStyle = new DDiagramElementContainerExperimentalQuery((DDiagramElementContainer) element).getLabelBorderStyle();
+            return labelBorderStyle.isPresent() && !LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
         }
         return false;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/operation/CenterEdgeEndModelChangeOperation.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/operation/CenterEdgeEndModelChangeOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2014, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -58,8 +58,6 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeEditPart;
 import org.eclipse.sirius.diagram.ui.internal.refresh.GMFHelper;
 import org.eclipse.sirius.diagram.ui.tools.internal.routers.RectilinearEdgeUtil;
 import org.eclipse.sirius.diagram.ui.tools.internal.util.GMFNotationUtilities;
-import org.eclipse.sirius.ext.base.Option;
-import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.sirius.ext.gmf.runtime.editparts.GraphicalHelper;
 import org.eclipse.ui.IEditorPart;
 
@@ -207,10 +205,10 @@ public class CenterEdgeEndModelChangeOperation extends AbstractModelChangeOperat
 
                 // We get the edge source and target nodes absolute bounds to
                 // compute absolute anchors coordinates
-                Option<Rectangle> sourceBounds = getAbsoluteSourceBounds(edgeSourceView);
-                Option<Rectangle> targetBounds = getAbsoluteTargetBounds(edgeTargetView);
+                Optional<Rectangle> sourceBounds = getAbsoluteSourceBounds(edgeSourceView);
+                Optional<Rectangle> targetBounds = getAbsoluteTargetBounds(edgeTargetView);
 
-                if (sourceBounds.some() && targetBounds.some()) {
+                if (sourceBounds.isPresent() && targetBounds.isPresent()) {
 
                     // Calculate the existing anchors absolute location
                     retrieveAndSetExistingAnchorsAbsoluteLocation(sourceBounds.get(), targetBounds.get());
@@ -249,7 +247,7 @@ public class CenterEdgeEndModelChangeOperation extends AbstractModelChangeOperat
      *            true if it represents the edge source, false otherwise.
      * @return the absolute bounds.
      */
-    private Option<Rectangle> getAbsoluteBounds(View gmfView, boolean isSource) {
+    private Optional<Rectangle> getAbsoluteBounds(View gmfView, boolean isSource) {
         if (connectionEditPart != null) {
             EditPart editPart = null;
             if (isSource) {
@@ -258,24 +256,24 @@ public class CenterEdgeEndModelChangeOperation extends AbstractModelChangeOperat
                 editPart = connectionEditPart.getTarget();
             }
             if (editPart instanceof GraphicalEditPart) {
-                return Options.newSome(GraphicalHelper.getAbsoluteBoundsIn100Percent((GraphicalEditPart) editPart));
+                return Optional.ofNullable(GraphicalHelper.getAbsoluteBoundsIn100Percent((GraphicalEditPart) editPart));
             }
         }
         return GMFHelper.getAbsoluteBounds(gmfView, true, true);
     }
 
-    private Option<Rectangle> getAbsoluteSourceBounds(View edgeSourceView) {
-        Option<Rectangle> option = getAbsoluteBounds(edgeSourceView, true);
-        if (sourceFigureSize != null && option.some()) {
+    private Optional<Rectangle> getAbsoluteSourceBounds(View edgeSourceView) {
+        Optional<Rectangle> option = getAbsoluteBounds(edgeSourceView, true);
+        if (sourceFigureSize != null && option.isPresent()) {
             Rectangle rectangle = option.get();
             rectangle.setSize(sourceFigureSize);
         }
         return option;
     }
 
-    private Option<Rectangle> getAbsoluteTargetBounds(View edgeTargetView) {
-        Option<Rectangle> option = getAbsoluteBounds(edgeTargetView, false);
-        if (targetFigureSize != null && option.some()) {
+    private Optional<Rectangle> getAbsoluteTargetBounds(View edgeTargetView) {
+        Optional<Rectangle> option = getAbsoluteBounds(edgeTargetView, false);
+        if (targetFigureSize != null && option.isPresent()) {
             Rectangle rectangle = option.get();
             rectangle.setSize(targetFigureSize);
         }
@@ -517,7 +515,7 @@ public class CenterEdgeEndModelChangeOperation extends AbstractModelChangeOperat
         if (connection != null || !useFigure) {
             return;
         }
-        Option<GraphicalEditPart> option = Options.newNone();
+        Optional<GraphicalEditPart> option = Optional.empty();
         final IEditorPart editorPart = EclipseUIUtil.getActiveEditor();
         if (editorPart instanceof DiagramEditor) {
             option = GMFHelper.getGraphicalEditPart(edge, (DiagramEditor) editorPart);
@@ -533,14 +531,14 @@ public class CenterEdgeEndModelChangeOperation extends AbstractModelChangeOperat
                 if (object instanceof DiagramEditor) {
                     option = GMFHelper.getGraphicalEditPart(edge, (DiagramEditor) object);
                 }
-                if (option.some()) {
+                if (option.isPresent()) {
                     break;
                 }
             }
 
         }
 
-        if (option.some()) {
+        if (option.isPresent()) {
             GraphicalEditPart editPart = option.get();
             if (editPart instanceof DEdgeEditPart) {
                 connectionEditPart = (DEdgeEditPart) editPart;

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
@@ -607,7 +607,7 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
             locator.setConstraint(constraint);
             dummyFigure.setVisible(true);
             final Rectangle rect = new Rectangle(constraint);
-            Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode, true);
+            Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode, true, false);
             rect.translate(parentAbsoluteLocation.x, parentAbsoluteLocation.y);
             dummyFigure.setBounds(rect);
             final Point realLocation = locator.getValidLocation(rect, createdNode, new ArrayList<Node>(Arrays.asList(createdNode)));
@@ -666,7 +666,7 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
 
             // CanonicalDBorderItemLocator works with absolute GMF parent
             // location so we need to translate BorderedNode absolute location.
-            final org.eclipse.draw2d.geometry.Point parentAbsoluteLocation = GMFHelper.getAbsoluteBounds(parentNode).getTopLeft();
+            final org.eclipse.draw2d.geometry.Point parentAbsoluteLocation = GMFHelper.getAbsoluteBounds(parentNode, false, false, false, false).getTopLeft();
             final Point realLocation = locator.getValidLocation(new Rectangle(location.getTranslated(parentAbsoluteLocation), size), createdNode, Collections.singleton(createdNode));
 
             // Compute the new relative position to the parent

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IAdaptable;
@@ -576,8 +577,8 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
 
                 if (size == null) {
                     if (new ViewQuery(createdView).isForNameEditPart()) {
-                        Option<Rectangle> optionalRect = GMFHelper.getAbsoluteBounds(createdView);
-                        if (optionalRect.some()) {
+                        Optional<Rectangle> optionalRect = GMFHelper.getAbsoluteBounds(createdView);
+                        if (optionalRect.isPresent()) {
                             size = optionalRect.get().getSize();
                         }
                     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -156,17 +156,34 @@ public final class GMFHelper {
      * @return the absolute location of the node relative to the origin (Diagram)
      */
     public static Point getAbsoluteLocation(Node node, boolean insetsAware) {
-        Node currentNode = node;
-        Point absoluteNodeLocation = getLocation(currentNode);
-        if (currentNode.eContainer() instanceof Node) {
-            currentNode = (Node) currentNode.eContainer();
-            Point parentNodeLocation = getAbsoluteLocation(currentNode, insetsAware);
-            absoluteNodeLocation.translate(parentNodeLocation);
-            if (insetsAware) {
-                translateWithInsets(absoluteNodeLocation, node);
+        // TODO: Location of title "DNode*NameEditPart", x coordinate, can be wrong according to label alignment. This
+        // problem is not yet handled.
+
+        Point location = new Point(0, 0);
+        LayoutConstraint layoutConstraint = node.getLayoutConstraint();
+        if (layoutConstraint instanceof Bounds) {
+            Bounds gmfBounds = (Bounds) layoutConstraint;
+            location.setX(gmfBounds.getX());
+            location.setY(gmfBounds.getY());
+            // manage location of bordered node with closest side
+            if (node.getElement() instanceof DNode dNode && dNode.eContainer() instanceof AbstractDNode parentAbstractDNode && parentAbstractDNode.getOwnedBorderedNodes().contains(dNode)) {
+                Node parentNode = (Node) node.eContainer();
+                if (parentNode.getLayoutConstraint() instanceof Bounds parentBounds) {
+                    int position = CanonicalDBorderItemLocator.findClosestSideOfParent(new Rectangle(gmfBounds.getX(), gmfBounds.getY(), gmfBounds.getWidth(), gmfBounds.getHeight()),
+                            new Rectangle(parentBounds.getX(), parentBounds.getY(), parentBounds.getWidth(), parentBounds.getHeight()));
+                    updateLocation(location, position, parentBounds, gmfBounds);
+                }
             }
         }
-        return absoluteNodeLocation;
+
+        if (node.eContainer() instanceof Node container) {
+            Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
+            location.translate(parentNodeLocation);
+            if (insetsAware) {
+                translateWithInsets(location, node);
+            }
+        }
+        return location;
     }
 
     /**
@@ -202,7 +219,8 @@ public final class GMFHelper {
     }
 
     /**
-     * Return the top-left insets of the container of this <code>node</code>. The insets also considers its border.
+     * Return the top-left insets of the container of this <code>node</code>. The insets also considers its border (the
+     * size of the border).
      * 
      * @param node
      *            The current node
@@ -372,31 +390,11 @@ public final class GMFHelper {
      * @param node
      *            the node whose location to compute.
      * @return the location of the node.
+     * @deprecated Use getAbsoluteLocation instead. This method will be removed in future.
      */
+    @Deprecated
     public static Point getLocation(Node node) {
-        Point location = new Point(0, 0);
-        LayoutConstraint layoutConstraint = node.getLayoutConstraint();
-        if (layoutConstraint instanceof Bounds) {
-            Bounds gmfBounds = (Bounds) layoutConstraint;
-            location.setX(gmfBounds.getX());
-            location.setY(gmfBounds.getY());
-            // manage location of bordered node with closest side
-            if (node.getElement() instanceof DNode && node.getElement().eContainer() instanceof AbstractDNode) {
-                DNode dNode = (DNode) node.getElement();
-                AbstractDNode parentAbstractDNode = (AbstractDNode) dNode.eContainer();
-                if (parentAbstractDNode.getOwnedBorderedNodes().contains(dNode)) {
-                    Node parentNode = (Node) node.eContainer();
-                    LayoutConstraint parentLayoutConstraint = parentNode.getLayoutConstraint();
-                    if (parentLayoutConstraint instanceof Bounds) {
-                        Bounds parentBounds = (Bounds) parentLayoutConstraint;
-                        int position = CanonicalDBorderItemLocator.findClosestSideOfParent(new Rectangle(gmfBounds.getX(), gmfBounds.getY(), gmfBounds.getWidth(), gmfBounds.getHeight()),
-                                new Rectangle(parentBounds.getX(), parentBounds.getY(), parentBounds.getWidth(), parentBounds.getHeight()));
-                        updateLocation(location, position, parentBounds, gmfBounds);
-                    }
-                }
-            }
-        }
-        return location;
+        return getAbsoluteLocation(node, true);
     }
 
     private static void updateLocation(Point location, int position, Bounds parentBounds, Bounds gmfBounds) {
@@ -427,7 +425,7 @@ public final class GMFHelper {
      * @return the absolute bounds of the node relative to the origin (Diagram)
      */
     public static Rectangle getAbsoluteBounds(Node node) {
-        return getAbsoluteBounds(node, false, false);
+        return getAbsoluteBounds(node, false);
     }
 
     /**
@@ -442,7 +440,7 @@ public final class GMFHelper {
      * @return the absolute bounds of the node relative to the origin (Diagram)
      */
     public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware) {
-        return getAbsoluteBounds(node, insetsAware, false);
+        return getAbsoluteBounds(node, insetsAware, false, false);
     }
 
     /**
@@ -459,17 +457,28 @@ public final class GMFHelper {
      * @return the absolute bounds of the node relative to the origin (Diagram)
      */
     public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection) {
-        Node currentNode = node;
-        Rectangle absoluteNodeBounds = getBounds(currentNode, false, false, boxForConnection, false);
-        if (currentNode.eContainer() instanceof Node) {
-            currentNode = (Node) currentNode.eContainer();
-            Point parentNodeLocation = getAbsoluteLocation(currentNode, insetsAware);
-            absoluteNodeBounds = absoluteNodeBounds.getTranslated(parentNodeLocation);
-            if (insetsAware) {
-                translateWithInsets(absoluteNodeBounds, node);
-            }
-        }
-        return absoluteNodeBounds;
+        return getAbsoluteBounds(node, insetsAware, boxForConnection, false);
+    }
+
+    /**
+     * Get the absolute bounds relative to the origin (Diagram).
+     * 
+     * @param node
+     *            the GMF Node
+     * @param insetsAware
+     *            true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
+     *            current Sirius editParts and could become wrong if a developer customizes them.
+     * @param boxForConnection
+     *            true if we want to have the bounds used to compute connection anchor from source or target, false
+     *            otherwise
+     * @param recursiveGetBounds
+     *            true if this method is called from a parent "getBounds" call, false otherwise.
+     * @return the absolute bounds of the node relative to the origin (Diagram)
+     */
+    public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection, boolean recursiveGetBounds) {
+        Point location = getAbsoluteLocation(node, insetsAware);
+        Rectangle bounds = getBounds(node, false, false, boxForConnection, recursiveGetBounds, location);
+        return new PrecisionRectangle(location.preciseX(), location.preciseY(), bounds.preciseWidth(), bounds.preciseHeight());
     }
 
     /**
@@ -552,7 +561,7 @@ public final class GMFHelper {
     public static Option<Rectangle> getAbsoluteBounds(View view, boolean insetsAware, boolean boxForConnection) {
         Option<Rectangle> result = Options.newNone();
         if (view instanceof Node) {
-            result = Options.newSome(getAbsoluteBounds((Node) view, insetsAware, boxForConnection));
+            result = Options.newSome(getAbsoluteBounds((Node) view, insetsAware, boxForConnection, false));
         } else if (view instanceof Edge) {
             result = getAbsoluteBounds((Edge) view, insetsAware, boxForConnection);
         }
@@ -596,7 +605,7 @@ public final class GMFHelper {
      * @return the bounds of the node.
      */
     public static Rectangle getBounds(Node node, boolean useFigureForAutoSizeConstraint, boolean forceFigureAutoSize) {
-        return getBounds(node, useFigureForAutoSizeConstraint, forceFigureAutoSize, false, false);
+        return getBounds(node, useFigureForAutoSizeConstraint, forceFigureAutoSize, false, false, new Point());
     }
 
     /**
@@ -613,20 +622,19 @@ public final class GMFHelper {
      *            true if we want to have the bounds used to compute connection anchor from source or target, false
      *            otherwise
      * @param recursiveGetBounds
-     *            true if this method is called from a parent "getBounds" call, false otherwise.
+     *            true if this method is called from a parent "getBounds" call, false otherwise
+     * @param computedAbsoluteLocation
+     *            The absolute location of the <code>node</code>
      * 
      * @return the bounds of the node.
      */
-    public static Rectangle getBounds(Node node, boolean useFigureForAutoSizeConstraint, boolean forceFigureAutoSize, boolean boxForConnection, boolean recursiveGetBounds) {
-        PrecisionRectangle bounds = new PrecisionRectangle(0, 0, 0, 0);
+    public static Rectangle getBounds(Node node, boolean useFigureForAutoSizeConstraint, boolean forceFigureAutoSize, boolean boxForConnection, boolean recursiveGetBounds,
+            Point computedAbsoluteLocation) {
+        PrecisionRectangle bounds = new PrecisionRectangle(computedAbsoluteLocation.preciseX(), computedAbsoluteLocation.preciseY(), 0, 0);
         LayoutConstraint layoutConstraint = node.getLayoutConstraint();
         EObject element = node.getElement();
         if (element instanceof AbstractDNode) {
             AbstractDNode abstractDNode = (AbstractDNode) element;
-            if (layoutConstraint instanceof Location) {
-                bounds.setX(((Location) layoutConstraint).getX());
-                bounds.setY(((Location) layoutConstraint).getY());
-            }
             if (layoutConstraint instanceof Size) {
                 bounds.setWidth(((Size) layoutConstraint).getWidth());
                 bounds.setHeight(((Size) layoutConstraint).getHeight());
@@ -659,8 +667,8 @@ public final class GMFHelper {
                 // This insets corresponds to insets of {@link
                 // org.eclipse.sirius.diagram.ui.tools.api.figure.AlphaDropShadowBorder#getTransparentInsets()}.
                 double shadowBorderSize = getShadowBorderSize(node);
-                bounds.setWidth(bounds.width - shadowBorderSize);
-                bounds.setHeight(bounds.height - shadowBorderSize);
+                bounds.setPreciseWidth(bounds.preciseWidth() - shadowBorderSize);
+                bounds.setPreciseHeight(bounds.preciseHeight() - shadowBorderSize);
             }
         }
         return bounds;
@@ -689,7 +697,7 @@ public final class GMFHelper {
      * 
      * @return false for regions and workspace images, true otherwise.
      */
-    public static boolean isShadowBorderNeeded(Node node) {
+    private static boolean isShadowBorderNeeded(Node node) {
         boolean needShadowBorder = false;
         EObject element = node.getElement();
         if (element instanceof DDiagramElementContainer) {
@@ -714,7 +722,7 @@ public final class GMFHelper {
      * @param recursive
      *            true if this method is called from a "parent" call, false otherwise.
      */
-    private static void replaceAutoSize(Node node, Rectangle bounds, boolean useFigureForAutoSizeConstraint, Dimension providedDefaultSize, boolean recursive) {
+    private static void replaceAutoSize(Node node, PrecisionRectangle bounds, boolean useFigureForAutoSizeConstraint, Dimension providedDefaultSize, boolean recursive) {
         if (bounds.width == -1 || bounds.height == -1) {
             Dimension defaultSize = providedDefaultSize;
             if (providedDefaultSize == null) {
@@ -757,26 +765,29 @@ public final class GMFHelper {
                 // Compute the bounds of all children and use the lowest
                 // one (y+height) for height and the rightmost one
                 // (x+width) for width plus the margin.
-                Point bottomRight = getBottomRight(node, recursive);
+                Rectangle childrenBounds = getChildrenBounds(node, recursive);
+                // Add the potential shadow border size and the bottom right insets of the node (i.e. container)
                 double shadowBorderSize = getShadowBorderSize(node);
-                Dimension topLeftInsets = getTopLeftInsets(node);
                 Dimension bottomRightInsets = getBottomRightInsets(node);
-                if (!recursive) {
-                    bottomRight.setX(bottomRight.x + Double.valueOf(shadowBorderSize).intValue() + topLeftInsets.width() + bottomRightInsets.width());
-                    bottomRight.setY(bottomRight.y + Double.valueOf(shadowBorderSize).intValue() + topLeftInsets.height() + bottomRightInsets.height());
-                }
+                // Do not add bottom right insets and shadow if there is at least one border node on the corresponding
+                // side
+                int borderNodesSides = getBorderNodesSides(node, childrenBounds);
+                boolean isBorderNodeOnRightSide = recursive && (PositionConstants.RIGHT & borderNodesSides) == PositionConstants.RIGHT;
+                boolean isBorderNodeOnBottomSide = recursive && (PositionConstants.BOTTOM & borderNodesSides) == PositionConstants.BOTTOM;
+                childrenBounds.resize(isBorderNodeOnRightSide ? 0 : bottomRightInsets.width() + shadowBorderSize, isBorderNodeOnBottomSide ? 0 : bottomRightInsets.height() + shadowBorderSize);
+                // Replace -1 by the new computed values
                 if (bounds.width == -1) {
-                    if (bottomRight.x > defaultSize.width) {
-                        bounds.setWidth(bottomRight.x);
-                    } else {
-                        bounds.setWidth(defaultSize.width);
+                    bounds.setPreciseWidth(defaultSize.preciseWidth());
+                    double deltaWidth = childrenBounds.getRight().preciseX() - bounds.getRight().preciseX();
+                    if (deltaWidth > 0) {
+                        bounds.resize(deltaWidth, 0);
                     }
                 }
                 if (bounds.height == -1) {
-                    if (bottomRight.y > defaultSize.height) {
-                        bounds.setHeight(bottomRight.y);
-                    } else {
-                        bounds.setHeight(defaultSize.height);
+                    bounds.setPreciseHeight(defaultSize.preciseHeight());
+                    double deltaHeight = childrenBounds.getBottom().preciseY() - bounds.getBottom().preciseY();
+                    if (deltaHeight > 0) {
+                        bounds.resize(0, deltaHeight);
                     }
                 }
             }
@@ -788,6 +799,29 @@ public final class GMFHelper {
                 bounds.setHeight(defaultSize.height);
             }
         }
+    }
+
+    private static int getBorderNodesSides(Node container, Rectangle containerChildrenBounds) {
+        int result = PositionConstants.NONE;
+        for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
+            Node child = children.next();
+            if (new NodeQuery(child).isBorderedNode()) {
+                Rectangle borderNodeBounds = getAbsoluteBounds(child, true);
+                if (borderNodeBounds.preciseX() == containerChildrenBounds.preciseX()) {
+                    result = result | PositionConstants.LEFT;
+                }
+                if (borderNodeBounds.preciseY() == containerChildrenBounds.preciseY()) {
+                    result = result | PositionConstants.TOP;
+                }
+                if (borderNodeBounds.preciseX() + borderNodeBounds.preciseWidth() == containerChildrenBounds.preciseX() + containerChildrenBounds.preciseWidth()) {
+                    result = result | PositionConstants.RIGHT;
+                }
+                if (borderNodeBounds.preciseY() + borderNodeBounds.preciseHeight() == containerChildrenBounds.preciseY() + containerChildrenBounds.preciseHeight()) {
+                    result = result | PositionConstants.BOTTOM;
+                }
+            }
+        }
+        return result;
     }
 
     private static void lookForNextRegionLocation(Rectangle bounds, Node node) {
@@ -832,32 +866,33 @@ public final class GMFHelper {
      * Returns a new Point representing the bottom right point of all bounds of children of this Node. Useful for Node
      * with size of -1x-1 to be more accurate (but it is still not necessarily the same size that draw2d).
      * 
-     * @param node
+     * @param container
      *            the node whose bottom right corner is to compute.
      * @param considerBorderNode
      *            true to consider border nodes when computing the bottom right corner point, false otherwise.
      * 
      * @return Point at the bottom right of the rectangle
      */
-    private static Point getBottomRight(Node node, boolean considerBorderNodes) {
-        int right = 0;
-        int bottom = 0;
-        for (Iterator<Node> children = Iterators.filter(node.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
+    private static Rectangle getChildrenBounds(Node container, boolean considerBorderNodes) {
+        Rectangle result = null;
+        if (container.getChildren().isEmpty()) {
+            result = new PrecisionRectangle();
+        }
+        for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
             Node child = children.next();
             // The border nodes are ignored, except if it is expected to consider it (auto-size of a container with
             // children having border nodes)
             if (considerBorderNodes || !(new NodeQuery(child).isBorderedNode())) {
-                Rectangle bounds = getBounds(child, false, false, false, true);
-                Point bottomRight = bounds.getBottomRight();
-                if (bottomRight.x > right) {
-                    right = bottomRight.x;
-                }
-                if (bottomRight.y > bottom) {
-                    bottom = bottomRight.y;
+                Rectangle childAbsoluteBounds = getAbsoluteBounds(child, true, false, true);
+                if (result == null) {
+                    result = childAbsoluteBounds.getCopy();
+                } else {
+                    // Make union of the child bounds and its parent bounds
+                    result.union(childAbsoluteBounds);
                 }
             }
         }
-        return new Point(right, bottom);
+        return result;
     }
 
     private static Dimension getDefaultSize(AbstractDNode abstractDNode) {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -132,6 +133,8 @@ public final class GMFHelper {
      * (org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.SiriusWrapLabel.getIconTextGap()).
      */
     private static final int ICON_TEXT_GAP = 3;
+
+    private static Map<Node, Rectangle> boundsCache = new HashMap<>();
 
     private GMFHelper() {
         // Helper to not instantiate
@@ -616,9 +619,21 @@ public final class GMFHelper {
      * @return the absolute bounds of the node relative to the origin (Diagram)
      */
     public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection, boolean recursiveGetBounds) {
-        Point location = getAbsoluteLocation(node, insetsAware);
-        Rectangle bounds = getBounds(node, false, false, boxForConnection, recursiveGetBounds, location);
-        return new PrecisionRectangle(location.preciseX(), location.preciseY(), bounds.preciseWidth(), bounds.preciseHeight());
+        if (!recursiveGetBounds) {
+            boundsCache.clear();
+        }
+        Rectangle result;
+        if (boundsCache.containsKey(node)) {
+            result = boundsCache.get(node);
+        } else {
+            Point location = getAbsoluteLocation(node, insetsAware);
+            Rectangle bounds = getBounds(node, false, false, boxForConnection, recursiveGetBounds, location);
+            result = new PrecisionRectangle(location.preciseX(), location.preciseY(), bounds.preciseWidth(), bounds.preciseHeight());
+            if (recursiveGetBounds) {
+                boundsCache.put(node, result);
+            }
+        }
+        return result.getCopy();
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -40,6 +40,7 @@ import org.eclipse.emf.edit.ui.provider.ExtendedImageRegistry;
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.figures.ResizableCompartmentFigure;
 import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor;
 import org.eclipse.gmf.runtime.gef.ui.figures.NodeFigure;
 import org.eclipse.gmf.runtime.notation.Bounds;
@@ -700,7 +701,8 @@ public final class GMFHelper {
     private static boolean isShadowBorderNeeded(Node node) {
         boolean needShadowBorder = false;
         EObject element = node.getElement();
-        if (element instanceof DDiagramElementContainer) {
+        ViewQuery viewQuery = new ViewQuery(node);
+        if (!viewQuery.isFreeFormCompartment() && element instanceof DDiagramElementContainer) {
             DDiagramElementContainer ddec = (DDiagramElementContainer) element;
             needShadowBorder = !(new DDiagramElementContainerExperimentalQuery(ddec).isRegion() || ddec.getOwnedStyle() instanceof WorkspaceImage);
         }
@@ -729,7 +731,9 @@ public final class GMFHelper {
                 // if there is no default size, we compute it from the given
                 // node.
                 EObject element = node.getElement();
-                if (element instanceof AbstractDNode) {
+                if (new ViewQuery(node).isFreeFormCompartment()) {
+                    defaultSize = new Dimension(ResizableCompartmentFigure.MIN_CLIENT_DP, ResizableCompartmentFigure.MIN_CLIENT_DP);
+                } else if (element instanceof AbstractDNode) {
                     defaultSize = getDefaultSize((AbstractDNode) element);
                 }
             }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -276,11 +276,10 @@ public final class GMFHelper {
         NodeQuery nodeQuery = new NodeQuery(container);
         if (nodeQuery.isContainer()) {
             EObject element = container.getElement();
-            if (element instanceof DDiagramElementContainer) {
-                DDiagramElementContainer ddec = (DDiagramElementContainer) element;
+            if (element instanceof DDiagramElementContainer ddec) {
                 // RegionContainer do not have containers insets
-                if (ddec instanceof DNodeContainer) {
-                    if (new DNodeContainerExperimentalQuery((DNodeContainer) ddec).isRegionContainer()) {
+                if (ddec instanceof DNodeContainer dNodeContainer) {
+                    if (new DNodeContainerExperimentalQuery(dNodeContainer).isRegionContainer()) {
                         result.setHeight(HV_STACK_CONTAINER_INSETS.top);
                     } else if (hasFullLabelBorder(ddec)) {
                         result.setHeight(FREEFORM_CONTAINER_INSETS.top);
@@ -332,8 +331,7 @@ public final class GMFHelper {
     public static Dimension getContainerTopLeftInsets(Node node, boolean searchFirstParentContainer) {
         Dimension result = new Dimension(0, 0);
         EObject nodeContainer = node.eContainer();
-        if (nodeContainer instanceof Node) {
-            Node parentNode = (Node) nodeContainer;
+        if (nodeContainer instanceof Node parentNode) {
             NodeQuery nodeQuery = new NodeQuery(parentNode);
             if (nodeQuery.isContainer() || nodeQuery.isListCompartment() || nodeQuery.isRegionContainerCompartment()) {
                 result = getTopLeftInsets(parentNode);
@@ -357,11 +355,10 @@ public final class GMFHelper {
         NodeQuery nodeQuery = new NodeQuery(container);
         if (nodeQuery.isContainer()) {
             EObject element = container.getElement();
-            if (element instanceof DDiagramElementContainer) {
-                DDiagramElementContainer ddec = (DDiagramElementContainer) element;
+            if (element instanceof DDiagramElementContainer ddec) {
                 // RegionContainer do not have containers insets
-                if (ddec instanceof DNodeContainer) {
-                    if (new DNodeContainerExperimentalQuery((DNodeContainer) ddec).isRegionContainer()) {
+                if (ddec instanceof DNodeContainer dNodeContainer) {
+                    if (new DNodeContainerExperimentalQuery(dNodeContainer).isRegionContainer()) {
                         result.setWidth(LIST_CONTAINER_INSETS.right);
                         result.setHeight(LIST_CONTAINER_INSETS.bottom);
                         // TODO: to verify
@@ -420,16 +417,15 @@ public final class GMFHelper {
     public static Dimension getContainerTopLeftInsetsAfterLabel(Node node, boolean searchFirstParentContainer) {
         Dimension result = new Dimension(0, 0);
         EObject nodeContainer = node.eContainer();
-        if (nodeContainer instanceof Node) {
-            Node parentNode = (Node) nodeContainer;
+        if (nodeContainer instanceof Node parentNode) {
             NodeQuery nodeQuery = new NodeQuery(parentNode);
             if (nodeQuery.isContainer()) {
                 EObject element = parentNode.getElement();
-                if (element instanceof DDiagramElementContainer) {
+                if (element instanceof DDiagramElementContainer dDiagramElementContainer) {
                     result.setWidth(FREEFORM_CONTAINER_INSETS.left);
                     result.setHeight(FREEFORM_CONTAINER_INSETS.top);
 
-                    Dimension borderSize = getBorderSize((DDiagramElementContainer) element);
+                    Dimension borderSize = getBorderSize(dDiagramElementContainer);
                     result.setWidth(result.width() + borderSize.width());
                     result.setHeight(result.height() + borderSize.height());
                 }
@@ -481,11 +477,9 @@ public final class GMFHelper {
         // Border nodes are not concerned by those insets.
         if (!nodeQuery.isBorderedNode()) {
             locationToTranslate.translate(getContainerTopLeftInsets(currentNode, false));
-            if (currentNode.eContainer() instanceof Node container) {
-                if (new ViewQuery(currentNode).isListItem() && container.getChildren().get(0) == currentNode) {
-                    // This is the first list item, add a one margin border over it.
-                    locationToTranslate.translate(0, 1);
-                }
+            if (currentNode.eContainer() instanceof Node container && new ViewQuery(currentNode).isListItem() && container.getChildren().get(0) == currentNode) {
+                // This is the first list item, add a one margin border over it.
+                locationToTranslate.translate(0, 1);
             }
         }
     }
@@ -497,8 +491,8 @@ public final class GMFHelper {
 
     private static boolean isFirstRegion(DDiagramElementContainer ddec) {
         EObject potentialRegionContainer = ddec.eContainer();
-        if (potentialRegionContainer instanceof DNodeContainer) {
-            Iterable<DDiagramElementContainer> regions = Iterables.filter(((DNodeContainer) potentialRegionContainer).getOwnedDiagramElements(), DDiagramElementContainer.class);
+        if (potentialRegionContainer instanceof DNodeContainer dNodeContainer) {
+            Iterable<DDiagramElementContainer> regions = Iterables.filter((dNodeContainer).getOwnedDiagramElements(), DDiagramElementContainer.class);
             return !Iterables.isEmpty(regions) && ddec == Iterables.getFirst(regions, null);
         }
         return false;
@@ -533,14 +527,12 @@ public final class GMFHelper {
 
     private static void centerLocationIfZero(Point location, int position, Bounds parentBounds, Bounds gmfBounds) {
         switch (position) {
-        case PositionConstants.NORTH:
-        case PositionConstants.SOUTH:
+        case PositionConstants.NORTH, PositionConstants.SOUTH:
             if (location.x == 0) {
                 location.setX(location.x + (parentBounds.getWidth() - gmfBounds.getWidth()) / 2);
             }
             break;
-        case PositionConstants.WEST:
-        case PositionConstants.EAST:
+        case PositionConstants.WEST, PositionConstants.EAST:
             if (location.y == 0) {
                 location.setY(location.y + (parentBounds.getHeight() - gmfBounds.getHeight()) / 2);
             }
@@ -549,56 +541,6 @@ public final class GMFHelper {
             break;
         }
     }
-    //
-    // /**
-    // * Get the absolute bounds relative to the origin (Diagram).
-    // *
-    // * @param node
-    // * the GMF Node
-    // * @param adaptBorderNodeLocation
-    // * Useful for specific border nodes, like in sequence diagrams, to center the border nodes if the
-    // * coordinate is 0 (x for EAST or WEST side, y for NORTH or SOUTH side)
-    // *
-    // * @return the absolute bounds of the node relative to the origin (Diagram)
-    // */
-    // public static Rectangle getAbsoluteBounds(Node node, boolean adaptBorderNodeLocation) {
-    // return getAbsoluteBounds(node, false, false, false, adaptBorderNodeLocation);
-    // }
-    // /**
-    // * Get the absolute bounds relative to the origin (Diagram).
-    // *
-    // * @param node
-    // * the GMF Node
-    // * @param insetsAware
-    // * true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
-    // * current Sirius editParts and could become wrong if a developer customizes them.
-    // * @param adaptBorderNodeLocation
-    // * Useful for specific border nodes, like in sequence diagrams, to center the border nodes if the
-    // * coordinate is 0 (x for EAST or WEST side, y for NORTH or SOUTH side)
-    // *
-    // * @return the absolute bounds of the node relative to the origin (Diagram)
-    // */
-    // public static Rectangle getAbsoluteBounds2(Node node, boolean insetsAware, boolean adaptBorderNodeLocation) {
-    // return getAbsoluteBounds(node, insetsAware, false, false, adaptBorderNodeLocation);
-    // }
-    //
-    // /**
-    // * Get the absolute bounds relative to the origin (Diagram).
-    // *
-    // * @param node
-    // * the GMF Node
-    // * @param insetsAware
-    // * true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
-    // * current Sirius editParts and could become wrong if a developer customizes them.
-    // * @param boxForConnection
-    // * true if we want to have the bounds used to compute connection anchor from source or target, false
-    // * otherwise
-    // * @return the absolute bounds of the node relative to the origin (Diagram)
-    // */
-    // public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection, boolean
-    // adaptBorderNodeLocation) {
-    // return getAbsoluteBounds(node, insetsAware, boxForConnection, false, adaptBorderNodeLocation);
-    // }
 
     /**
      * Get the absolute bounds relative to the origin (Diagram).
@@ -789,11 +731,10 @@ public final class GMFHelper {
         PrecisionRectangle bounds = new PrecisionRectangle(computedAbsoluteLocation.preciseX(), computedAbsoluteLocation.preciseY(), 0, 0);
         LayoutConstraint layoutConstraint = node.getLayoutConstraint();
         EObject element = node.getElement();
-        if (element instanceof AbstractDNode) {
-            AbstractDNode abstractDNode = (AbstractDNode) element;
-            if (layoutConstraint instanceof Size) {
-                bounds.setWidth(((Size) layoutConstraint).getWidth());
-                bounds.setHeight(((Size) layoutConstraint).getHeight());
+        if (element instanceof AbstractDNode abstractDNode) {
+            if (layoutConstraint instanceof Size size) {
+                bounds.setWidth(size.getWidth());
+                bounds.setHeight(size.getHeight());
             } else {
                 bounds.setWidth(-1);
                 bounds.setHeight(-1);
@@ -857,8 +798,7 @@ public final class GMFHelper {
         boolean needShadowBorder = false;
         EObject element = node.getElement();
         ViewQuery viewQuery = new ViewQuery(node);
-        if (!viewQuery.isFreeFormCompartment() && !viewQuery.isListCompartment() && !viewQuery.isForNameEditPart() && element instanceof DDiagramElementContainer) {
-            DDiagramElementContainer ddec = (DDiagramElementContainer) element;
+        if (!viewQuery.isFreeFormCompartment() && !viewQuery.isListCompartment() && !viewQuery.isForNameEditPart() && element instanceof DDiagramElementContainer ddec) {
             needShadowBorder = !(new DDiagramElementContainerExperimentalQuery(ddec).isRegion() || ddec.getOwnedStyle() instanceof WorkspaceImage);
         }
         return needShadowBorder;
@@ -889,14 +829,12 @@ public final class GMFHelper {
                 ViewQuery nodeQuery = new ViewQuery(node);
                 if (nodeQuery.isFreeFormCompartment() || nodeQuery.isListCompartment()) {
                     defaultSize = new Dimension(ResizableCompartmentFigure.MIN_CLIENT_DP, ResizableCompartmentFigure.MIN_CLIENT_DP);
-                    if (node.getChildren().isEmpty()) {
-                        if (nodeQuery.isListCompartment() || nodeQuery.isVerticalRegionContainerCompartment() || nodeQuery.isHorizontalRegionContainerCompartment()) {
-                            // Add one margin border (even if empty)
-                            defaultSize.expand(0, 1);
-                        }
+                    if (node.getChildren().isEmpty() && (nodeQuery.isListCompartment() || nodeQuery.isVerticalRegionContainerCompartment() || nodeQuery.isHorizontalRegionContainerCompartment())) {
+                        // Add one margin border (even if empty)
+                        defaultSize.expand(0, 1);
                     }
-                } else if (element instanceof AbstractDNode) {
-                    defaultSize = getDefaultSize((AbstractDNode) element);
+                } else if (element instanceof AbstractDNode abstractDNode) {
+                    defaultSize = getDefaultSize(abstractDNode);
                 }
             }
             if (useFigureForAutoSizeConstraint) {
@@ -906,8 +844,8 @@ public final class GMFHelper {
                 // CHECKSTYLE:OFF
                 if (optionalTargetEditPart.some()) {
                     GraphicalEditPart graphicalEditPart = optionalTargetEditPart.get();
-                    if (graphicalEditPart instanceof AbstractDiagramElementContainerEditPart) {
-                        ((AbstractDiagramElementContainerEditPart) graphicalEditPart).forceFigureAutosize();
+                    if (graphicalEditPart instanceof AbstractDiagramElementContainerEditPart abstractDiagramElementContainerEditPart) {
+                        abstractDiagramElementContainerEditPart.forceFigureAutosize();
                         ((GraphicalEditPart) graphicalEditPart.getParent()).getFigure().validate();
                     }
 
@@ -995,18 +933,16 @@ public final class GMFHelper {
 
     private static void lookForNextRegionLocation(Rectangle bounds, Node node) {
         EObject element = node.getElement();
-        if (element instanceof DDiagramElementContainer && node.eContainer() instanceof Node) {
-            DDiagramElementContainer ddec = (DDiagramElementContainer) element;
+        if (element instanceof DDiagramElementContainer ddec && node.eContainer() instanceof Node nodeContainer) {
             DDiagramElementContainerExperimentalQuery query = new DDiagramElementContainerExperimentalQuery(ddec);
             boolean isRegion = query.isRegion();
-            EList children = ((Node) node.eContainer()).getChildren();
+            EList children = nodeContainer.getChildren();
             int currentIndex = children.indexOf(node);
             if (!(currentIndex != 0 && bounds.equals(new Rectangle(0, 0, -1, -1)))) {
                 // We are not in the case of a new region insertion (in this
                 // case, we use the default size)
                 int nextIndex = currentIndex + 1;
-                if (isRegion && nextIndex != 0 && nextIndex < children.size() && children.get(nextIndex) instanceof Node) {
-                    Node nextNode = (Node) children.get(nextIndex);
+                if (isRegion && nextIndex != 0 && nextIndex < children.size() && children.get(nextIndex) instanceof Node nextNode) {
                     int visualID = SiriusVisualIDRegistry.getVisualID(nextNode.getType());
                     if (DNodeContainer2EditPart.VISUAL_ID == visualID || DNodeListEditPart.VISUAL_ID == visualID || DNodeList2EditPart.VISUAL_ID == visualID) {
                         // DNodeContainerEditPart.VISUAL_ID == visualID is not
@@ -1014,8 +950,7 @@ public final class GMFHelper {
                         // DNodeContainerEditPart as it is directly contained by
                         // the diagram part.
                         LayoutConstraint layoutConstraint = nextNode.getLayoutConstraint();
-                        if (layoutConstraint instanceof Location) {
-                            Location nextLocation = (Location) layoutConstraint;
+                        if (layoutConstraint instanceof Location nextLocation) {
                             // Update only the parent stack direction if some
                             // layout has already been done.
                             if (bounds.width == -1 && query.isRegionInHorizontalStack() && nextLocation.getX() != 0) {
@@ -1084,10 +1019,10 @@ public final class GMFHelper {
 
     private static Dimension getDefaultSize(AbstractDNode abstractDNode) {
         Dimension defaultSize = new Dimension(-1, -1);
-        if (abstractDNode instanceof DNode) {
-            defaultSize = new DNodeQuery((DNode) abstractDNode).getDefaultDimension();
-        } else if (abstractDNode instanceof DNodeContainer) {
-            defaultSize = new DNodeContainerQuery((DNodeContainer) abstractDNode).getDefaultDimension();
+        if (abstractDNode instanceof DNode dNode) {
+            defaultSize = new DNodeQuery(dNode).getDefaultDimension();
+        } else if (abstractDNode instanceof DNodeContainer dNodeContainer) {
+            defaultSize = new DNodeContainerQuery(dNodeContainer).getDefaultDimension();
         } else if (abstractDNode instanceof DNodeList) {
             defaultSize = LayoutUtils.NEW_DEFAULT_CONTAINER_DIMENSION;
         }
@@ -1109,10 +1044,10 @@ public final class GMFHelper {
             IEditorPart editor = EclipseUIUtil.getActiveEditor();
             if (isEditorFor(editor, gmfDiagram)) {
                 return getGraphicalEditPart(view, (DiagramEditor) editor);
-            } else if (gmfDiagram.getElement() instanceof DDiagram) {
+            } else if (gmfDiagram.getElement() instanceof DDiagram dDiagram) {
                 // Otherwise check all active Sirius editors
                 for (IEditingSession uiSession : SessionUIManager.INSTANCE.getUISessions()) {
-                    DialectEditor dialectEditor = uiSession.getEditor((DDiagram) gmfDiagram.getElement());
+                    DialectEditor dialectEditor = uiSession.getEditor(dDiagram);
                     if (isEditorFor(dialectEditor, gmfDiagram)) {
                         return getGraphicalEditPart(view, (DiagramEditor) dialectEditor);
                     }
@@ -1123,7 +1058,7 @@ public final class GMFHelper {
     }
 
     private static boolean isEditorFor(IEditorPart editor, Diagram diagram) {
-        return editor instanceof DiagramEditor && ((DiagramEditor) editor).getDiagram() == diagram;
+        return editor instanceof DiagramEditor diagramEditor && diagramEditor.getDiagram() == diagram;
     }
 
     /**
@@ -1140,8 +1075,8 @@ public final class GMFHelper {
         Option<GraphicalEditPart> result = Options.newNone();
         final Map<?, ?> editPartRegistry = editor.getDiagramGraphicalViewer().getEditPartRegistry();
         final EditPart targetEditPart = (EditPart) editPartRegistry.get(view);
-        if (targetEditPart instanceof GraphicalEditPart) {
-            result = Options.newSome((GraphicalEditPart) targetEditPart);
+        if (targetEditPart instanceof GraphicalEditPart graphicalEditPart) {
+            result = Options.newSome(graphicalEditPart);
         }
         return result;
     }
@@ -1156,10 +1091,8 @@ public final class GMFHelper {
      *             when the edgeEditPart is not as expected
      */
     public static List<Point> getPointsFromSource(ConnectionEditPart edgeEditPart) throws IllegalArgumentException {
-        if (edgeEditPart.getModel() instanceof Edge && edgeEditPart.getFigure() instanceof Connection) {
+        if (edgeEditPart.getModel() instanceof Edge gmfEdge && edgeEditPart.getFigure() instanceof Connection connectionFigure) {
             List<Point> result = new ArrayList<>();
-            Edge gmfEdge = (Edge) edgeEditPart.getModel();
-            Connection connectionFigure = (Connection) edgeEditPart.getFigure();
             Point srcAnchorLoc = connectionFigure.getSourceAnchor().getReferencePoint();
             connectionFigure.translateToRelative(srcAnchorLoc);
 
@@ -1184,10 +1117,8 @@ public final class GMFHelper {
      *             when the edgeEditPart is not as expected
      */
     public static List<Point> getPointsFromTarget(ConnectionEditPart edgeEditPart) throws IllegalArgumentException {
-        if (edgeEditPart.getModel() instanceof Edge && edgeEditPart.getFigure() instanceof Connection) {
+        if (edgeEditPart.getModel() instanceof Edge gmfEdge && edgeEditPart.getFigure() instanceof Connection connectionFigure) {
             List<Point> result = new ArrayList<>();
-            Edge gmfEdge = (Edge) edgeEditPart.getModel();
-            Connection connectionFigure = (Connection) edgeEditPart.getFigure();
             Point tgtAnchorLoc = connectionFigure.getTargetAnchor().getReferencePoint();
             connectionFigure.translateToRelative(tgtAnchorLoc);
 
@@ -1216,35 +1147,31 @@ public final class GMFHelper {
         Dimension labelSize = defaultDimension;
         ViewQuery viewQuery = new ViewQuery(node);
         EObject element = node.getElement();
-        if (element instanceof DDiagramElement) {
-            DDiagramElement dDiagramElement = (DDiagramElement) element;
+        if (element instanceof DDiagramElement dDiagramElement) {
             org.eclipse.sirius.viewpoint.Style siriusStyle = dDiagramElement.getStyle();
-            if (!new DDiagramElementQuery(dDiagramElement).isLabelHidden()) {
-                if (siriusStyle instanceof BasicLabelStyle) {
-                    BasicLabelStyle bls = (BasicLabelStyle) siriusStyle;
-                    String fontName = (String) viewQuery.getDefaultValue(NotationPackage.Literals.FONT_STYLE__FONT_NAME);
-                    Optional<Style> optionalStyle = getFontStyleOf(node);
-                    if (optionalStyle.isPresent() && optionalStyle.get() instanceof FontStyle) {
-                        String currentFontName = ((FontStyle) optionalStyle.get()).getFontName();
-                        if (currentFontName != null && !currentFontName.isEmpty()) {
-                            // Use the defined font name in the node if it is defined.
-                            fontName = currentFontName;
-                        }
+            if (!new DDiagramElementQuery(dDiagramElement).isLabelHidden() && siriusStyle instanceof BasicLabelStyle bls) {
+                String fontName = (String) viewQuery.getDefaultValue(NotationPackage.Literals.FONT_STYLE__FONT_NAME);
+                Optional<Style> optionalStyle = getFontStyleOf(node);
+                if (optionalStyle.isPresent() && optionalStyle.get() instanceof FontStyle fontStyle) {
+                    String currentFontName = fontStyle.getFontName();
+                    if (currentFontName != null && !currentFontName.isEmpty()) {
+                        // Use the defined font name in the node if it is defined.
+                        fontName = currentFontName;
                     }
-                    Font defaultFont = VisualBindingManager.getDefault().getFontFromLabelStyle(bls, fontName);
-                    try {
-                        labelSize = FigureUtilities.getStringExtents(dDiagramElement.getName(), defaultFont);
-                        if (bls.isShowIcon()) {
-                            // Also consider the icon size
-                            Dimension iconDimension = getIconDimension(dDiagramElement, bls);
-                            labelSize.setHeight(Math.max(labelSize.height(), iconDimension.height));
-                            labelSize.setWidth(labelSize.width() + ICON_TEXT_GAP + iconDimension.width);
-                        }
-                    } catch (SWTException e) {
-                        // Probably an "Invalid thread access" (FigureUtilities
-                        // creates a new Shell to compute the label size). So in
-                        // this case, we use the default size.
+                }
+                Font defaultFont = VisualBindingManager.getDefault().getFontFromLabelStyle(bls, fontName);
+                try {
+                    labelSize = FigureUtilities.getStringExtents(dDiagramElement.getName(), defaultFont);
+                    if (bls.isShowIcon()) {
+                        // Also consider the icon size
+                        Dimension iconDimension = getIconDimension(dDiagramElement, bls);
+                        labelSize.setHeight(Math.max(labelSize.height(), iconDimension.height));
+                        labelSize.setWidth(labelSize.width() + ICON_TEXT_GAP + iconDimension.width);
                     }
+                } catch (SWTException e) {
+                    // Probably an "Invalid thread access" (FigureUtilities
+                    // creates a new Shell to compute the label size). So in
+                    // this case, we use the default size.
                 }
             }
         }
@@ -1367,9 +1294,14 @@ public final class GMFHelper {
         List<Edge> noteAttachments = getIncomingOutgoingEdges(view).stream() //
                 .filter(GMFNotationHelper::isNoteAttachment).toList();
 
-        return noteAttachments.stream().flatMap(edge -> {
-            return Stream.of(edge.getSource(), edge.getTarget());
-        }).filter(attachedView -> { // all nodes linked to note attachment: filter notes/texts
+        return noteAttachments.stream().flatMap(edge -> Stream.of(edge.getSource(), edge.getTarget())).filter(attachedView -> { // all
+                                                                                                                                // nodes
+                                                                                                                                // linked
+                                                                                                                                // to
+                                                                                                                                // note
+                                                                                                                                // attachment:
+                                                                                                                                // filter
+                                                                                                                                // notes/texts
             if (attachedView instanceof Node attachedNode) {
                 return GMFNotationHelper.isNote(attachedNode) || GMFNotationHelper.isTextNote(attachedNode);
             } else {
@@ -1406,10 +1338,10 @@ public final class GMFHelper {
                     .filter(edge -> edge.eContainer() != null).toList();
 
             // remove unattached notes/texts
-            if (validEdges.size() == 0) {
+            if (validEdges.isEmpty()) {
                 EcoreUtil.remove(pureGraphicalElement);
             } else {
-                Stream<Edge> visibleEdges = validEdges.stream().filter(edge -> edge.isVisible());
+                Stream<Edge> visibleEdges = validEdges.stream().filter(View::isVisible);
 
                 // hide notes/texts attached to invisible element
                 if (visibleEdges.count() == 0) {
@@ -1445,9 +1377,7 @@ public final class GMFHelper {
 
             // Filter on edges by visibility attribute and excluded edges
             // Return node with none attached edges (except excluded edges or hidden edges)
-            return edges.noneMatch(edge -> {
-                return edge.isVisible() && !excludedEdges.contains(edge);
-            });
+            return edges.noneMatch(edge -> edge.isVisible() && !excludedEdges.contains(edge));
         }).toList();
     }
 }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -163,6 +163,38 @@ public final class GMFHelper {
     }
 
     /**
+     * Return the top-left insets of this <code>container</code>. The insets also considers its border.
+     * 
+     * @param container
+     *            The container for which we wish to have the insets. This {@link Node} must correspond to a container,
+     *            otherwise, {0,0} is returned
+     * @return the top-left insets of this <code>container</code>
+     */
+    public static Dimension getTopLeftInsets(Node container) {
+        Dimension result = new Dimension(0, 0);
+        NodeQuery nodeQuery = new NodeQuery(container);
+        if (nodeQuery.isContainer()) {
+            EObject element = container.getElement();
+            if (element instanceof DDiagramElementContainer) {
+                DDiagramElementContainer ddec = (DDiagramElementContainer) element;
+                // RegionContainer do not have containers insets
+                if (ddec instanceof DNodeContainer) {
+                    if (new DNodeContainerExperimentalQuery((DNodeContainer) ddec).isRegionContainer() || hasFullLabelBorder(ddec)) {
+                        result.setHeight(CONTAINER_INSETS.y + getLabelSize(container) + AbstractDiagramElementContainerEditPart.DEFAULT_SPACING);
+                    } else {
+                        result.setWidth(CONTAINER_INSETS.x);
+                        result.setHeight(CONTAINER_INSETS.y);
+                    }
+                }
+                Dimension borderSize = getBorderSize(ddec);
+                result.setWidth(result.width() + borderSize.width());
+                result.setHeight(result.height() + borderSize.height());
+            }
+        }
+        return result;
+    }
+
+    /**
      * Return the top-left insets of the container of this <code>node</code>. The insets also considers its border.
      * 
      * @param node
@@ -179,22 +211,7 @@ public final class GMFHelper {
             Node parentNode = (Node) nodeContainer;
             NodeQuery nodeQuery = new NodeQuery(parentNode);
             if (nodeQuery.isContainer()) {
-                EObject element = parentNode.getElement();
-                if (element instanceof DDiagramElementContainer) {
-                    DDiagramElementContainer ddec = (DDiagramElementContainer) element;
-                    // RegionContainer do not have containers insets
-                    if (ddec instanceof DNodeContainer) {
-                        if (new DNodeContainerExperimentalQuery((DNodeContainer) ddec).isRegionContainer() || hasFullLabelBorder(ddec)) {
-                            result.setHeight(CONTAINER_INSETS.y + getLabelSize(parentNode) + AbstractDiagramElementContainerEditPart.DEFAULT_SPACING);
-                        } else {
-                            result.setWidth(CONTAINER_INSETS.x);
-                            result.setHeight(CONTAINER_INSETS.y);
-                        }
-                    }
-                    Dimension borderSize = getBorderSize(ddec);
-                    result.setWidth(result.width() + borderSize.width());
-                    result.setHeight(result.height() + borderSize.height());
-                }
+                result = getTopLeftInsets(parentNode);
             } else if (searchFirstParentContainer) {
                 result = getContainerTopLeftInsets(parentNode, searchFirstParentContainer);
             }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -166,11 +166,13 @@ public final class GMFHelper {
 
         Point location = new Point(0, 0);
         LayoutConstraint layoutConstraint = node.getLayoutConstraint();
-        if (layoutConstraint instanceof Bounds && !(new ViewQuery(node).isRegion())) {
+        if (layoutConstraint instanceof Bounds gmfBounds && !(new ViewQuery(node).isRegion())) {
             // The bounds is computed for horizontal or vertical regions, even if it is stored in GMF data
-            Bounds gmfBounds = (Bounds) layoutConstraint;
             location.setX(gmfBounds.getX());
             location.setY(gmfBounds.getY());
+        }
+        ViewQuery viewQuery = new ViewQuery(node);
+        if (viewQuery.isBorderedNode() && layoutConstraint instanceof Bounds gmfBounds) {
             // manage location of bordered node with closest side
             if (node.getElement() instanceof DNode dNode && dNode.eContainer() instanceof AbstractDNode parentAbstractDNode && parentAbstractDNode.getOwnedBorderedNodes().contains(dNode)) {
                 Node parentNode = (Node) node.eContainer();
@@ -181,7 +183,6 @@ public final class GMFHelper {
                 }
             }
         }
-        ViewQuery viewQuery = new ViewQuery(node);
         if (viewQuery.isListCompartment()) {
             // Translate the compartment to be just below the the title, the x coordinate is also the same (same parent
             // insets)
@@ -237,7 +238,7 @@ public final class GMFHelper {
                     Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true);
                     location.translate(previousChildBounds.preciseX() + previousChildBounds.preciseWidth(), previousChildBounds.preciseY());
                 }
-            } 
+            }
         } else if (node.eContainer() instanceof Node container) {
             Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
             location.translate(parentNodeLocation);
@@ -374,7 +375,7 @@ public final class GMFHelper {
                         result.setWidth(result.width() + borderSize.width());
                         result.setHeight(result.height() + borderSize.height());
                     } else if (new DDiagramElementContainerExperimentalQuery(ddec).isRegion()) {
-                     // No margin, except the border size
+                        // No margin, except the border size
                         Dimension borderSize = getBorderSize(ddec);
                         result.setWidth(result.width() + borderSize.width());
                         result.setHeight(result.height() + borderSize.height());
@@ -920,9 +921,12 @@ public final class GMFHelper {
                 Dimension bottomRightInsets = getBottomRightInsets(node);
                 // Do not add bottom right insets and shadow if there is at least one border node on the corresponding
                 // side
-                int borderNodesSides = getBorderNodesSides(node, childrenBounds);
-                boolean isBorderNodeOnRightSide = recursive && (PositionConstants.RIGHT & borderNodesSides) == PositionConstants.RIGHT;
-                boolean isBorderNodeOnBottomSide = recursive && (PositionConstants.BOTTOM & borderNodesSides) == PositionConstants.BOTTOM;
+                int borderNodesSides = PositionConstants.NONE;
+                if (recursive) {
+                    borderNodesSides = getBorderNodesSides(node, childrenBounds);
+                }
+                boolean isBorderNodeOnRightSide = (PositionConstants.RIGHT & borderNodesSides) == PositionConstants.RIGHT;
+                boolean isBorderNodeOnBottomSide = (PositionConstants.BOTTOM & borderNodesSides) == PositionConstants.BOTTOM;
                 childrenBounds.resize(isBorderNodeOnRightSide ? 0 : bottomRightInsets.width() + shadowBorderSize, isBorderNodeOnBottomSide ? 0 : bottomRightInsets.height() + shadowBorderSize);
                 // Replace -1 by the new computed values
                 if (bounds.width == -1) {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -103,9 +104,6 @@ import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IEditorPart;
-
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 
 /**
  * GMF Helper.
@@ -241,16 +239,18 @@ public final class GMFHelper {
         return location;
     }
 
-    private static Node getPreviousChild(Node node) {
+    private static Node getPreviousChild(Node searchedNode) {
         Node previousChild = null;
         boolean found = false;
-        if (node.eContainer() instanceof Node container) {
-            for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext() && !found; /* */) {
-                Node child = children.next();
-                if (node == child) {
-                    found = true;
-                } else {
-                    previousChild = child;
+        if (searchedNode.eContainer() instanceof Node container) {
+            for (Iterator<View> children = container.getChildren().iterator(); children.hasNext() && !found; /* */) {
+                View child = children.next();
+                if (child instanceof Node nodeChild) {
+                    if (searchedNode == nodeChild) {
+                        found = true;
+                    } else {
+                        previousChild = nodeChild;
+                    }
                 }
             }
         }
@@ -490,8 +490,8 @@ public final class GMFHelper {
     private static boolean isFirstRegion(DDiagramElementContainer ddec) {
         EObject potentialRegionContainer = ddec.eContainer();
         if (potentialRegionContainer instanceof DNodeContainer dNodeContainer) {
-            Iterable<DDiagramElementContainer> regions = Iterables.filter((dNodeContainer).getOwnedDiagramElements(), DDiagramElementContainer.class);
-            return !Iterables.isEmpty(regions) && ddec == Iterables.getFirst(regions, null);
+            Optional<DDiagramElement> optionalDDiagramElement = dNodeContainer.getOwnedDiagramElements().stream().filter(DDiagramElementContainer.class::isInstance).findFirst();
+            return optionalDDiagramElement.isPresent() && ddec == optionalDDiagramElement.get();
         }
         return false;
     }
@@ -908,10 +908,10 @@ public final class GMFHelper {
 
     private static int getBorderNodesSides(Node container, Rectangle containerChildrenBounds) {
         int result = PositionConstants.NONE;
-        for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
-            Node child = children.next();
-            if (new NodeQuery(child).isBorderedNode()) {
-                Rectangle borderNodeBounds = getAbsoluteBounds(child, true, false, false, false);
+        for (ListIterator<View> children = container.getChildren().listIterator(); children.hasNext(); /* */) {
+            View child = children.next();
+            if (child instanceof Node nodeChild && new NodeQuery(nodeChild).isBorderedNode()) {
+                Rectangle borderNodeBounds = getAbsoluteBounds(nodeChild, true, false, false, false);
                 if (borderNodeBounds.preciseX() == containerChildrenBounds.preciseX()) {
                     result = result | PositionConstants.LEFT;
                 }
@@ -987,11 +987,11 @@ public final class GMFHelper {
                 result = getAbsoluteBounds(lastChild, true, false, true, false);
             }
         } else {
-            for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
-                Node nodeChild = children.next();
+            for (ListIterator<View> children = container.getChildren().listIterator(); children.hasNext(); /* */) {
+                View child = children.next();
                 // The border nodes are ignored, except if it is expected to consider it (auto-size of a container with
                 // children having border nodes)
-                if (considerBorderNodes || !(new NodeQuery(nodeChild).isBorderedNode())) {
+                if (child instanceof Node nodeChild && (considerBorderNodes || !(new NodeQuery(nodeChild).isBorderedNode()))) {
                     Rectangle childAbsoluteBounds = getAbsoluteBounds(nodeChild, true, false, true, false);
                     if (result == null) {
                         result = childAbsoluteBounds.getCopy();

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -145,25 +145,16 @@ public final class GMFHelper {
      * 
      * @param node
      *            the GMF Node
-     * 
-     * @return the absolute location of the node relative to the origin (Diagram)
-     */
-    public static Point getAbsoluteLocation(Node node) {
-        return getAbsoluteLocation(node, false);
-    }
-
-    /**
-     * Get the absolute location relative to the origin (Diagram).
-     * 
-     * @param node
-     *            the GMF Node
      * @param insetsAware
      *            true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
      *            current Sirius editParts and could become wrong if a developer customizes them.
+     * @param adaptBorderNodeLocation
+     *            Useful for specific border nodes, like in sequence diagrams, to center the border nodes if the
+     *            coordinate is 0 (x for EAST or WEST side, y for NORTH or SOUTH side)
      * 
      * @return the absolute location of the node relative to the origin (Diagram)
      */
-    public static Point getAbsoluteLocation(Node node, boolean insetsAware) {
+    public static Point getAbsoluteLocation(Node node, boolean insetsAware, boolean adaptBorderNodeLocation) {
         // TODO: Location of title "DNode*NameEditPart", x coordinate, can be wrong according to label alignment. This
         // problem is not yet handled.
 
@@ -175,75 +166,75 @@ public final class GMFHelper {
             location.setY(gmfBounds.getY());
         }
         ViewQuery viewQuery = new ViewQuery(node);
-        if (viewQuery.isBorderedNode() && layoutConstraint instanceof Bounds gmfBounds) {
+        if (adaptBorderNodeLocation && viewQuery.isBorderedNode() && layoutConstraint instanceof Bounds gmfBounds) {
             // manage location of bordered node with closest side
             if (node.getElement() instanceof DNode dNode && dNode.eContainer() instanceof AbstractDNode parentAbstractDNode && parentAbstractDNode.getOwnedBorderedNodes().contains(dNode)) {
                 Node parentNode = (Node) node.eContainer();
                 if (parentNode.getLayoutConstraint() instanceof Bounds parentBounds) {
                     int position = CanonicalDBorderItemLocator.findClosestSideOfParent(new Rectangle(gmfBounds.getX(), gmfBounds.getY(), gmfBounds.getWidth(), gmfBounds.getHeight()),
                             new Rectangle(parentBounds.getX(), parentBounds.getY(), parentBounds.getWidth(), parentBounds.getHeight()));
-                    updateLocation(location, position, parentBounds, gmfBounds);
+                    centerLocationIfZero(location, position, parentBounds, gmfBounds);
                 }
             }
         }
         if (viewQuery.isListCompartment()) {
             // Translate the compartment to be just below the the title, the x coordinate is also the same (same parent
             // insets)
-            Rectangle titleBounds = getAbsoluteBounds(getPreviousChild(node), true);
+            Rectangle titleBounds = getAbsoluteBounds(getPreviousChild(node), true, false, false, false);
             location.translate(titleBounds.preciseX(), titleBounds.preciseY() + titleBounds.preciseHeight());
             // Translate from the spacing (5 pixels)
             location.translate(0, IContainerLabelOffsets.LABEL_OFFSET);
         } else if (viewQuery.isListItem()) {
             if (node.eContainer() instanceof Node container) {
                 if (container.getChildren().get(0) == node) {
-                    Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
+                    Point parentNodeLocation = getAbsoluteLocation(container, insetsAware, false);
                     location.translate(parentNodeLocation);
                     if (insetsAware) {
                         translateWithInsets(location, node);
                     }
                 } else {
                     // Translate from the previous children
-                    Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true);
+                    Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true, false, false, false);
                     location.translate(previousChildBounds.preciseX(), previousChildBounds.preciseY() + previousChildBounds.preciseHeight());
                 }
             }
         } else if (viewQuery.isRegionContainerCompartment()) {
             // Translate the compartment to be just below the the title, the x coordinate is also the same (same parent
             // insets)
-            Rectangle titleBounds = getAbsoluteBounds(getPreviousChild(node), true);
+            Rectangle titleBounds = getAbsoluteBounds(getPreviousChild(node), true, false, false, false);
             location.translate(titleBounds.preciseX(), titleBounds.preciseY() + titleBounds.preciseHeight());
             // Translate from the spacing (5 pixels)
             location.translate(0, IContainerLabelOffsets.LABEL_OFFSET);
         } else if (viewQuery.isVerticalRegion()) {
             if (node.eContainer() instanceof Node container) {
                 if (container.getChildren().get(0) == node) {
-                    Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
+                    Point parentNodeLocation = getAbsoluteLocation(container, insetsAware, false);
                     location.translate(parentNodeLocation);
                     if (insetsAware) {
                         translateWithInsets(location, node);
                     }
                 } else {
                     // Translate from the previous children
-                    Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true);
+                    Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true, false, false, false);
                     location.translate(previousChildBounds.preciseX(), previousChildBounds.preciseY() + previousChildBounds.preciseHeight());
                 }
             }
         } else if (viewQuery.isHorizontalRegion()) {
             if (node.eContainer() instanceof Node container) {
                 if (container.getChildren().get(0) == node) {
-                    Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
+                    Point parentNodeLocation = getAbsoluteLocation(container, insetsAware, false);
                     location.translate(parentNodeLocation);
                     if (insetsAware) {
                         translateWithInsets(location, node);
                     }
                 } else {
                     // Translate from the previous children
-                    Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true);
+                    Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true, false, false, false);
                     location.translate(previousChildBounds.preciseX() + previousChildBounds.preciseWidth(), previousChildBounds.preciseY());
                 }
             }
         } else if (node.eContainer() instanceof Node container) {
-            Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
+            Point parentNodeLocation = getAbsoluteLocation(container, insetsAware, true);
             location.translate(parentNodeLocation);
             if (insetsAware) {
                 translateWithInsets(location, node);
@@ -537,10 +528,10 @@ public final class GMFHelper {
      */
     @Deprecated
     public static Point getLocation(Node node) {
-        return getAbsoluteLocation(node, true);
+        return getAbsoluteLocation(node, true, true);
     }
 
-    private static void updateLocation(Point location, int position, Bounds parentBounds, Bounds gmfBounds) {
+    private static void centerLocationIfZero(Point location, int position, Bounds parentBounds, Bounds gmfBounds) {
         switch (position) {
         case PositionConstants.NORTH:
         case PositionConstants.SOUTH:
@@ -558,50 +549,56 @@ public final class GMFHelper {
             break;
         }
     }
-
-    /**
-     * Get the absolute bounds relative to the origin (Diagram).
-     * 
-     * @param node
-     *            the GMF Node
-     * 
-     * @return the absolute bounds of the node relative to the origin (Diagram)
-     */
-    public static Rectangle getAbsoluteBounds(Node node) {
-        return getAbsoluteBounds(node, false);
-    }
-
-    /**
-     * Get the absolute bounds relative to the origin (Diagram).
-     * 
-     * @param node
-     *            the GMF Node
-     * @param insetsAware
-     *            true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
-     *            current Sirius editParts and could become wrong if a developer customizes them.
-     * 
-     * @return the absolute bounds of the node relative to the origin (Diagram)
-     */
-    public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware) {
-        return getAbsoluteBounds(node, insetsAware, false, false);
-    }
-
-    /**
-     * Get the absolute bounds relative to the origin (Diagram).
-     * 
-     * @param node
-     *            the GMF Node
-     * @param insetsAware
-     *            true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
-     *            current Sirius editParts and could become wrong if a developer customizes them.
-     * @param boxForConnection
-     *            true if we want to have the bounds used to compute connection anchor from source or target, false
-     *            otherwise
-     * @return the absolute bounds of the node relative to the origin (Diagram)
-     */
-    public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection) {
-        return getAbsoluteBounds(node, insetsAware, boxForConnection, false);
-    }
+    //
+    // /**
+    // * Get the absolute bounds relative to the origin (Diagram).
+    // *
+    // * @param node
+    // * the GMF Node
+    // * @param adaptBorderNodeLocation
+    // * Useful for specific border nodes, like in sequence diagrams, to center the border nodes if the
+    // * coordinate is 0 (x for EAST or WEST side, y for NORTH or SOUTH side)
+    // *
+    // * @return the absolute bounds of the node relative to the origin (Diagram)
+    // */
+    // public static Rectangle getAbsoluteBounds(Node node, boolean adaptBorderNodeLocation) {
+    // return getAbsoluteBounds(node, false, false, false, adaptBorderNodeLocation);
+    // }
+    // /**
+    // * Get the absolute bounds relative to the origin (Diagram).
+    // *
+    // * @param node
+    // * the GMF Node
+    // * @param insetsAware
+    // * true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
+    // * current Sirius editParts and could become wrong if a developer customizes them.
+    // * @param adaptBorderNodeLocation
+    // * Useful for specific border nodes, like in sequence diagrams, to center the border nodes if the
+    // * coordinate is 0 (x for EAST or WEST side, y for NORTH or SOUTH side)
+    // *
+    // * @return the absolute bounds of the node relative to the origin (Diagram)
+    // */
+    // public static Rectangle getAbsoluteBounds2(Node node, boolean insetsAware, boolean adaptBorderNodeLocation) {
+    // return getAbsoluteBounds(node, insetsAware, false, false, adaptBorderNodeLocation);
+    // }
+    //
+    // /**
+    // * Get the absolute bounds relative to the origin (Diagram).
+    // *
+    // * @param node
+    // * the GMF Node
+    // * @param insetsAware
+    // * true to consider the draw2D figures insets. <strong>Warning:</strong> Those insets are based on the
+    // * current Sirius editParts and could become wrong if a developer customizes them.
+    // * @param boxForConnection
+    // * true if we want to have the bounds used to compute connection anchor from source or target, false
+    // * otherwise
+    // * @return the absolute bounds of the node relative to the origin (Diagram)
+    // */
+    // public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection, boolean
+    // adaptBorderNodeLocation) {
+    // return getAbsoluteBounds(node, insetsAware, boxForConnection, false, adaptBorderNodeLocation);
+    // }
 
     /**
      * Get the absolute bounds relative to the origin (Diagram).
@@ -616,9 +613,13 @@ public final class GMFHelper {
      *            otherwise
      * @param recursiveGetBounds
      *            true if this method is called from a parent "getBounds" call, false otherwise.
+     * @param adaptBorderNodeLocation
+     *            Useful for specific border nodes, like in sequence diagrams, to center the border nodes if the
+     *            coordinate is 0 (x for EAST or WEST side, y for NORTH or SOUTH side)
+     * 
      * @return the absolute bounds of the node relative to the origin (Diagram)
      */
-    public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection, boolean recursiveGetBounds) {
+    public static Rectangle getAbsoluteBounds(Node node, boolean insetsAware, boolean boxForConnection, boolean recursiveGetBounds, boolean adaptBorderNodeLocation) {
         if (!recursiveGetBounds) {
             boundsCache.clear();
         }
@@ -626,7 +627,7 @@ public final class GMFHelper {
         if (boundsCache.containsKey(node)) {
             result = boundsCache.get(node);
         } else {
-            Point location = getAbsoluteLocation(node, insetsAware);
+            Point location = getAbsoluteLocation(node, insetsAware, adaptBorderNodeLocation);
             Rectangle bounds = getBounds(node, false, false, boxForConnection, recursiveGetBounds, location);
             result = new PrecisionRectangle(location.preciseX(), location.preciseY(), bounds.preciseWidth(), bounds.preciseHeight());
             if (recursiveGetBounds) {
@@ -716,7 +717,7 @@ public final class GMFHelper {
     public static Option<Rectangle> getAbsoluteBounds(View view, boolean insetsAware, boolean boxForConnection) {
         Option<Rectangle> result = Options.newNone();
         if (view instanceof Node) {
-            result = Options.newSome(getAbsoluteBounds((Node) view, insetsAware, boxForConnection, false));
+            result = Options.newSome(getAbsoluteBounds((Node) view, insetsAware, boxForConnection, false, true));
         } else if (view instanceof Edge) {
             result = getAbsoluteBounds((Edge) view, insetsAware, boxForConnection);
         }
@@ -974,7 +975,7 @@ public final class GMFHelper {
         for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
             Node child = children.next();
             if (new NodeQuery(child).isBorderedNode()) {
-                Rectangle borderNodeBounds = getAbsoluteBounds(child, true);
+                Rectangle borderNodeBounds = getAbsoluteBounds(child, true, false, false, false);
                 if (borderNodeBounds.preciseX() == containerChildrenBounds.preciseX()) {
                     result = result | PositionConstants.LEFT;
                 }
@@ -1050,7 +1051,7 @@ public final class GMFHelper {
         if (containerViewQuery.isListContainer() || containerViewQuery.isListCompartment() || containerViewQuery.isVerticalRegionContainerCompartment()) {
             if (!container.getChildren().isEmpty()) {
                 Node lastChild = getLastChild(container, considerBorderNodes);
-                result = getAbsoluteBounds(lastChild, true, false, true);
+                result = getAbsoluteBounds(lastChild, true, false, true, false);
             }
         } else {
             for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
@@ -1058,7 +1059,7 @@ public final class GMFHelper {
                 // The border nodes are ignored, except if it is expected to consider it (auto-size of a container with
                 // children having border nodes)
                 if (considerBorderNodes || !(new NodeQuery(child).isBorderedNode())) {
-                    Rectangle childAbsoluteBounds = getAbsoluteBounds(child, true, false, true);
+                    Rectangle childAbsoluteBounds = getAbsoluteBounds(child, true, false, true, false);
                     if (result == null) {
                         result = childAbsoluteBounds.getCopy();
                     } else {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -274,7 +274,7 @@ public final class GMFHelper {
      */
     private static void translateWithInsets(Point locationToTranslate, Node currentNode) {
         NodeQuery nodeQuery = new NodeQuery(currentNode);
-        // bordered node are not concerned by those insets.
+        // Border nodes are not concerned by those insets.
         if (!nodeQuery.isBorderedNode()) {
             locationToTranslate.translate(getContainerTopLeftInsets(currentNode, false));
         }
@@ -789,8 +789,8 @@ public final class GMFHelper {
         int bottom = 0;
         for (Iterator<Node> children = Iterators.filter(node.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
             Node child = children.next();
-            // The bordered nodes is ignored
-            if (!(new NodeQuery(node).isBorderedNode())) {
+            // The border nodes are ignored
+            if (!(new NodeQuery(child).isBorderedNode())) {
                 Rectangle bounds = getBounds(child);
                 Point bottomRight = bounds.getBottomRight();
                 if (bottomRight.x > right) {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -224,6 +224,20 @@ public final class GMFHelper {
                     location.translate(previousChildBounds.preciseX(), previousChildBounds.preciseY() + previousChildBounds.preciseHeight());
                 }
             }
+        } else if (viewQuery.isHorizontalRegion()) {
+            if (node.eContainer() instanceof Node container) {
+                if (container.getChildren().get(0) == node) {
+                    Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
+                    location.translate(parentNodeLocation);
+                    if (insetsAware) {
+                        translateWithInsets(location, node);
+                    }
+                } else {
+                    // Translate from the previous children
+                    Rectangle previousChildBounds = getAbsoluteBounds(getPreviousChild(node), true);
+                    location.translate(previousChildBounds.preciseX() + previousChildBounds.preciseWidth(), previousChildBounds.preciseY());
+                }
+            } 
         } else if (node.eContainer() instanceof Node container) {
             Point parentNodeLocation = getAbsoluteLocation(container, insetsAware);
             location.translate(parentNodeLocation);
@@ -360,6 +374,7 @@ public final class GMFHelper {
                         result.setWidth(result.width() + borderSize.width());
                         result.setHeight(result.height() + borderSize.height());
                     } else if (new DDiagramElementContainerExperimentalQuery(ddec).isRegion()) {
+                     // No margin, except the border size
                         Dimension borderSize = getBorderSize(ddec);
                         result.setWidth(result.width() + borderSize.width());
                         result.setHeight(result.height() + borderSize.height());
@@ -858,7 +873,7 @@ public final class GMFHelper {
                 if (nodeQuery.isFreeFormCompartment() || nodeQuery.isListCompartment()) {
                     defaultSize = new Dimension(ResizableCompartmentFigure.MIN_CLIENT_DP, ResizableCompartmentFigure.MIN_CLIENT_DP);
                     if (node.getChildren().isEmpty()) {
-                        if (nodeQuery.isListCompartment() || nodeQuery.isVerticalRegionContainerCompartment()) {
+                        if (nodeQuery.isListCompartment() || nodeQuery.isVerticalRegionContainerCompartment() || nodeQuery.isHorizontalRegionContainerCompartment()) {
                             // Add one margin border (even if empty)
                             defaultSize.expand(0, 1);
                         }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/GMFHelper.java
@@ -89,8 +89,6 @@ import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
 import org.eclipse.sirius.diagram.ui.tools.api.layout.LayoutUtils;
 import org.eclipse.sirius.diagram.ui.tools.api.util.GMFNotationHelper;
-import org.eclipse.sirius.ext.base.Option;
-import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.AlphaDropShadowBorder;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.IContainerLabelOffsets;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.LabelBorderStyleIds;
@@ -485,8 +483,8 @@ public final class GMFHelper {
     }
 
     private static boolean hasFullLabelBorder(DDiagramElementContainer ddec) {
-        Option<LabelBorderStyleDescription> labelBorderStyle = new DDiagramElementContainerExperimentalQuery(ddec).getLabelBorderStyle();
-        return labelBorderStyle.some() && LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
+        Optional<LabelBorderStyleDescription> labelBorderStyle = new DDiagramElementContainerExperimentalQuery(ddec).getLabelBorderStyle();
+        return labelBorderStyle.isPresent() && LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId());
     }
 
     private static boolean isFirstRegion(DDiagramElementContainer ddec) {
@@ -587,7 +585,7 @@ public final class GMFHelper {
      * 
      * @return the absolute bounds of the edge relative to the origin (Diagram)
      */
-    public static Option<Rectangle> getAbsoluteBounds(Edge edge) {
+    public static Optional<Rectangle> getAbsoluteBounds(Edge edge) {
         return getAbsoluteBounds(edge, false, false);
     }
 
@@ -605,14 +603,14 @@ public final class GMFHelper {
      * 
      * @return the absolute bounds of the edge relative to the origin (Diagram)
      */
-    public static Option<Rectangle> getAbsoluteBounds(Edge edge, boolean insetsAware, boolean boxForConnection) {
+    public static Optional<Rectangle> getAbsoluteBounds(Edge edge, boolean insetsAware, boolean boxForConnection) {
         // Workaround for canonical refresh about edge on edge
-        Option<Rectangle> optionalSourceBounds = getAbsoluteBounds(edge.getSource(), insetsAware, boxForConnection);
-        Option<Rectangle> optionalTargetBounds = getAbsoluteBounds(edge.getTarget(), insetsAware, boxForConnection);
-        if (optionalSourceBounds.some() && optionalTargetBounds.some()) {
-            return Options.newSome(optionalSourceBounds.get().union(optionalTargetBounds.get()));
+        Optional<Rectangle> optionalSourceBounds = getAbsoluteBounds(edge.getSource(), insetsAware, boxForConnection);
+        Optional<Rectangle> optionalTargetBounds = getAbsoluteBounds(edge.getTarget(), insetsAware, boxForConnection);
+        if (optionalSourceBounds.isPresent() && optionalTargetBounds.isPresent()) {
+            return Optional.ofNullable(optionalSourceBounds.get().union(optionalTargetBounds.get()));
         }
-        return Options.newNone();
+        return Optional.empty();
     }
 
     /**
@@ -623,7 +621,7 @@ public final class GMFHelper {
      * 
      * @return an optional absolute bounds of the node or edge relative to the origin (Diagram)
      */
-    public static Option<Rectangle> getAbsoluteBounds(View view) {
+    public static Optional<Rectangle> getAbsoluteBounds(View view) {
         return getAbsoluteBounds(view, false);
     }
 
@@ -638,7 +636,7 @@ public final class GMFHelper {
      * 
      * @return an optional absolute bounds of the node or edge relative to the origin (Diagram)
      */
-    public static Option<Rectangle> getAbsoluteBounds(View view, boolean insetsAware) {
+    public static Optional<Rectangle> getAbsoluteBounds(View view, boolean insetsAware) {
         return getAbsoluteBounds(view, insetsAware, false);
     }
 
@@ -656,10 +654,10 @@ public final class GMFHelper {
      * 
      * @return an optional absolute bounds of the node or edge relative to the origin (Diagram)
      */
-    public static Option<Rectangle> getAbsoluteBounds(View view, boolean insetsAware, boolean boxForConnection) {
-        Option<Rectangle> result = Options.newNone();
+    public static Optional<Rectangle> getAbsoluteBounds(View view, boolean insetsAware, boolean boxForConnection) {
+        Optional<Rectangle> result = Optional.empty();
         if (view instanceof Node) {
-            result = Options.newSome(getAbsoluteBounds((Node) view, insetsAware, boxForConnection, false, true));
+            result = Optional.ofNullable(getAbsoluteBounds((Node) view, insetsAware, boxForConnection, false, true));
         } else if (view instanceof Edge) {
             result = getAbsoluteBounds((Edge) view, insetsAware, boxForConnection);
         }
@@ -840,9 +838,9 @@ public final class GMFHelper {
             if (useFigureForAutoSizeConstraint) {
                 // Use the figure (if founded) to set width and height
                 // instead of (-1, -1)
-                Option<GraphicalEditPart> optionalTargetEditPart = getGraphicalEditPart(node);
+                Optional<GraphicalEditPart> optionalTargetEditPart = getGraphicalEditPart(node);
                 // CHECKSTYLE:OFF
-                if (optionalTargetEditPart.some()) {
+                if (optionalTargetEditPart.isPresent()) {
                     GraphicalEditPart graphicalEditPart = optionalTargetEditPart.get();
                     if (graphicalEditPart instanceof AbstractDiagramElementContainerEditPart abstractDiagramElementContainerEditPart) {
                         abstractDiagramElementContainerEditPart.forceFigureAutosize();
@@ -990,11 +988,11 @@ public final class GMFHelper {
             }
         } else {
             for (Iterator<Node> children = Iterators.filter(container.getChildren().iterator(), Node.class); children.hasNext(); /* */) {
-                Node child = children.next();
+                Node nodeChild = children.next();
                 // The border nodes are ignored, except if it is expected to consider it (auto-size of a container with
                 // children having border nodes)
-                if (considerBorderNodes || !(new NodeQuery(child).isBorderedNode())) {
-                    Rectangle childAbsoluteBounds = getAbsoluteBounds(child, true, false, true, false);
+                if (considerBorderNodes || !(new NodeQuery(nodeChild).isBorderedNode())) {
+                    Rectangle childAbsoluteBounds = getAbsoluteBounds(nodeChild, true, false, true, false);
                     if (result == null) {
                         result = childAbsoluteBounds.getCopy();
                     } else {
@@ -1037,7 +1035,7 @@ public final class GMFHelper {
      *            The view element that is searched
      * @return The optional corresponding edit part.
      */
-    public static Option<GraphicalEditPart> getGraphicalEditPart(View view) {
+    public static Optional<GraphicalEditPart> getGraphicalEditPart(View view) {
         if (view != null) {
             Diagram gmfDiagram = view.getDiagram();
             // Try the active editor first (most likely case in practice)
@@ -1054,7 +1052,7 @@ public final class GMFHelper {
                 }
             }
         }
-        return Options.<GraphicalEditPart> newNone();
+        return Optional.empty();
     }
 
     private static boolean isEditorFor(IEditorPart editor, Diagram diagram) {
@@ -1071,12 +1069,12 @@ public final class GMFHelper {
      *            the editor where looking for the edit part.
      * @return The optional corresponding edit part.
      */
-    public static Option<GraphicalEditPart> getGraphicalEditPart(View view, DiagramEditor editor) {
-        Option<GraphicalEditPart> result = Options.newNone();
+    public static Optional<GraphicalEditPart> getGraphicalEditPart(View view, DiagramEditor editor) {
+        Optional<GraphicalEditPart> result = Optional.empty();
         final Map<?, ?> editPartRegistry = editor.getDiagramGraphicalViewer().getEditPartRegistry();
         final EditPart targetEditPart = (EditPart) editPartRegistry.get(view);
         if (targetEditPart instanceof GraphicalEditPart graphicalEditPart) {
-            result = Options.newSome(graphicalEditPart);
+            result = Optional.of(graphicalEditPart);
         }
         return result;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/borderednode/CanonicalDBorderItemLocator.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/borderednode/CanonicalDBorderItemLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -669,26 +669,28 @@ public class CanonicalDBorderItemLocator {
         final ListIterator<?> iterator = borderItems.listIterator();
         while (iterator.hasNext()) {
             final Node borderItem = (Node) iterator.next();
-            boolean takeIntoAccount = true;
-            // Does not consider label that is not on border.
-            ViewQuery viewQuery = new ViewQuery(borderItem);
-            NodeQuery nodeQuery = new NodeQuery(borderItem);
-            if (!nodeQuery.isBorderedNode() && !viewQuery.isForNameEditPartOnBorder()) {
-                takeIntoAccount = false;
-            }
-            if (isVisible(borderItem) && takeIntoAccount) {
-                LayoutConstraint borderItemLayoutConstraint = borderItem.getLayoutConstraint();
-                if (borderItemLayoutConstraint instanceof Bounds) {
-                    Dimension extendedDimension = getExtendedDimension(borderItem);
+            if (!portsNodesToIgnore.contains(borderItem)) {
+                boolean takeIntoAccount = true;
+                // Does not consider label that is not on border.
+                ViewQuery viewQuery = new ViewQuery(borderItem);
+                NodeQuery nodeQuery = new NodeQuery(borderItem);
+                if (!nodeQuery.isBorderedNode() && !viewQuery.isForNameEditPartOnBorder()) {
+                    takeIntoAccount = false;
+                }
+                if (isVisible(borderItem) && takeIntoAccount) {
+                    LayoutConstraint borderItemLayoutConstraint = borderItem.getLayoutConstraint();
+                    if (borderItemLayoutConstraint instanceof Bounds) {
+                        Dimension extendedDimension = getExtendedDimension(borderItem);
 
-                    Rectangle borderItemBounds = GMFHelper.getAbsoluteBounds(borderItem, true);
+                        Rectangle borderItemBounds = GMFHelper.getAbsoluteBounds(borderItem, true);
 
-                    if (extendedDimension != null) {
-                        borderItemBounds = PortLayoutHelper.getUncollapseCandidateLocation(extendedDimension, borderItemBounds, getParentBorder());
-                    }
+                        if (extendedDimension != null) {
+                            borderItemBounds = PortLayoutHelper.getUncollapseCandidateLocation(extendedDimension, borderItemBounds, getParentBorder());
+                        }
 
-                    if (!(portsNodesToIgnore.contains(borderItem)) && borderItemBounds.intersects(recommendedRect)) {
-                        return Options.newSome(borderItemBounds);
+                        if (borderItemBounds.intersects(recommendedRect)) {
+                            return Options.newSome(borderItemBounds);
+                        }
                     }
                 }
             }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/borderednode/CanonicalDBorderItemLocator.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/borderednode/CanonicalDBorderItemLocator.java
@@ -682,7 +682,7 @@ public class CanonicalDBorderItemLocator {
                     if (borderItemLayoutConstraint instanceof Bounds) {
                         Dimension extendedDimension = getExtendedDimension(borderItem);
 
-                        Rectangle borderItemBounds = GMFHelper.getAbsoluteBounds(borderItem, true);
+                        Rectangle borderItemBounds = GMFHelper.getAbsoluteBounds(borderItem, true, false, false, false);
 
                         if (extendedDimension != null) {
                             borderItemBounds = PortLayoutHelper.getUncollapseCandidateLocation(extendedDimension, borderItemBounds, getParentBorder());

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/diagram/ConnectionsFactory.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/diagram/ConnectionsFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -230,7 +230,7 @@ public class ConnectionsFactory {
                         getAttributesForSourceOrTargetMove(edgeLayoutData, edge, source, target);
                     }
                 } else {
-                    Option<Rectangle> optionalSourceBounds = GMFHelper.getAbsoluteBounds(source);
+                    Optional<Rectangle> optionalSourceBounds = GMFHelper.getAbsoluteBounds(source);
                     LayoutData sourceLayoutData = null;
                     if (sourceEdgeTarget instanceof AbstractDNode) {
                         AbstractDNode sourceDNode = (AbstractDNode) sourceEdgeTarget;
@@ -238,14 +238,14 @@ public class ConnectionsFactory {
                     }
                     Point firstClick = getFirstClick(sourceLayoutData, optionalSourceBounds);
 
-                    if (optionalSourceBounds.some()) {
+                    if (optionalSourceBounds.isPresent()) {
                         PrecisionPoint sourceRelativeLocation = BaseSlidableAnchor.getAnchorRelativeLocation(firstClick, optionalSourceBounds.get());
                         sourceTerminal = GMFNotationUtilities.getTerminalString(sourceRelativeLocation.preciseX(), sourceRelativeLocation.preciseY());
                     } else {
                         sourceTerminal = GMFNotationUtilities.getTerminalString(0.5d, 0.5d);
                     }
 
-                    Option<Rectangle> optionaltargetBounds = GMFHelper.getAbsoluteBounds(target);
+                    Optional<Rectangle> optionaltargetBounds = GMFHelper.getAbsoluteBounds(target);
                     LayoutData targetLayoutData = null;
                     if (targetEdgeTarget instanceof AbstractDNode) {
                         AbstractDNode targetDNode = (AbstractDNode) targetEdgeTarget;
@@ -253,7 +253,7 @@ public class ConnectionsFactory {
                     }
                     Point secondClick = getSecondClick(targetLayoutData, optionaltargetBounds);
 
-                    if (optionaltargetBounds.some()) {
+                    if (optionaltargetBounds.isPresent()) {
                         PrecisionPoint targetRelativeLocation = BaseSlidableAnchor.getAnchorRelativeLocation(secondClick, optionaltargetBounds.get());
                         targetTerminal = GMFNotationUtilities.getTerminalString(targetRelativeLocation.preciseX(), targetRelativeLocation.preciseY());
                     } else {
@@ -323,10 +323,12 @@ public class ConnectionsFactory {
         }
 
         if (edgeLayoutData.getPointList() != null) {
-            GraphicalEditPart srceEditPart = GMFHelper.getGraphicalEditPart(source).get();
-            GraphicalEditPart tgtEditPart = GMFHelper.getGraphicalEditPart(target).get();
+            Optional<GraphicalEditPart> optionalSrceEditPart = GMFHelper.getGraphicalEditPart(source);
+            Optional<GraphicalEditPart> optionalTgtEditPart = GMFHelper.getGraphicalEditPart(target);
 
-            if (srceEditPart != null && tgtEditPart != null) {
+            if (optionalSrceEditPart.isPresent() && optionalTgtEditPart.isPresent()) {
+                GraphicalEditPart srceEditPart = optionalSrceEditPart.get();
+                GraphicalEditPart tgtEditPart = optionalTgtEditPart.get();
                 GraphicalHelper.screen2logical(sourceRefPoint, srceEditPart);
                 GraphicalHelper.screen2logical(targetRefPoint, tgtEditPart);
 
@@ -422,10 +424,10 @@ public class ConnectionsFactory {
         }
     }
 
-    private Point getFirstClick(LayoutData sourceLayoutData, Option<Rectangle> optionalSourceBounds) {
+    private Point getFirstClick(LayoutData sourceLayoutData, Optional<Rectangle> optionalSourceBounds) {
         Point firstClick = new Point(0, 0);
         if (sourceLayoutData == null) {
-            if (optionalSourceBounds.some()) {
+            if (optionalSourceBounds.isPresent()) {
                 firstClick = optionalSourceBounds.get().getCenter();
             }
         } else {
@@ -435,10 +437,10 @@ public class ConnectionsFactory {
         return firstClick;
     }
 
-    private Point getSecondClick(LayoutData targetLayoutData, Option<Rectangle> optionaltargetBounds) {
+    private Point getSecondClick(LayoutData targetLayoutData, Optional<Rectangle> optionaltargetBounds) {
         Point secondClick = new Point(0, 0);
         if (targetLayoutData == null) {
-            if (optionaltargetBounds.some()) {
+            if (optionaltargetBounds.isPresent()) {
                 secondClick = optionaltargetBounds.get().getCenter();
             }
         } else {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/edge/SlidableAnchor.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/edge/SlidableAnchor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *    Obeo - initial API and implementation
  *******************************************************************************/
 package org.eclipse.sirius.diagram.ui.internal.refresh.edge;
+
+import java.util.Optional;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Point;
@@ -27,7 +29,6 @@ import org.eclipse.gmf.runtime.notation.LayoutConstraint;
 import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.diagram.ui.internal.refresh.GMFHelper;
-import org.eclipse.sirius.ext.base.Option;
 
 /**
  * Provides the GMF implementation of Slidable anchor.
@@ -115,8 +116,8 @@ public class SlidableAnchor {
                 }
             }
         } else if (owner instanceof Edge) {
-            Option<Rectangle> optionalRect = GMFHelper.getAbsoluteBounds((Edge) owner);
-            if (optionalRect.some()) {
+            Optional<Rectangle> optionalRect = GMFHelper.getAbsoluteBounds((Edge) owner);
+            if (optionalRect.isPresent()) {
                 box = optionalRect.get();
             }
         }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/listeners/EdgeLayoutUpdaterModelChangeTrigger.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/listeners/EdgeLayoutUpdaterModelChangeTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2014, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -446,7 +446,7 @@ public class EdgeLayoutUpdaterModelChangeTrigger implements ModelChangeTrigger {
      */
     private DEdgeEditPart getEdgeEditPart(Edge edge) {
         DEdgeEditPart edgeEditPart = null;
-        Option<GraphicalEditPart> option = Options.newNone();
+        Optional<GraphicalEditPart> option = Optional.empty();
         final IEditorPart editorPart = EclipseUIUtil.getActiveEditor();
         if (editorPart instanceof DiagramEditor) {
             option = GMFHelper.getGraphicalEditPart(edge, (DiagramEditor) editorPart);
@@ -460,12 +460,12 @@ public class EdgeLayoutUpdaterModelChangeTrigger implements ModelChangeTrigger {
                 if (object instanceof DiagramEditor) {
                     option = GMFHelper.getGraphicalEditPart(edge, (DiagramEditor) object);
                 }
-                if (option.some()) {
+                if (option.isPresent()) {
                     break;
                 }
             }
         }
-        if (option.some()) {
+        if (option.isPresent()) {
             GraphicalEditPart editPart = option.get();
             if (editPart instanceof DEdgeEditPart) {
                 edgeEditPart = ((DEdgeEditPart) editPart);

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/AbstractSiriusFormatDataManager.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/format/AbstractSiriusFormatDataManager.java
@@ -1021,7 +1021,7 @@ public abstract class AbstractSiriusFormatDataManager implements SiriusFormatDat
                 final org.eclipse.draw2d.geometry.Point realLocation = locator.getValidLocation(rect, toRestoreView, portsNodesToIgnore);
 
                 // Compute the new relative position to the parent
-                final org.eclipse.draw2d.geometry.Point parentAbsoluteLocation = GMFHelper.getAbsoluteBounds(parentNode, true).getTopLeft();
+                final org.eclipse.draw2d.geometry.Point parentAbsoluteLocation = GMFHelper.getAbsoluteBounds(parentNode, true, false, false, false).getTopLeft();
                 locationToApply.setX(realLocation.x);
                 locationToApply.setY(realLocation.y);
                 locationToApply = FormatDataHelper.INSTANCE.getTranslated(locationToApply, parentAbsoluteLocation.negate());

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/commands/SnapCommand.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/commands/SnapCommand.java
@@ -183,7 +183,7 @@ public class SnapCommand extends AbstractTransactionalCommand {
                 figure.translateToAbsolute(figureBounds);
 
                 // We compute the new GMF Absolute Location. The SnapToHelper works with absolute coordinates.
-                Point newGMFAbsoluteLocation = GMFHelper.getAbsoluteLocation((Node) newEditPart.getModel(), true);
+                Point newGMFAbsoluteLocation = GMFHelper.getAbsoluteLocation((Node) newEditPart.getModel(), true, true);
 
                 // We convert in screen coordinate as it is expected by the SnapToHelper
                 GraphicalHelper.logical2screen(newGMFAbsoluteLocation, newEditPart);
@@ -220,11 +220,11 @@ public class SnapCommand extends AbstractTransactionalCommand {
             // We use the CanonicalDBorderItemLocator to compute the new border node location in absolute coordinates
             Dimension spacing = (Dimension) newEditPart.getViewer().getProperty(SnapToGrid.PROPERTY_GRID_SPACING);
             CanonicalDBorderItemLocator itemLocator = initCDBIL(node, parentNode, spacing);
-            Rectangle newGMFAbsoluteBounds = GMFHelper.getAbsoluteBounds(node, true);
+            Rectangle newGMFAbsoluteBounds = GMFHelper.getAbsoluteBounds(node, true, false, false, false);
             Point newValidLocation = itemLocator.getValidLocation(newGMFAbsoluteBounds, node, Collections.singleton(node));
 
             // We compute the new relative coordinates
-            Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode, true);
+            Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode, true, false);
             Point newValidRelativeLocation = newValidLocation.getTranslated(parentAbsoluteLocation.getNegated());
 
             // We compute the move delta by calculating the difference between the current figure relative location and

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/layout/provider/BorderItemAwareLayoutProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/layout/provider/BorderItemAwareLayoutProvider.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -102,8 +103,6 @@ import org.eclipse.sirius.diagram.ui.tools.internal.edit.command.CommandFactory;
 import org.eclipse.sirius.diagram.ui.tools.internal.graphical.edit.policies.ChangeBoundRequestRecorder;
 import org.eclipse.sirius.diagram.ui.tools.internal.layout.ArrangeAllWithAutoSize;
 import org.eclipse.sirius.diagram.ui.tools.internal.part.SiriusDiagramGraphicalViewer;
-import org.eclipse.sirius.ext.base.Option;
-import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.sirius.ext.gmf.runtime.editparts.GraphicalHelper;
 import org.eclipse.sirius.viewpoint.DSemanticDecorator;
 
@@ -704,8 +703,8 @@ public class BorderItemAwareLayoutProvider extends AbstractLayoutProvider {
         for (Entry<View, List<Request>> requestByView : getViewsToChangeBoundsRequest().entrySet()) {
             View view = requestByView.getKey();
             // Get corresponding edit part
-            Option<IBorderItemEditPart> optionalPart = getCorrespondingEditPart(view);
-            if (optionalPart.some()) {
+            Optional<IBorderItemEditPart> optionalPart = getCorrespondingEditPart(view);
+            if (optionalPart.isPresent()) {
                 // In theory we are always in this case...
                 IBorderItemEditPart borderItemEditPart = optionalPart.get();
                 List<Request> requests = requestByView.getValue();
@@ -766,11 +765,11 @@ public class BorderItemAwareLayoutProvider extends AbstractLayoutProvider {
         } else {
             edgeOtherExtremityView = edge.getSource();
         }
-        Option<? extends GraphicalEditPart> optionalOtherExtremityPart = getCorrespondingEditPart(edgeOtherExtremityView);
-        if (!(optionalOtherExtremityPart.some())) {
+        Optional<? extends GraphicalEditPart> optionalOtherExtremityPart = getCorrespondingEditPart(edgeOtherExtremityView);
+        if (optionalOtherExtremityPart.isEmpty()) {
             optionalOtherExtremityPart = GMFHelper.getGraphicalEditPart(edgeOtherExtremityView);
         }
-        if (optionalOtherExtremityPart.some()) {
+        if (optionalOtherExtremityPart.isPresent()) {
             Point secondAnchorLocation;
             if (sourceEdge) {
                 secondAnchorLocation = GraphicalHelper.getAnchorPoint(optionalOtherExtremityPart.get(), edge.getTargetAnchor());
@@ -846,13 +845,13 @@ public class BorderItemAwareLayoutProvider extends AbstractLayoutProvider {
         previousIterationDatasbyEditPart.clear();
     }
 
-    private Option<IBorderItemEditPart> getCorrespondingEditPart(View view) {
+    private Optional<IBorderItemEditPart> getCorrespondingEditPart(View view) {
         for (IBorderItemEditPart borderItemEditPart : previousIterationDatasbyEditPart.keySet()) {
             if (view.equals(borderItemEditPart.getModel())) {
-                return Options.newSome(borderItemEditPart);
+                return Optional.of(borderItemEditPart);
             }
         }
-        return Options.newNone();
+        return Optional.empty();
     }
 
     /**

--- a/plugins/org.eclipse.sirius.tests.junit/data/unit/layout/ticket1481/tc1481.aird
+++ b/plugins/org.eclipse.sirius.tests.junit/data/unit/layout/ticket1481/tc1481.aird
@@ -169,7 +169,7 @@
           </edges>
           <edges xmi:type="notation:Edge" xmi:id="_2MVpYA8vEd-Sv-AozcjW4A" type="4001" element="_-wPYJZjEEeCTjf2eRUPO7Q" source="_2JCdwA8vEd-Sv-AozcjW4A" target="_2LYnIA8vEd-Sv-AozcjW4A">
             <children xmi:type="notation:Node" xmi:id="_2MVpZA8vEd-Sv-AozcjW4A" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zFyVAoRLEeOg_8QSiaL3XA" y="40"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zFyVAoRLEeOg_8QSiaL3XA" x="-1" y="40"/>
             </children>
             <children xmi:type="notation:Node" xmi:id="_-vDFUpjEEeCTjf2eRUPO7Q" type="6002">
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-vDFU5jEEeCTjf2eRUPO7Q" y="10"/>
@@ -179,7 +179,7 @@
             </children>
             <styles xmi:type="notation:ConnectorStyle" xmi:id="_2MVpYQ8vEd-Sv-AozcjW4A" routing="Rectilinear" jumpLinkStatus="Above"/>
             <styles xmi:type="notation:FontStyle" xmi:id="_2MVpYg8vEd-Sv-AozcjW4A" fontName="Segoe UI" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2MVpYw8vEd-Sv-AozcjW4A" points="[10, 0, -384, 111]$[143, 0, -251, 111]$[143, -111, -251, 0]$[384, -111, -10, 0]"/>
+            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2MVpYw8vEd-Sv-AozcjW4A" points="[10, 0, -384, 107]$[143, 0, -251, 107]$[143, -107, -251, 0]$[384, -107, -10, 0]"/>
           </edges>
           <edges xmi:type="notation:Edge" xmi:id="_gYqHwDaZEd-5jPRUUjhbiA" type="4001" element="_-wP_MJjEEeCTjf2eRUPO7Q" source="_gXrQUDaZEd-5jPRUUjhbiA" target="_gYVXoDaZEd-5jPRUUjhbiA">
             <children xmi:type="notation:Node" xmi:id="_gYrV4DaZEd-5jPRUUjhbiA" type="6001">

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/CanonicalDBorderItemLocatorTest.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/CanonicalDBorderItemLocatorTest.java
@@ -89,7 +89,7 @@ public class CanonicalDBorderItemLocatorTest extends SiriusDiagramTestCase {
                 Node node = (Node) iterator.next();
                 CanonicalDBorderItemLocator locator = new CanonicalDBorderItemLocator((Node) node.eContainer(), PositionConstants.NSEW);
                 locator.setBorderItemOffset(IBorderItemOffsets.DEFAULT_OFFSET);
-                Rectangle expectedBounds = GMFHelper.getAbsoluteBounds(node);
+                Rectangle expectedBounds = GMFHelper.getAbsoluteBounds(node, false, false, false, true);
                 Point location = locator.getValidLocation(expectedBounds, node, Collections.singletonList(node));
                 assertEquals("The border node should not be in conflict", expectedBounds.getLocation(), location);
             }

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/compartment/CompartmentsLayoutTest.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/compartment/CompartmentsLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 Obeo.
+ * Copyright (c) 2015, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.draw2d.Border;
@@ -81,7 +82,6 @@ import org.eclipse.sirius.diagram.ui.tools.api.figure.GradientRoundedRectangle;
 import org.eclipse.sirius.diagram.ui.tools.api.layout.LayoutUtils;
 import org.eclipse.sirius.diagram.ui.tools.internal.figure.RegionRoundedGradientRectangle;
 import org.eclipse.sirius.diagram.ui.tools.internal.preferences.SiriusDiagramUiInternalPreferencesKeys;
-import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.AlphaDropShadowBorder;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.LabelBorderStyleIds;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.RoundedCornerMarginBorder;
@@ -1091,7 +1091,7 @@ public class CompartmentsLayoutTest extends SiriusDiagramTestCase implements ICo
 
     private Insets getExpectedScrollPaneInsets(DNodeContainer dnc) {
         DDiagramElementContainerExperimentalQuery query = new DDiagramElementContainerExperimentalQuery(dnc);
-        Option<LabelBorderStyleDescription> labelBorderStyle = query.getLabelBorderStyle();
+        Optional<LabelBorderStyleDescription> labelBorderStyle = query.getLabelBorderStyle();
         final int defaultMargin = AbstractDNodeContainerCompartmentEditPart.DEFAULT_MARGIN;
 
         int borderSize = 0;
@@ -1102,7 +1102,7 @@ public class CompartmentsLayoutTest extends SiriusDiagramTestCase implements ICo
         Insets insets = new Insets(1, 0, 0, 0);
         if (new DNodeContainerExperimentalQuery(dnc).isRegionContainer()) {
             insets = new Insets(0, 0, -1, -1);
-        } else if (labelBorderStyle.some() && LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId())) {
+        } else if (labelBorderStyle.isPresent() && LabelBorderStyleIds.LABEL_FULL_BORDER_STYLE_FOR_CONTAINER_ID.equals(labelBorderStyle.get().getId())) {
             insets = new Insets(defaultMargin, defaultMargin, defaultMargin, defaultMargin);
         } else if (query.isRegionInVerticalStack()) {
             insets = new Insets(borderSize + defaultMargin, defaultMargin, defaultMargin, defaultMargin);

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/format/data/EdgeStabilityOnPortCollapsingTest.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/format/data/EdgeStabilityOnPortCollapsingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,10 +82,10 @@ public class EdgeStabilityOnPortCollapsingTest extends SiriusDiagramTestCase {
         pointsToE.add(new Point(612, 250));
         CONNECTION_EDITPART_POINTS.put("toE", pointsToE);
         ArrayList<Point> pointsToF = new ArrayList<Point>();
-        pointsToF.add(new Point(244, 195));
-        pointsToF.add(new Point(377, 195));
-        pointsToF.add(new Point(377, 85));
-        pointsToF.add(new Point(618, 85));
+        pointsToF.add(new Point(244, 194));
+        pointsToF.add(new Point(377, 194));
+        pointsToF.add(new Point(377, 87));
+        pointsToF.add(new Point(618, 87));
         CONNECTION_EDITPART_POINTS.put("toF", pointsToF);
     }
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/layout/gmfHelper/My.ecore
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/layout/gmfHelper/My.ecore
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="root">
+  <eSubpackages name="p1"/>
+  <eSubpackages name="p2">
+    <eSubpackages name="p21"/>
+    <eSubpackages name="p22"/>
+  </eSubpackages>
+  <eSubpackages name="p3">
+    <eClassifiers xsi:type="ecore:EClass" name="Class1" abstract="true"/>
+    <eClassifiers xsi:type="ecore:EClass" name="Class2" abstract="true"/>
+  </eSubpackages>
+  <eSubpackages name="p4">
+    <eSubpackages name="p41">
+      <eClassifiers xsi:type="ecore:EClass" name="Class3"/>
+      <eClassifiers xsi:type="ecore:EClass" name="Class4"/>
+    </eSubpackages>
+    <eSubpackages name="p42"/>
+  </eSubpackages>
+  <eSubpackages name="p5">
+    <eSubpackages name="p51">
+      <eClassifiers xsi:type="ecore:EClass" name="Class5"/>
+      <eClassifiers xsi:type="ecore:EClass" name="Class6"/>
+    </eSubpackages>
+    <eSubpackages name="p52"/>
+    <eSubpackages name="p53">
+      <eClassifiers xsi:type="ecore:EClass" name="Class7"/>
+      <eClassifiers xsi:type="ecore:EClass" name="Class8"/>
+    </eSubpackages>
+  </eSubpackages>
+</ecore:EPackage>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/layout/gmfHelper/My.odesign
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/layout/gmfHelper/My.odesign
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="ASCII"?>
+<description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" name="description" version="15.4.0.202401051836">
+  <ownedViewpoints endUserDocumentation="2262&#xD;&#xA;" name="SampleWithContainers" modelFileExtension="ecore">
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" name="DiagramWithFreeFormContainers" domainClass="ecore::EPackage">
+      <metamodel href="http://www.eclipse.org/emf/2002/Ecore#/"/>
+      <defaultLayer name="Default" label="default">
+        <containerMappings name="EPackageContainerMapping" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage">
+          <borderedNodeMappings name="BorderClass" semanticCandidatesExpression="feature:eClassifiers" domainClass="ecore::EClass">
+            <style xsi:type="style:SquareDescription" showIcon="false" sizeComputationExpression="2" labelPosition="node">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
+            </style>
+          </borderedNodeMappings>
+          <subContainerMappings name="EPackageContainerMapping2" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage">
+            <borderedNodeMappings name="BorderClass2" semanticCandidatesExpression="feature:eClassifiers" domainClass="ecore::EClass">
+              <style xsi:type="style:SquareDescription" showIcon="false" sizeComputationExpression="2" labelPosition="node">
+                <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
+              </style>
+            </borderedNodeMappings>
+            <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" borderSizeComputationExpression="1">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='blue']"/>
+              <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='blue']"/>
+            </style>
+          </subContainerMappings>
+          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" borderSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_blue']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_blue']"/>
+          </style>
+        </containerMappings>
+      </defaultLayer>
+    </ownedRepresentations>
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" name="DiagramWithListContainers" domainClass="ecore::EPackage">
+      <metamodel href="http://www.eclipse.org/emf/2002/Ecore#/"/>
+      <defaultLayer name="Default" label="default">
+        <containerMappings name="EPackageListMapping" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage" childrenPresentation="List">
+          <borderedNodeMappings name="BorderClass" semanticCandidatesExpression="aql:self.eClassifiers + self.eSubpackages.eClassifiers" domainClass="ecore::EClass">
+            <style xsi:type="style:SquareDescription" showIcon="false" sizeComputationExpression="2" labelPosition="node">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_green']"/>
+            </style>
+          </borderedNodeMappings>
+          <subNodeMappings name="EPackageListItemMapping" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage">
+            <style xsi:type="style:BundledImageDescription" labelAlignment="LEFT" labelPosition="node" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='green']"/>
+            </style>
+          </subNodeMappings>
+          <style xsi:type="style:FlatContainerStyleDescription" borderSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_green']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_green']"/>
+          </style>
+        </containerMappings>
+      </defaultLayer>
+    </ownedRepresentations>
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" name="DiagramWithHStackContainers" domainClass="ecore::EPackage">
+      <metamodel href="http://www.eclipse.org/emf/2002/Ecore#/"/>
+      <defaultLayer name="Default" label="default">
+        <containerMappings name="EPackageHStackMapping" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage" childrenPresentation="HorizontalStack">
+          <borderedNodeMappings name="BorderClass" semanticCandidatesExpression="aql:self.eClassifiers + self.eSubpackages.eClassifiers" domainClass="ecore::EClass">
+            <style xsi:type="style:SquareDescription" showIcon="false" sizeComputationExpression="2" labelPosition="node">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_red']"/>
+            </style>
+          </borderedNodeMappings>
+          <subContainerMappings name="EPackageContainerInHStack" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage">
+            <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" borderSizeComputationExpression="1">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='red']"/>
+              <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='red']"/>
+            </style>
+          </subContainerMappings>
+          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" borderSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_red']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_red']"/>
+          </style>
+        </containerMappings>
+      </defaultLayer>
+    </ownedRepresentations>
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" name="DiagramWithVStackContainers" domainClass="ecore::EPackage">
+      <metamodel href="http://www.eclipse.org/emf/2002/Ecore#/"/>
+      <defaultLayer name="Default" label="default">
+        <containerMappings name="EPackageVStackMapping" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage" childrenPresentation="VerticalStack">
+          <borderedNodeMappings name="BorderClass" semanticCandidatesExpression="aql:self.eClassifiers + self.eSubpackages.eClassifiers" domainClass="ecore::EClass">
+            <style xsi:type="style:SquareDescription" showIcon="false" sizeComputationExpression="2" labelPosition="node">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_yellow']"/>
+            </style>
+          </borderedNodeMappings>
+          <subContainerMappings name="EPackageContainerInHStack" semanticCandidatesExpression="aql:self.eSubpackages" domainClass="ecore::EPackage">
+            <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" borderSizeComputationExpression="1">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='yellow']"/>
+              <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='yellow']"/>
+            </style>
+          </subContainerMappings>
+          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" borderSizeComputationExpression="1">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_yellow']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_yellow']"/>
+          </style>
+        </containerMappings>
+      </defaultLayer>
+    </ownedRepresentations>
+  </ownedViewpoints>
+</description:Group>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/layout/gmfHelper/representations.aird
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/layout/gmfHelper/representations.aird
@@ -1,0 +1,1484 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_QkZpsDO2Ee-fh55MefVB6Q" selectedViews="_F2PBYDO3Ee-fh55MefVB6Q" version="15.4.3.202406261640">
+    <semanticResources>My.ecore</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_F2PBYDO3Ee-fh55MefVB6Q">
+      <viewpoint xmi:type="description:Viewpoint" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_HxDIQDO3Ee-fh55MefVB6Q" name="DiagramWithFreeFormContainers" repPath="#_HxB6IDO3Ee-fh55MefVB6Q" changeId="1721291573934">
+        <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']"/>
+        <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_i_OEAD-PEe--waJe9VgAOw" name="DiagramWithListContainers" repPath="#_i_MO0D-PEe--waJe9VgAOw" changeId="1721291528911">
+        <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']"/>
+        <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_kN754D-PEe--waJe9VgAOw" name="DiagramWithHStackContainers" repPath="#_kN7S0D-PEe--waJe9VgAOw" changeId="1721291603291">
+        <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']"/>
+        <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_lcYqAD-PEe--waJe9VgAOw" name="DiagramWithVStackContainers" repPath="#_lcXb4D-PEe--waJe9VgAOw" changeId="1721291510730">
+        <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']"/>
+        <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_HxB6IDO3Ee-fh55MefVB6Q">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_HxM5QDO3Ee-fh55MefVB6Q" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_HxM5QTO3Ee-fh55MefVB6Q" type="Sirius" element="_HxB6IDO3Ee-fh55MefVB6Q" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_HxZGgDO3Ee-fh55MefVB6Q" type="2002" element="_HxP8kDO3Ee-fh55MefVB6Q">
+          <children xmi:type="notation:Node" xmi:id="_Hxcw4DO3Ee-fh55MefVB6Q" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Hxd_ADO3Ee-fh55MefVB6Q" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Hxd_ATO3Ee-fh55MefVB6Q"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Hxd_AjO3Ee-fh55MefVB6Q"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_HxZGgTO3Ee-fh55MefVB6Q" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HxZGgjO3Ee-fh55MefVB6Q" x="20" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_HxfNIDO3Ee-fh55MefVB6Q" type="2002" element="_HxS_4DO3Ee-fh55MefVB6Q">
+          <children xmi:type="notation:Node" xmi:id="_HxfNIzO3Ee-fh55MefVB6Q" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_HxfNJDO3Ee-fh55MefVB6Q" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_hrRTcD7MEe-VHJr4U3B3XA" type="3008" element="_hq3DwD7MEe-VHJr4U3B3XA">
+              <children xmi:type="notation:Node" xmi:id="_hrXaED7MEe-VHJr4U3B3XA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_hrYBID7MEe-VHJr4U3B3XA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_hrYBIT7MEe-VHJr4U3B3XA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_hrYBIj7MEe-VHJr4U3B3XA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_hrRTcT7MEe-VHJr4U3B3XA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hrRTcj7MEe-VHJr4U3B3XA" x="15" y="34"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_hrZ2UD7MEe-VHJr4U3B3XA" type="3008" element="_hq7VMD7MEe-VHJr4U3B3XA">
+              <children xmi:type="notation:Node" xmi:id="_hrZ2Uz7MEe-VHJr4U3B3XA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_hrZ2VD7MEe-VHJr4U3B3XA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_hrZ2VT7MEe-VHJr4U3B3XA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_hrZ2Vj7MEe-VHJr4U3B3XA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_hrZ2UT7MEe-VHJr4U3B3XA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hrZ2Uj7MEe-VHJr4U3B3XA" x="15" y="114"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_HxfNJTO3Ee-fh55MefVB6Q"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_HxfNJjO3Ee-fh55MefVB6Q"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_HxfNITO3Ee-fh55MefVB6Q" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HxfNIjO3Ee-fh55MefVB6Q" x="200" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_LJWg0DO3Ee-fh55MefVB6Q" type="2002" element="_LJCXxDO3Ee-fh55MefVB6Q">
+          <children xmi:type="notation:Node" xmi:id="_LJXH4DO3Ee-fh55MefVB6Q" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_LJXH4TO3Ee-fh55MefVB6Q" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_LJXH4jO3Ee-fh55MefVB6Q"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_LJXH4zO3Ee-fh55MefVB6Q"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_LJXH5DO3Ee-fh55MefVB6Q" type="3012" element="_LJC-0jO3Ee-fh55MefVB6Q">
+            <children xmi:type="notation:Node" xmi:id="_LJXu8DO3Ee-fh55MefVB6Q" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LJXu8TO3Ee-fh55MefVB6Q" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_LJXu8jO3Ee-fh55MefVB6Q" type="3003" element="_LJC-0zO3Ee-fh55MefVB6Q">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_LJXu8zO3Ee-fh55MefVB6Q" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LJXu9DO3Ee-fh55MefVB6Q"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_LJXH5TO3Ee-fh55MefVB6Q" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LJXH5jO3Ee-fh55MefVB6Q" x="140" y="20" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_vz56MDPYEe-M05DeDxUDow" type="3012" element="_vzoNYDPYEe-M05DeDxUDow">
+            <children xmi:type="notation:Node" xmi:id="_vz6hQDPYEe-M05DeDxUDow" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_vz6hQTPYEe-M05DeDxUDow" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_vz6hQjPYEe-M05DeDxUDow" type="3003" element="_vzoNYTPYEe-M05DeDxUDow">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_vz6hQzPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vz6hRDPYEe-M05DeDxUDow"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_vz56MTPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vz56MjPYEe-M05DeDxUDow" x="100" y="60" width="20" height="20"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_LJWg0TO3Ee-fh55MefVB6Q" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LJWg0jO3Ee-fh55MefVB6Q" x="420" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_hTchcDPYEe-M05DeDxUDow" type="2002" element="_hTEG9jPYEe-M05DeDxUDow">
+          <children xmi:type="notation:Node" xmi:id="_hTgL0DPYEe-M05DeDxUDow" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_hThZ8DPYEe-M05DeDxUDow" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_hTj2MzPYEe-M05DeDxUDow" type="3008" element="_hTI_cDPYEe-M05DeDxUDow">
+              <children xmi:type="notation:Node" xmi:id="_hTkdQDPYEe-M05DeDxUDow" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_hTkdQTPYEe-M05DeDxUDow" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_hTkdQjPYEe-M05DeDxUDow"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_hTkdQzPYEe-M05DeDxUDow"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_vz7IUDPYEe-M05DeDxUDow" type="3012" element="_vzo0cjPYEe-M05DeDxUDow">
+                <children xmi:type="notation:Node" xmi:id="_vz7IUzPYEe-M05DeDxUDow" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_vz7IVDPYEe-M05DeDxUDow" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_vz7vYDPYEe-M05DeDxUDow" type="3003" element="_vzo0czPYEe-M05DeDxUDow">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_vz7vYTPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="10"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vz7vYjPYEe-M05DeDxUDow"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_vz7IUTPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vz7IUjPYEe-M05DeDxUDow" x="140" y="20" width="20" height="20"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_vz7IVTPYEe-M05DeDxUDow" type="3012" element="_vzpbgTPYEe-M05DeDxUDow">
+                <children xmi:type="notation:Node" xmi:id="_vz7IWDPYEe-M05DeDxUDow" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_vz7IWTPYEe-M05DeDxUDow" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_vz7vYzPYEe-M05DeDxUDow" type="3003" element="_vzpbgjPYEe-M05DeDxUDow">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_vz7vZDPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="10"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vz7vZTPYEe-M05DeDxUDow"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_vz7IVjPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vz7IVzPYEe-M05DeDxUDow" x="60" y="60" width="20" height="20"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_hTj2NDPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hTj2NTPYEe-M05DeDxUDow" x="35" y="114"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_z37oVD30Ee-PWqbD1HrhMA" type="3008" element="_z3uM9D30Ee-PWqbD1HrhMA">
+              <children xmi:type="notation:Node" xmi:id="_z37oVz30Ee-PWqbD1HrhMA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_z38PYD30Ee-PWqbD1HrhMA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_z38PYT30Ee-PWqbD1HrhMA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_z38PYj30Ee-PWqbD1HrhMA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_z37oVT30Ee-PWqbD1HrhMA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z37oVj30Ee-PWqbD1HrhMA" x="35" y="34"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_hThZ8TPYEe-M05DeDxUDow"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_hThZ8jPYEe-M05DeDxUDow"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_hTchcTPYEe-M05DeDxUDow" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hTchcjPYEe-M05DeDxUDow" x="600" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_PGKPcETgEe-1qJZv2Fx6GA" type="2002" element="_PGDhxETgEe-1qJZv2Fx6GA">
+          <children xmi:type="notation:Node" xmi:id="_PGKPc0TgEe-1qJZv2Fx6GA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_PGKPdETgEe-1qJZv2Fx6GA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_PGK2gETgEe-1qJZv2Fx6GA" type="3008" element="_PGEI0UTgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_PGLdkETgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_PGLdkUTgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_PGLdkkTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_PGLdk0TgEe-1qJZv2Fx6GA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_PGMEpETgEe-1qJZv2Fx6GA" type="3012" element="_PGFW8kTgEe-1qJZv2Fx6GA">
+                <children xmi:type="notation:Node" xmi:id="_PGMrsETgEe-1qJZv2Fx6GA" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_PGMrsUTgEe-1qJZv2Fx6GA" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_PGNSwkTgEe-1qJZv2Fx6GA" type="3003" element="_PGFW80TgEe-1qJZv2Fx6GA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_PGNSw0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGNSxETgEe-1qJZv2Fx6GA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_PGMEpUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGMEpkTgEe-1qJZv2Fx6GA" x="140" y="25" width="20" height="20"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_PGMrskTgEe-1qJZv2Fx6GA" type="3012" element="_PGF-AUTgEe-1qJZv2Fx6GA">
+                <children xmi:type="notation:Node" xmi:id="_PGNSwETgEe-1qJZv2Fx6GA" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_PGNSwUTgEe-1qJZv2Fx6GA" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_PGN50ETgEe-1qJZv2Fx6GA" type="3003" element="_PGF-AkTgEe-1qJZv2Fx6GA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_PGN50UTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGN50kTgEe-1qJZv2Fx6GA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_PGMrs0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGMrtETgEe-1qJZv2Fx6GA" x="80" y="60" width="20" height="20"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_PGK2gUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGK2gkTgEe-1qJZv2Fx6GA" x="20" y="20"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_PGLdlETgEe-1qJZv2Fx6GA" type="3008" element="_PGEv4UTgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_PGLdl0TgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_PGLdmETgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_PGLdmUTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_PGLdmkTgEe-1qJZv2Fx6GA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_PGLdlUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGLdlkTgEe-1qJZv2Fx6GA" x="15" y="114"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_PGLdm0TgEe-1qJZv2Fx6GA" type="3008" element="_PGEv5ETgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_PGMEoETgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_PGMEoUTgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_PGMEokTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_PGMEo0TgEe-1qJZv2Fx6GA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_PGN500TgEe-1qJZv2Fx6GA" type="3012" element="_PGGlEETgEe-1qJZv2Fx6GA">
+                <children xmi:type="notation:Node" xmi:id="_PGOg4ETgEe-1qJZv2Fx6GA" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_PGOg4UTgEe-1qJZv2Fx6GA" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_PGPH8kTgEe-1qJZv2Fx6GA" type="3003" element="_PGGlEUTgEe-1qJZv2Fx6GA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_PGPH80TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGPH9ETgEe-1qJZv2Fx6GA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_PGN51ETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGN51UTgEe-1qJZv2Fx6GA" x="140" y="20" width="20" height="20"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_PGOg4kTgEe-1qJZv2Fx6GA" type="3012" element="_PGGlE0TgEe-1qJZv2Fx6GA">
+                <children xmi:type="notation:Node" xmi:id="_PGPH8ETgEe-1qJZv2Fx6GA" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_PGPH8UTgEe-1qJZv2Fx6GA" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_PGPvAETgEe-1qJZv2Fx6GA" type="3003" element="_PGGlFETgEe-1qJZv2Fx6GA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_PGPvAUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGPvAkTgEe-1qJZv2Fx6GA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_PGOg40TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGOg5ETgEe-1qJZv2Fx6GA" x="15" y="60" width="20" height="20"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_PGLdnETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGLdnUTgEe-1qJZv2Fx6GA" x="215" y="74"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_PGKPdUTgEe-1qJZv2Fx6GA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_PGKPdkTgEe-1qJZv2Fx6GA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_PGKPcUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGKPckTgEe-1qJZv2Fx6GA" x="840" y="20"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_HxM5QjO3Ee-fh55MefVB6Q"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_HxUOAzO3Ee-fh55MefVB6Q" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_HxUOBDO3Ee-fh55MefVB6Q"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HxP8kDO3Ee-fh55MefVB6Q" name="p1" tooltipText="">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HxRKsDO3Ee-fh55MefVB6Q" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="194,239,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HxS_4DO3Ee-fh55MefVB6Q" name="p2">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HxS_4TO3Ee-fh55MefVB6Q" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="194,239,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_hq3DwD7MEe-VHJr4U3B3XA" name="p21">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_hq4R4D7MEe-VHJr4U3B3XA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="114,159,207" foregroundColor="114,159,207">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_hq7VMD7MEe-VHJr4U3B3XA" name="p22">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_hq7VMT7MEe-VHJr4U3B3XA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="114,159,207" foregroundColor="114,159,207">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_LJCXxDO3Ee-fh55MefVB6Q" name="p3">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_LJC-0jO3Ee-fh55MefVB6Q" name="Class1" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_LJC-0zO3Ee-fh55MefVB6Q" showIcon="false" labelPosition="node" color="39,76,114">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_vzoNYDPYEe-M05DeDxUDow" name="Class2" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_vzoNYTPYEe-M05DeDxUDow" showIcon="false" labelPosition="node" color="39,76,114">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_LJC-0DO3Ee-fh55MefVB6Q" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="194,239,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_hTEG9jPYEe-M05DeDxUDow" name="p4">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_hTGjMDPYEe-M05DeDxUDow" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="194,239,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_hTI_cDPYEe-M05DeDxUDow" name="p41">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_vzo0cjPYEe-M05DeDxUDow" name="Class3" width="2" height="2">
+          <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+          <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_vzo0czPYEe-M05DeDxUDow" showIcon="false" labelPosition="node" color="39,76,114">
+            <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_vzpbgTPYEe-M05DeDxUDow" name="Class4" width="2" height="2">
+          <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+          <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_vzpbgjPYEe-M05DeDxUDow" showIcon="false" labelPosition="node" color="39,76,114">
+            <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_hTI_cTPYEe-M05DeDxUDow" borderSize="1" borderSizeComputationExpression="1" backgroundColor="114,159,207" foregroundColor="114,159,207">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_z3uM9D30Ee-PWqbD1HrhMA" name="p42">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_z3uM9T30Ee-PWqbD1HrhMA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="114,159,207" foregroundColor="114,159,207">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_PGDhxETgEe-1qJZv2Fx6GA" name="p5">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_PGDhxUTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="194,239,255" foregroundColor="194,239,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_PGEI0UTgEe-1qJZv2Fx6GA" name="p51">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_PGFW8kTgEe-1qJZv2Fx6GA" name="Class5" width="2" height="2">
+          <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+          <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_PGFW80TgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="39,76,114">
+            <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_PGF-AUTgEe-1qJZv2Fx6GA" name="Class6" width="2" height="2">
+          <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+          <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_PGF-AkTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="39,76,114">
+            <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_PGEI0kTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="114,159,207" foregroundColor="114,159,207">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_PGEv4UTgEe-1qJZv2Fx6GA" name="p52">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_PGEv4kTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="114,159,207" foregroundColor="114,159,207">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_PGEv5ETgEe-1qJZv2Fx6GA" name="p53">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_PGGlEETgEe-1qJZv2Fx6GA" name="Class7" width="2" height="2">
+          <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+          <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_PGGlEUTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="39,76,114">
+            <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_PGGlE0TgEe-1qJZv2Fx6GA" name="Class8" width="2" height="2">
+          <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+          <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_PGGlFETgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="39,76,114">
+            <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@borderedNodeMappings[name='BorderClass2']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_PGFW8ETgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="114,159,207" foregroundColor="114,159,207">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer/@containerMappings[name='EPackageContainerMapping']/@subContainerMappings[name='EPackageContainerMapping2']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_HxChMDO3Ee-fh55MefVB6Q"/>
+    <activatedLayers xmi:type="description_1:Layer" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithFreeFormContainers']/@defaultLayer"/>
+    <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_i_MO0D-PEe--waJe9VgAOw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_i_UxsD-PEe--waJe9VgAOw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_i_UxsT-PEe--waJe9VgAOw" type="Sirius" element="_i_MO0D-PEe--waJe9VgAOw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_i_kpUD-PEe--waJe9VgAOw" type="2003" element="_i_VYwD-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_i_oTsD-PEe--waJe9VgAOw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_i_ph0D-PEe--waJe9VgAOw" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_i_ph0T-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_i_ph0j-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_i_kpUT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_kpUj-PEe--waJe9VgAOw" x="20" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_i_qv8D-PEe--waJe9VgAOw" type="2003" element="_i_ZqMT-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_i_rXAD-PEe--waJe9VgAOw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_i_rXAT-PEe--waJe9VgAOw" type="7004">
+            <children xmi:type="notation:Node" xmi:id="_i_tMMD-PEe--waJe9VgAOw" type="3010" element="_i_aRRj-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_i_tMMT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_tMMj-PEe--waJe9VgAOw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_i_tzQD-PEe--waJe9VgAOw" type="3010" element="_i_a4UT-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_i_tzQT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_tzQj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_i_rXAj-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_i_rXAz-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_i_qv8T-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_qv8j-PEe--waJe9VgAOw" x="100" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_i_rXBD-PEe--waJe9VgAOw" type="2003" element="_i_aRQD-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_i_uaUD-PEe--waJe9VgAOw" type="3012" element="_i_a4Uz-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_i_vocD-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_vocT-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_i_0g8D-PEe--waJe9VgAOw" type="3003" element="_i_a4VD-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_i_0g8T-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_0g8j-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_i_uaUT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_uaUj-PEe--waJe9VgAOw" x="30" y="10" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_i_zS0D-PEe--waJe9VgAOw" type="3012" element="_i_bfYT-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_i_z54D-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_z54T-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_i_1IAD-PEe--waJe9VgAOw" type="3003" element="_i_bfYj-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_i_1IAT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_1IAj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_i_zS0T-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_zS0j-PEe--waJe9VgAOw" x="9" y="31" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_i_rXBz-PEe--waJe9VgAOw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_i_rXCD-PEe--waJe9VgAOw" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_i_rXCT-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_i_rXCj-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_i_rXBT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_rXBj-PEe--waJe9VgAOw" x="200" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_i_rXCz-PEe--waJe9VgAOw" type="2003" element="_i_aRQz-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_i_1IAz-PEe--waJe9VgAOw" type="3012" element="_i_bfZD-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_i_1IBj-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_1IBz-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_i_2WID-PEe--waJe9VgAOw" type="3003" element="_i_bfZT-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_i_2WIT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_2WIj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_i_1IBD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_1IBT-PEe--waJe9VgAOw" x="42" y="21" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_i_1vED-PEe--waJe9VgAOw" type="3012" element="_i_bfZz-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_i_1vEz-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_1vFD-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_i_2WIz-PEe--waJe9VgAOw" type="3003" element="_i_cGcD-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_i_2WJD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_2WJT-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_i_1vET-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_1vEj-PEe--waJe9VgAOw" x="20" y="53" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_i_r-ED-PEe--waJe9VgAOw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_i_r-ET-PEe--waJe9VgAOw" type="7004">
+            <children xmi:type="notation:Node" xmi:id="_i_2WJj-PEe--waJe9VgAOw" type="3010" element="_i_cGcj-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_i_2WJz-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_2WKD-PEe--waJe9VgAOw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_i_29MD-PEe--waJe9VgAOw" type="3010" element="_i_cGdD-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_i_29MT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_i_29Mj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_i_r-Ej-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_i_r-Ez-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_i_rXDD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_rXDT-PEe--waJe9VgAOw" x="300" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Md07QETgEe-1qJZv2Fx6GA" type="2003" element="_MdvbtUTgEe-1qJZv2Fx6GA">
+          <children xmi:type="notation:Node" xmi:id="_Md2wc0TgEe-1qJZv2Fx6GA" type="3012" element="_MdvbuETgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_Md2wdkTgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Md2wd0TgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Md5Mt0TgEe-1qJZv2Fx6GA" type="3003" element="_MdvbuUTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Md5MuETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md5MuUTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Md2wdETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md2wdUTgEe-1qJZv2Fx6GA" x="-12" y="34" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Md2weETgEe-1qJZv2Fx6GA" type="3012" element="_Mdvbu0TgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_Md2we0TgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Md2wfETgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Md5MukTgEe-1qJZv2Fx6GA" type="3003" element="_MdvbvETgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Md5Mu0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md5MvETgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Md2weUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md2wekTgEe-1qJZv2Fx6GA" x="15" y="69" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Md2wfUTgEe-1qJZv2Fx6GA" type="3012" element="_MdvbvkTgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_Md5MsETgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Md5MsUTgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Md5MvUTgEe-1qJZv2Fx6GA" type="3003" element="_Mdvbv0TgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Md5MvkTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md5Mv0TgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Md2wfkTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md2wf0TgEe-1qJZv2Fx6GA" x="42" y="24" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Md5MskTgEe-1qJZv2Fx6GA" type="3012" element="_MdvbwUTgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_Md5MtUTgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Md5MtkTgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Md5MwETgEe-1qJZv2Fx6GA" type="3003" element="_MdvbwkTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Md5MwUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md5MwkTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Md5Ms0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md5MtETgEe-1qJZv2Fx6GA" x="20" y="-12" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Md07Q0TgEe-1qJZv2Fx6GA" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_Md2wcETgEe-1qJZv2Fx6GA" type="7004">
+            <children xmi:type="notation:Node" xmi:id="_Md7o8ETgEe-1qJZv2Fx6GA" type="3010" element="_MdvbxETgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:FontStyle" xmi:id="_Md7o8UTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Md7o8kTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Md7o80TgEe-1qJZv2Fx6GA" type="3010" element="_Mdx38UTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:FontStyle" xmi:id="_Md7o9ETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Md7o9UTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Md7o9kTgEe-1qJZv2Fx6GA" type="3010" element="_Mdx380TgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:FontStyle" xmi:id="_Md7o90TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Md7o-ETgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Md2wcUTgEe-1qJZv2Fx6GA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Md2wckTgEe-1qJZv2Fx6GA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Md07QUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Md07QkTgEe-1qJZv2Fx6GA" x="400" y="20"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_i_Uxsj-PEe--waJe9VgAOw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_i_ctgT-PEe--waJe9VgAOw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_i_ctgj-PEe--waJe9VgAOw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_i_VYwD-PEe--waJe9VgAOw" name="p1">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i_XN8D-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="204,242,166" foregroundColor="204,242,166">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_i_ZqMT-PEe--waJe9VgAOw" name="p2">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i_ZqMj-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="204,242,166" foregroundColor="204,242,166">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']"/>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_i_aRRj-PEe--waJe9VgAOw" name="p21">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_i_a4UD-PEe--waJe9VgAOw" labelAlignment="LEFT" labelPosition="node" color="138,226,52">
+          <description xmi:type="style:BundledImageDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_i_a4UT-PEe--waJe9VgAOw" name="p22">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_i_a4Uj-PEe--waJe9VgAOw" labelAlignment="LEFT" labelPosition="node" color="138,226,52">
+          <description xmi:type="style:BundledImageDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']"/>
+      </ownedElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_i_aRQD-PEe--waJe9VgAOw" name="p3">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_i_a4Uz-PEe--waJe9VgAOw" name="Class1" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_i_a4VD-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_i_bfYT-PEe--waJe9VgAOw" name="Class2" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_i_bfYj-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i_aRQT-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="204,242,166" foregroundColor="204,242,166">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_i_aRQz-PEe--waJe9VgAOw" name="p4">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_i_bfZD-PEe--waJe9VgAOw" name="Class3" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_i_bfZT-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_i_bfZz-PEe--waJe9VgAOw" name="Class4" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_i_cGcD-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i_aRRD-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="204,242,166" foregroundColor="204,242,166">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']"/>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_i_cGcj-PEe--waJe9VgAOw" name="p41">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_i_cGcz-PEe--waJe9VgAOw" labelAlignment="LEFT" labelPosition="node" color="138,226,52">
+          <description xmi:type="style:BundledImageDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_i_cGdD-PEe--waJe9VgAOw" name="p42">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_i_ctgD-PEe--waJe9VgAOw" labelAlignment="LEFT" labelPosition="node" color="138,226,52">
+          <description xmi:type="style:BundledImageDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']"/>
+      </ownedElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_MdvbtUTgEe-1qJZv2Fx6GA" name="p5">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_MdvbuETgEe-1qJZv2Fx6GA" name="Class5" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_MdvbuUTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Mdvbu0TgEe-1qJZv2Fx6GA" name="Class6" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_MdvbvETgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_MdvbvkTgEe-1qJZv2Fx6GA" name="Class7" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_Mdvbv0TgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_MdvbwUTgEe-1qJZv2Fx6GA" name="Class8" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_MdvbwkTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="77,137,20">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_MdvbtkTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="204,242,166" foregroundColor="204,242,166">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']"/>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_MdvbxETgEe-1qJZv2Fx6GA" name="p51">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_Mdx38ETgEe-1qJZv2Fx6GA" labelAlignment="LEFT" labelPosition="node" color="138,226,52">
+          <description xmi:type="style:BundledImageDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_Mdx38UTgEe-1qJZv2Fx6GA" name="p52">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_Mdx38kTgEe-1qJZv2Fx6GA" labelAlignment="LEFT" labelPosition="node" color="138,226,52">
+          <description xmi:type="style:BundledImageDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_Mdx380TgEe-1qJZv2Fx6GA" name="p53">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_Mdx39ETgEe-1qJZv2Fx6GA" labelAlignment="LEFT" labelPosition="node" color="138,226,52">
+          <description xmi:type="style:BundledImageDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer/@containerMappings[name='EPackageListMapping']/@subNodeMappings[name='EPackageListItemMapping']"/>
+      </ownedElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_i_M14D-PEe--waJe9VgAOw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithListContainers']/@defaultLayer"/>
+    <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_kN7S0D-PEe--waJe9VgAOw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_kN754j-PEe--waJe9VgAOw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_kN754z-PEe--waJe9VgAOw" type="Sirius" element="_kN7S0D-PEe--waJe9VgAOw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_kOCnkD-PEe--waJe9VgAOw" type="2002" element="_kN8g8D-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_kODOoD-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_kOFD0D-PEe--waJe9VgAOw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_kOFD0T-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_kOFD0j-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_kOCnkT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOCnkj-PEe--waJe9VgAOw" x="20" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_kOFD0z-PEe--waJe9VgAOw" type="2002" element="_kN8g8z-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_kOFD1j-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_kOFD1z-PEe--waJe9VgAOw" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_kOG5AD-PEe--waJe9VgAOw" type="3008" element="_kN9vET-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_kOHgED-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_kOIHID-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_kOIHIT-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_kOIHIj-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_kOIuMD-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOG5AT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOG5Aj-PEe--waJe9VgAOw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_kOIuMT-PEe--waJe9VgAOw" type="3008" element="_kN-WID-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_kOIuND-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_kOIuNT-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_kOIuNj-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_kOIuNz-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_kOIuOD-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOIuMj-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOIuMz-PEe--waJe9VgAOw" x="40"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_kOFD2D-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_kOFD2T-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_kOFD1D-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOFD1T-PEe--waJe9VgAOw" x="100" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_kOFq4D-PEe--waJe9VgAOw" type="2002" element="_kN9IAj-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_kOIuOT-PEe--waJe9VgAOw" type="3012" element="_kN-WIz-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_kOJVQD-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_kOJVQT-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_kOJVRz-PEe--waJe9VgAOw" type="3003" element="_kN-WJD-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOJVSD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOJVST-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_kOIuOj-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOIuOz-PEe--waJe9VgAOw" x="30" y="10" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_kOJVQj-PEe--waJe9VgAOw" type="3012" element="_kN-WJj-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_kOJVRT-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_kOJVRj-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_kOJ8UD-PEe--waJe9VgAOw" type="3003" element="_kN-WJz-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOJ8UT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOJ8Uj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_kOJVQz-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOJVRD-PEe--waJe9VgAOw" x="5" y="31" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_kOFq4z-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_kOFq5D-PEe--waJe9VgAOw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_kOFq5T-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_kOFq5j-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_kOFq4T-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOFq4j-PEe--waJe9VgAOw" x="200" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_kOFq5z-PEe--waJe9VgAOw" type="2002" element="_kN9IBT-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_kOJ8Uz-PEe--waJe9VgAOw" type="3012" element="_kN-9MT-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_kOJ8Vj-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_kOJ8Vz-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_kOKjZT-PEe--waJe9VgAOw" type="3003" element="_kN-9Mj-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOKjZj-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOKjZz-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_kOJ8VD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOJ8VT-PEe--waJe9VgAOw" x="25" y="60" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_kOKjYD-PEe--waJe9VgAOw" type="3012" element="_kN-9ND-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_kOKjYz-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_kOKjZD-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_kOLKcD-PEe--waJe9VgAOw" type="3003" element="_kN-9NT-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOLKcT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOLKcj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_kOKjYT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOKjYj-PEe--waJe9VgAOw" x="75" y="19" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_kOFq6j-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_kOFq6z-PEe--waJe9VgAOw" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_kOLKcz-PEe--waJe9VgAOw" type="3008" element="_kN_kQD-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_kOLKdj-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_kOLKdz-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_kOLKeD-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_kOLKeT-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_kOLKej-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOLKdD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOLKdT-PEe--waJe9VgAOw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_kOLKez-PEe--waJe9VgAOw" type="3008" element="_kN_kQz-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_kOLxgD-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_kOLxgT-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_kOLxgj-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_kOLxgz-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_kOLxhD-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kOLKfD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOLKfT-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_kOFq7D-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_kOFq7T-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_kOFq6D-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOFq6T-PEe--waJe9VgAOw" x="300" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_WxTWMkTgEe-1qJZv2Fx6GA" type="2002" element="_WxOduUTgEe-1qJZv2Fx6GA">
+          <children xmi:type="notation:Node" xmi:id="_WxTWOUTgEe-1qJZv2Fx6GA" type="3012" element="_WxQ58UTgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_WxTWPETgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_WxTWPUTgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_WxVyd0TgEe-1qJZv2Fx6GA" type="3003" element="_WxQ58kTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WxVyeETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxVyeUTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_WxTWOkTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxTWO0TgEe-1qJZv2Fx6GA" x="-12" y="10" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_WxTWPkTgEe-1qJZv2Fx6GA" type="3012" element="_WxQ59ETgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_WxTWQUTgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_WxTWQkTgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_WxYOsETgEe-1qJZv2Fx6GA" type="3003" element="_WxQ59UTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WxYOsUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxYOskTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_WxTWP0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxTWQETgEe-1qJZv2Fx6GA" x="42" y="60" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_WxTWQ0TgEe-1qJZv2Fx6GA" type="3012" element="_WxQ590TgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_WxVycETgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_WxVycUTgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_WxYOs0TgEe-1qJZv2Fx6GA" type="3003" element="_WxQ5-ETgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WxYOtETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxYOtUTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_WxTWRETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxTWRUTgEe-1qJZv2Fx6GA" x="116" y="10" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_WxVyckTgEe-1qJZv2Fx6GA" type="3012" element="_WxQ5-kTgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_WxVydUTgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_WxVydkTgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_WxYOtkTgEe-1qJZv2Fx6GA" type="3003" element="_WxQ5-0TgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WxYOt0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxYOuETgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_WxVyc0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxVydETgEe-1qJZv2Fx6GA" x="82" y="-12" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_WxTWNUTgEe-1qJZv2Fx6GA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_WxTWNkTgEe-1qJZv2Fx6GA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_WxYOuUTgEe-1qJZv2Fx6GA" type="3008" element="_WxQ5_UTgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_WxYOvETgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_WxYOvUTgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_WxYOvkTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_WxYOv0TgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_WxYOwETgEe-1qJZv2Fx6GA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WxYOukTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxYOu0TgEe-1qJZv2Fx6GA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_WxYOwUTgEe-1qJZv2Fx6GA" type="3008" element="_WxQ6AETgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_WxYOxETgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_WxYOxUTgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_WxYOxkTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_WxYOx0TgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_WxYOyETgEe-1qJZv2Fx6GA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WxYOwkTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxYOw0TgEe-1qJZv2Fx6GA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_WxYOyUTgEe-1qJZv2Fx6GA" type="3008" element="_WxQ6A0TgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_WxYOzETgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_WxYOzUTgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_WxYOzkTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_WxYOz0TgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_WxYO0ETgEe-1qJZv2Fx6GA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WxYOykTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxYOy0TgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_WxTWN0TgEe-1qJZv2Fx6GA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_WxTWOETgEe-1qJZv2Fx6GA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_WxTWM0TgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxTWNETgEe-1qJZv2Fx6GA" x="500" y="20"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_kN755D-PEe--waJe9VgAOw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_kOALUD-PEe--waJe9VgAOw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_kOALUT-PEe--waJe9VgAOw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN8g8D-PEe--waJe9VgAOw" name="p1" childrenPresentation="HorizontalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN8g8T-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="246,139,139" foregroundColor="246,139,139">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN8g8z-PEe--waJe9VgAOw" name="p2" childrenPresentation="HorizontalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN9IAD-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="246,139,139" foregroundColor="246,139,139">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN9vET-PEe--waJe9VgAOw" name="p21">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN9vEj-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="239,41,41" foregroundColor="239,41,41">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN-WID-PEe--waJe9VgAOw" name="p22">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN-WIT-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="239,41,41" foregroundColor="239,41,41">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN9IAj-PEe--waJe9VgAOw" name="p3" childrenPresentation="HorizontalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_kN-WIz-PEe--waJe9VgAOw" name="Class1" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_kN-WJD-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_kN-WJj-PEe--waJe9VgAOw" name="Class2" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_kN-WJz-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN9IAz-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="246,139,139" foregroundColor="246,139,139">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN9IBT-PEe--waJe9VgAOw" name="p4" childrenPresentation="HorizontalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_kN-9MT-PEe--waJe9VgAOw" name="Class3" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_kN-9Mj-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_kN-9ND-PEe--waJe9VgAOw" name="Class4" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_kN-9NT-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN9IBj-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="246,139,139" foregroundColor="246,139,139">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN_kQD-PEe--waJe9VgAOw" name="p41">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN_kQT-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="239,41,41" foregroundColor="239,41,41">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kN_kQz-PEe--waJe9VgAOw" name="p42">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kN_kRD-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="239,41,41" foregroundColor="239,41,41">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_WxOduUTgEe-1qJZv2Fx6GA" name="p5" childrenPresentation="HorizontalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_WxQ58UTgEe-1qJZv2Fx6GA" name="Class5" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_WxQ58kTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_WxQ59ETgEe-1qJZv2Fx6GA" name="Class6" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_WxQ59UTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_WxQ590TgEe-1qJZv2Fx6GA" name="Class7" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_WxQ5-ETgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_WxQ5-kTgEe-1qJZv2Fx6GA" name="Class8" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_WxQ5-0TgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="156,12,12">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_WxOdukTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="246,139,139" foregroundColor="246,139,139">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_WxQ5_UTgEe-1qJZv2Fx6GA" name="p51">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_WxQ5_kTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="239,41,41" foregroundColor="239,41,41">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_WxQ6AETgEe-1qJZv2Fx6GA" name="p52">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_WxQ6AUTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="239,41,41" foregroundColor="239,41,41">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_WxQ6A0TgEe-1qJZv2Fx6GA" name="p53">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_WxQ6BETgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="239,41,41" foregroundColor="239,41,41">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer/@containerMappings[name='EPackageHStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_kN7S0T-PEe--waJe9VgAOw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithHStackContainers']/@defaultLayer"/>
+    <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_lcXb4D-PEe--waJe9VgAOw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_lcYqAj-PEe--waJe9VgAOw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_lcYqAz-PEe--waJe9VgAOw" type="Sirius" element="_lcXb4D-PEe--waJe9VgAOw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_lcfXsD-PEe--waJe9VgAOw" type="2002" element="_lcZ4ID-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_lcf-wD-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_lcf-wT-PEe--waJe9VgAOw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_lcf-wj-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_lcf-wz-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_lcfXsT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcfXsj-PEe--waJe9VgAOw" x="20" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_lcf-xD-PEe--waJe9VgAOw" type="2002" element="_lcafMT-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_lcgl0D-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_lcgl0T-PEe--waJe9VgAOw" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_lcibAz-PEe--waJe9VgAOw" type="3008" element="_lcbGQz-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_lcibBj-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_lcibBz-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_lcibCD-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_lcibCT-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_lcibCj-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lcibBD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcibBT-PEe--waJe9VgAOw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_lcibCz-PEe--waJe9VgAOw" type="3008" element="_lcbtUj-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_lcjCED-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_lcjCET-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_lcjCEj-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_lcjCEz-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_lcjCFD-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lcibDD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcibDT-PEe--waJe9VgAOw" y="40"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_lcgl0j-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_lcgl0z-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_lcf-xT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcf-xj-PEe--waJe9VgAOw" x="100" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_lcgl1D-PEe--waJe9VgAOw" type="2002" element="_lcafND-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_lcjCFT-PEe--waJe9VgAOw" type="3012" element="_lccUYD-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_lcjCGD-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_lcjCGT-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_lcjpID-PEe--waJe9VgAOw" type="3003" element="_lccUYT-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lcjpIT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcjpIj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_lcjCFj-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcjCFz-PEe--waJe9VgAOw" x="30" y="10" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lcjCGj-PEe--waJe9VgAOw" type="3012" element="_lccUYz-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_lcjCHT-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_lcjCHj-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_lcjpIz-PEe--waJe9VgAOw" type="3003" element="_lccUZD-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lcjpJD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcjpJT-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_lcjCGz-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcjCHD-PEe--waJe9VgAOw" x="5" y="31" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lcgl1z-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_lcgl2D-PEe--waJe9VgAOw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_lcgl2T-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_lcgl2j-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_lcgl1T-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcgl1j-PEe--waJe9VgAOw" x="200" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_lchM4D-PEe--waJe9VgAOw" type="2002" element="_lcbGQD-PEe--waJe9VgAOw">
+          <children xmi:type="notation:Node" xmi:id="_lcjpJj-PEe--waJe9VgAOw" type="3012" element="_lcc7cT-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_lckQMD-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_lckQMT-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_lck3QD-PEe--waJe9VgAOw" type="3003" element="_lcc7cj-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lck3QT-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lck3Qj-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_lcjpJz-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lcjpKD-PEe--waJe9VgAOw" x="11" y="100" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lckQMj-PEe--waJe9VgAOw" type="3012" element="_lcdigT-PEe--waJe9VgAOw">
+            <children xmi:type="notation:Node" xmi:id="_lckQNT-PEe--waJe9VgAOw" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_lckQNj-PEe--waJe9VgAOw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_lck3Qz-PEe--waJe9VgAOw" type="3003" element="_lcdigj-PEe--waJe9VgAOw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lck3RD-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lck3RT-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_lckQMz-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lckQND-PEe--waJe9VgAOw" x="34" y="30" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lchz8D-PEe--waJe9VgAOw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_lcibAD-PEe--waJe9VgAOw" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_lck3Rj-PEe--waJe9VgAOw" type="3008" element="_lcdihD-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_lck3ST-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_lck3Sj-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_lck3Sz-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_lck3TD-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_lck3TT-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lck3Rz-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lck3SD-PEe--waJe9VgAOw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_lck3Tj-PEe--waJe9VgAOw" type="3008" element="_lceJkj-PEe--waJe9VgAOw">
+              <children xmi:type="notation:Node" xmi:id="_lck3UT-PEe--waJe9VgAOw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_lck3Uj-PEe--waJe9VgAOw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_lck3Uz-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_lck3VD-PEe--waJe9VgAOw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_lck3VT-PEe--waJe9VgAOw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lck3Tz-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lck3UD-PEe--waJe9VgAOw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_lcibAT-PEe--waJe9VgAOw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_lcibAj-PEe--waJe9VgAOw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_lchM4T-PEe--waJe9VgAOw" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lchM4j-PEe--waJe9VgAOw" x="300" y="20"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Hf8sAETgEe-1qJZv2Fx6GA" type="2002" element="_HfeK50TgEe-1qJZv2Fx6GA">
+          <children xmi:type="notation:Node" xmi:id="_HgHEEETgEe-1qJZv2Fx6GA" type="3012" element="_HficUETgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_HgJgUETgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_HgJgUUTgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HgVGgETgEe-1qJZv2Fx6GA" type="3003" element="_HficUUTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HgVGgUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgVGgkTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_HgHEEUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgHEEkTgEe-1qJZv2Fx6GA" x="12" y="-12" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_HgQ1EETgEe-1qJZv2Fx6GA" type="3012" element="_HficU0TgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_HgQ1E0TgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_HgQ1FETgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HgVtkETgEe-1qJZv2Fx6GA" type="3003" element="_HficVETgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HgVtkUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgVtkkTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_HgQ1EUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgQ1EkTgEe-1qJZv2Fx6GA" y="31" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_HgRcIETgEe-1qJZv2Fx6GA" type="3012" element="_HfjDYUTgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_HgRcI0TgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_HgRcJETgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HgVtk0TgEe-1qJZv2Fx6GA" type="3003" element="_HfjDYkTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HgVtlETgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgVtlUTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_HgRcIUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgRcIkTgEe-1qJZv2Fx6GA" x="34" y="44" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_HgSDMETgEe-1qJZv2Fx6GA" type="3012" element="_HfjqcETgEe-1qJZv2Fx6GA">
+            <children xmi:type="notation:Node" xmi:id="_HgSDM0TgEe-1qJZv2Fx6GA" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_HgSDNETgEe-1qJZv2Fx6GA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HgWUoETgEe-1qJZv2Fx6GA" type="3003" element="_HfjqcUTgEe-1qJZv2Fx6GA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HgWUoUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgWUokTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_HgSDMUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgSDMkTgEe-1qJZv2Fx6GA" x="11" y="140" width="20" height="20"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_HgCLkETgEe-1qJZv2Fx6GA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_HgDZsETgEe-1qJZv2Fx6GA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_HgW7sETgEe-1qJZv2Fx6GA" type="3008" element="_Hfjqc0TgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_HgXiwETgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_HgYw4ETgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_HgYw4UTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_HgYw4kTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_HgYw40TgEe-1qJZv2Fx6GA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HgW7sUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgW7skTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HgZX8ETgEe-1qJZv2Fx6GA" type="3008" element="_HfkRgUTgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_HgZX80TgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_HgZX9ETgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_HgZX9UTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_HgZX9kTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_HgZX90TgEe-1qJZv2Fx6GA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HgZX8UTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgZX8kTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HgZX-ETgEe-1qJZv2Fx6GA" type="3008" element="_HfkRhETgEe-1qJZv2Fx6GA">
+              <children xmi:type="notation:Node" xmi:id="_HgZ_AETgEe-1qJZv2Fx6GA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_HgamEETgEe-1qJZv2Fx6GA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_HgamEUTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_HgamEkTgEe-1qJZv2Fx6GA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_HgamE0TgEe-1qJZv2Fx6GA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HgZX-UTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HgZX-kTgEe-1qJZv2Fx6GA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_HgDZsUTgEe-1qJZv2Fx6GA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_HgDZskTgEe-1qJZv2Fx6GA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Hf8sAUTgEe-1qJZv2Fx6GA" fontName="DejaVu Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Hf8sAkTgEe-1qJZv2Fx6GA" x="400" y="20"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_lcYqBD-PEe--waJe9VgAOw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_lceJlT-PEe--waJe9VgAOw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_lceJlj-PEe--waJe9VgAOw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lcZ4ID-PEe--waJe9VgAOw" name="p1" childrenPresentation="VerticalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p1"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lcZ4IT-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="255,245,181" foregroundColor="255,245,181">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lcafMT-PEe--waJe9VgAOw" name="p2" tooltipText="" childrenPresentation="VerticalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lcafMj-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="255,245,181" foregroundColor="255,245,181">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lcbGQz-PEe--waJe9VgAOw" name="p21" tooltipText="">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p21"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lcbtUD-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="252,233,79" foregroundColor="252,233,79">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lcbtUj-PEe--waJe9VgAOw" name="p22" tooltipText="">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p2/p22"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lcbtUz-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="252,233,79" foregroundColor="252,233,79">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lcafND-PEe--waJe9VgAOw" name="p3" childrenPresentation="VerticalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p3"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_lccUYD-PEe--waJe9VgAOw" name="Class1" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class1"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_lccUYT-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_lccUYz-PEe--waJe9VgAOw" name="Class2" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p3/Class2"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_lccUZD-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lcafNT-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="255,245,181" foregroundColor="255,245,181">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lcbGQD-PEe--waJe9VgAOw" name="p4" tooltipText="" childrenPresentation="VerticalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_lcc7cT-PEe--waJe9VgAOw" name="Class3" tooltipText="" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class3"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_lcc7cj-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_lcdigT-PEe--waJe9VgAOw" name="Class4" tooltipText="" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p4/p41/Class4"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_lcdigj-PEe--waJe9VgAOw" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lcbGQT-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="255,245,181" foregroundColor="255,245,181">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lcdihD-PEe--waJe9VgAOw" name="p41" tooltipText="">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p41"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lceJkD-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="252,233,79" foregroundColor="252,233,79">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_lceJkj-PEe--waJe9VgAOw" name="p42" tooltipText="">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p4/p42"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_lceJkz-PEe--waJe9VgAOw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="252,233,79" foregroundColor="252,233,79">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HfeK50TgEe-1qJZv2Fx6GA" name="p5" childrenPresentation="VerticalStack">
+      <target xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_HficUETgEe-1qJZv2Fx6GA" name="Class5" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class5"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_HficUUTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_HficU0TgEe-1qJZv2Fx6GA" name="Class6" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p51/Class6"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_HficVETgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_HfjDYUTgEe-1qJZv2Fx6GA" name="Class7" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class7"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_HfjDYkTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_HfjqcETgEe-1qJZv2Fx6GA" name="Class8" width="2" height="2">
+        <target xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+        <semanticElements xmi:type="ecore:EClass" href="My.ecore#//p5/p53/Class8"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_HfjqcUTgEe-1qJZv2Fx6GA" showIcon="false" labelPosition="node" color="214,197,66">
+          <description xmi:type="style:SquareDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@borderedNodeMappings[name='BorderClass']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HffZAETgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="255,245,181" foregroundColor="255,245,181">
+        <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Hfjqc0TgEe-1qJZv2Fx6GA" name="p51">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p51"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HfjqdETgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="252,233,79" foregroundColor="252,233,79">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HfkRgUTgEe-1qJZv2Fx6GA" name="p52">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p52"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HfkRgkTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="252,233,79" foregroundColor="252,233,79">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HfkRhETgEe-1qJZv2Fx6GA" name="p53">
+        <target xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <semanticElements xmi:type="ecore:EPackage" href="My.ecore#//p5/p53"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HfkRhUTgEe-1qJZv2Fx6GA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="252,233,79" foregroundColor="252,233,79">
+          <description xmi:type="style:FlatContainerStyleDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer/@containerMappings[name='EPackageVStackMapping']/@subContainerMappings[name='EPackageContainerInHStack']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_lcYC8D-PEe--waJe9VgAOw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="My.odesign#//@ownedViewpoints[name='SampleWithContainers']/@ownedRepresentations[name='DiagramWithVStackContainers']/@defaultLayer"/>
+    <target xmi:type="ecore:EPackage" href="My.ecore#/"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/BorderedNodeCreationTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/BorderedNodeCreationTest.java
@@ -637,7 +637,7 @@ public class BorderedNodeCreationTest extends AbstractSiriusSwtBotGefTestCase {
             errorMessage = "the BorderedNode has been created at wrong location (for near collapsed bordered node case).";
         }
         // Check GMF
-        Point gmfNodeLocation = GMFHelper.getAbsoluteLocation((Node) borderNodePart.getModel(), true);
+        Point gmfNodeLocation = GMFHelper.getAbsoluteLocation((Node) borderNodePart.getModel(), true, true);
         assertSameLocation("For GMF, " + errorMessage, expectedLocation, gmfNodeLocation, parentLocation, creationLocation, parentPart);
         // Check Draw2d
         assertSameLocation("For Draw2d, " + errorMessage, expectedLocation, nodeLocation, parentLocation, creationLocation, parentPart);

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/BorderedNodeCreationWithSnapToGridTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/BorderedNodeCreationWithSnapToGridTest.java
@@ -89,8 +89,8 @@ public class BorderedNodeCreationWithSnapToGridTest extends BorderedNodeCreation
 
         assertFalse("Second border node should not overlap the first one (draw2d).", firstNewNodeAbsoluteBounds.intersects(secondNewNodeAbsoluteLocation));
 
-        Rectangle firstNewNodeGMFBounds = GMFHelper.getAbsoluteBounds((Node) firstNewNode.part().getModel());
-        Rectangle secondNewNodeGMFBounds = GMFHelper.getAbsoluteBounds((Node) secondNewNode.part().getModel());
+        Rectangle firstNewNodeGMFBounds = GMFHelper.getAbsoluteBounds((Node) firstNewNode.part().getModel(), false, false, false, true);
+        Rectangle secondNewNodeGMFBounds = GMFHelper.getAbsoluteBounds((Node) secondNewNode.part().getModel(), false, false, false, true);
 
         assertFalse("Second border node should not overlap the first one (GMF).", firstNewNodeGMFBounds.intersects(secondNewNodeGMFBounds));
 

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeWithBorderNodeCreationPositionWithSnapToGridTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/EdgeWithBorderNodeCreationPositionWithSnapToGridTest.java
@@ -87,14 +87,14 @@ public class EdgeWithBorderNodeCreationPositionWithSnapToGridTest extends EdgeWi
         Point draw2DSourceBNLocation = GraphicalHelper.getAbsoluteBoundsIn100Percent(source, true).getTopLeft();
         assertTrue("For starting point (" + draw2DSourceBNLocation.preciseX() + ", " + draw2DSourceBNLocation.preciseY() + "), the x or y coordinate should be on the grid (step=" + gridStep
                 + ") or at least one should be the same as parent: " + parentSourceBounds + ".", checkLocation(draw2DSourceBNLocation, parentSourceBounds));
-        Point gmfSourceBNLocation = GMFHelper.getAbsoluteLocation((Node) source.getModel(), true);
+        Point gmfSourceBNLocation = GMFHelper.getAbsoluteLocation((Node) source.getModel(), true, true);
         assertEquals("The computing starting point from GMF data should be the same than draw2D", draw2DSourceBNLocation, gmfSourceBNLocation);
 
         Rectangle parentTargetBounds = GraphicalHelper.getAbsoluteBoundsIn100Percent(target, true);
         Point draw2DTargetBNLocation = GraphicalHelper.getAbsoluteBoundsIn100Percent(target, true).getTopLeft();
         assertTrue("For ending point (" + draw2DTargetBNLocation.preciseX() + ", " + draw2DTargetBNLocation.preciseY() + "), the x or y coordinate should be on the grid (step=" + gridStep
                 + ") or at least one should be the same as parent: " + parentTargetBounds + ".", checkLocation(draw2DTargetBNLocation, parentTargetBounds));
-        Point gmfTargetBNLocation = GMFHelper.getAbsoluteLocation((Node) target.getModel(), true);
+        Point gmfTargetBNLocation = GMFHelper.getAbsoluteLocation((Node) target.getModel(), true, true);
         assertEquals("The computing starting point from GMF data should be the same than draw2D", draw2DTargetBNLocation, gmfTargetBNLocation);
         // Contrary to super class, the checkSide are not done because
         // snapToGrid is enabled and has effect on the side.

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/GMFHelperTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/GMFHelperTest.java
@@ -273,7 +273,7 @@ public class GMFHelperTest extends AbstractSiriusSwtBotGefTestCase {
         // It's strange, the above method does not return absolute bounds. To check in another commit. And the method
         // GraphicalHelper.getAbsoluteBoundsIn100Percent consider handleBounds and this is not what is expected here.
         ((GraphicalEditPart) swtBotEditPart.part()).getFigure().translateToAbsolute(draw2DAbsoluteBounds);
-        Rectangle gmfAbsoluteBounds = GMFHelper.getAbsoluteBounds((Node) swtBotEditPart.part().getModel(), true);
+        Rectangle gmfAbsoluteBounds = GMFHelper.getAbsoluteBounds((Node) swtBotEditPart.part().getModel(), true, false, false, false);
         assertEquals("The GMF width of " + elementToCheckName + " in " + representationName + " does not correspond to the Draw2D one.", draw2DAbsoluteBounds.preciseWidth(),
                 gmfAbsoluteBounds.preciseWidth());
         assertEquals("The GMF height of " + elementToCheckName + " in " + representationName + " does not correspond to the Draw2D one.", draw2DAbsoluteBounds.preciseHeight(),

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/GMFHelperTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/GMFHelperTest.java
@@ -1,0 +1,286 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.tests.swtbot.layout;
+
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainer2EditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerEditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListEditPart;
+import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeListElementEditPart;
+import org.eclipse.sirius.diagram.ui.internal.refresh.GMFHelper;
+import org.eclipse.sirius.tests.swtbot.Activator;
+import org.eclipse.sirius.tests.swtbot.support.api.AbstractSiriusSwtBotGefTestCase;
+import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation.ZoomLevel;
+import org.eclipse.sirius.tests.swtbot.support.api.business.UIResource;
+import org.eclipse.sirius.tests.swtbot.support.api.editor.SWTBotSiriusDiagramEditor;
+import org.eclipse.sirius.tests.swtbot.support.api.view.DesignerViews;
+import org.eclipse.sirius.tests.swtbot.support.utils.SWTBotUtils;
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
+
+/**
+ * Tests defined to ensure that GMF Helper returns correct absolute GMF bounds.
+ * 
+ * TODO: - Add tests for border nodes bounds - Add tests for nodes bounds (inside container)
+ * 
+ * @author lredor
+ */
+public class GMFHelperTest extends AbstractSiriusSwtBotGefTestCase {
+
+    private static final String FREE_FORM_CONTAINER_REPRESENTATION_NAME = "DiagramWithFreeFormContainers";
+
+    private static final String LIST_CONTAINER_REPRESENTATION_NAME = "DiagramWithListContainers";
+
+    private static final String HSTACK_CONTAINER_REPRESENTATION_NAME = "DiagramWithHStackContainers";
+
+    private static final String VSTACK_CONTAINER_REPRESENTATION_NAME = "DiagramWithVStackContainers";
+
+    private static final String MODEL = "My.ecore";
+
+    private static final String SESSION_FILE = "representations.aird";
+
+    private static final String ODESIGN_FILE = "My.odesign";
+
+    private static final String DATA_UNIT_DIR = "data/unit/layout/gmfHelper/";
+
+    private static final String FILE_DIR = "/";
+
+    /**
+     * The name of a container that is empty.
+     */
+    private static final String EMPTY_CONTAINER_NAME = "p1";
+
+    /**
+     * The name of a container with children.
+     */
+    private static final String CONTAINER_WITH_CHILDREN_NAME = "p2";
+
+    /**
+     * The name of a container that is empty and in another container
+     */
+    private static final String EMPTY_CONTAINER_INSIDE_CONTAINER_NAME = "p22";
+
+
+    /**
+     * The name of an empty container with border node.
+     */
+    private static final String EMPTY_CONTAINER_WITH_BORDER_NODE_NAME = "p3";
+
+    /**
+     * The name of a container with children having border node.
+     */
+    private static final String CONTAINER_WITH_2_CHILDREN_HAVING_BORDER_NODE_NAME = "p4";
+
+    /**
+     * The name of an empty container with border node, inside a container.
+     */
+    private static final String EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_2_NAME = "p41";
+
+    /**
+     * The name of a container with children having border node.
+     */
+    private static final String CONTAINER_WITH_3_CHILDREN_HAVING_BORDER_NODE_NAME = "p5";
+
+    /**
+     * The name of an empty container with border node, inside a container.
+     */
+    private static final String EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_3_NAME = "p53";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onSetUpBeforeClosingWelcomePage() throws Exception {
+        copyFileToTestProject(Activator.PLUGIN_ID, DATA_UNIT_DIR, MODEL, SESSION_FILE, ODESIGN_FILE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onSetUpAfterOpeningDesignerPerspective() throws Exception {
+        sessionAirdResource = new UIResource(designerProject, FILE_DIR, SESSION_FILE);
+        localSession = designerPerspective.openSessionFromFile(sessionAirdResource);
+        closeOutline();
+    }
+
+    /**
+     * Method to open an editor. It should be called at the beginning of each test.
+     * 
+     * @param representationName
+     *            The name of the representation to be opened.
+     */
+    private void openEditor(String representationName) {
+        editor = (SWTBotSiriusDiagramEditor) openRepresentation(localSession.getOpenedSession(), representationName, representationName, DDiagram.class, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void tearDown() throws Exception {
+        // Go to the origin to avoid scroll bar
+        editor.scrollTo(0, 0);
+        // Restore the default zoom level
+        editor.click(1, 1); // Set the focus on the diagram
+        editor.zoom(ZoomLevel.ZOOM_100);
+        // Go to the origin to avoid scroll bar
+        editor.scrollTo(0, 0);
+        // Reopen outline
+        new DesignerViews(bot).openOutlineView();
+        SWTBotUtils.waitAllUiEvents();
+        super.tearDown();
+    }
+
+    public void testFreeFormContainerBounds_1() {
+        testFreeFormContainerBounds(EMPTY_CONTAINER_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testFreeFormContainerBounds_2() {
+        testFreeFormContainerBounds(CONTAINER_WITH_CHILDREN_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testFreeFormContainerBounds_3() {
+        testFreeFormContainerBounds(EMPTY_CONTAINER_INSIDE_CONTAINER_NAME, DNodeContainer2EditPart.class);
+    }
+
+    public void testFreeFormContainerBounds_4() {
+        testFreeFormContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testFreeFormContainerBounds_5() {
+        testFreeFormContainerBounds(CONTAINER_WITH_2_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+        testFreeFormContainerBounds(CONTAINER_WITH_3_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testFreeFormContainerBounds_6() {
+        testFreeFormContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_2_NAME, DNodeContainer2EditPart.class);
+        testFreeFormContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_3_NAME, DNodeContainerEditPart.class);
+    }
+
+
+    public void testListContainerBounds_1() {
+        testListContainerBounds(EMPTY_CONTAINER_NAME, DNodeListEditPart.class);
+    }
+
+    public void testListContainerBounds_2() {
+        testListContainerBounds(CONTAINER_WITH_CHILDREN_NAME, DNodeListEditPart.class);
+    }
+
+    public void testListContainerBounds_3() {
+        testListContainerBounds(EMPTY_CONTAINER_INSIDE_CONTAINER_NAME, DNodeListElementEditPart.class);
+    }
+
+    public void testListContainerBounds_4() {
+        testListContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_NAME, DNodeListEditPart.class);
+    }
+
+    public void testListContainerBounds_5() {
+        testListContainerBounds(CONTAINER_WITH_2_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeListEditPart.class);
+        testListContainerBounds(CONTAINER_WITH_3_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeListEditPart.class);
+    }
+
+    public void testListContainerBounds_6() {
+        testListContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_2_NAME, DNodeListElementEditPart.class);
+        testListContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_3_NAME, DNodeListElementEditPart.class);
+    }
+
+    public void testHStackContainerBounds_1() {
+        testHStackContainerBounds(EMPTY_CONTAINER_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testHStackContainerBounds_2() {
+        testHStackContainerBounds(CONTAINER_WITH_CHILDREN_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testHStackContainerBounds_3() {
+        testHStackContainerBounds(EMPTY_CONTAINER_INSIDE_CONTAINER_NAME, DNodeContainer2EditPart.class);
+    }
+
+    public void testHStackContainerBounds_4() {
+        testHStackContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testHStackContainerBounds_5() {
+        testHStackContainerBounds(CONTAINER_WITH_2_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+        testHStackContainerBounds(CONTAINER_WITH_3_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testHStackContainerBounds_6() {
+        testHStackContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_2_NAME, DNodeContainer2EditPart.class);
+        testHStackContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_3_NAME, DNodeContainer2EditPart.class);
+    }
+
+    public void testVStackContainerBounds_1() {
+        testVStackContainerBounds(EMPTY_CONTAINER_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testVStackContainerBounds_2() {
+        testVStackContainerBounds(CONTAINER_WITH_CHILDREN_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testVStackContainerBounds_3() {
+        testVStackContainerBounds(EMPTY_CONTAINER_INSIDE_CONTAINER_NAME, DNodeContainer2EditPart.class);
+    }
+
+    public void testVStackContainerBounds_4() {
+        testVStackContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testVStackContainerBounds_5() {
+        testVStackContainerBounds(CONTAINER_WITH_2_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+        testVStackContainerBounds(CONTAINER_WITH_3_CHILDREN_HAVING_BORDER_NODE_NAME, DNodeContainerEditPart.class);
+    }
+
+    public void testVStackContainerBounds_6() {
+        testVStackContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_2_NAME, DNodeContainer2EditPart.class);
+        testVStackContainerBounds(EMPTY_CONTAINER_WITH_BORDER_NODE_INSIDE_CONTAINER_3_NAME, DNodeContainer2EditPart.class);
+    }
+
+    private void testFreeFormContainerBounds(String elementToCheckName, Class<? extends EditPart> expectedEditPartType) {
+        testContainerBounds(FREE_FORM_CONTAINER_REPRESENTATION_NAME, elementToCheckName, expectedEditPartType);
+    }
+
+    private void testListContainerBounds(String elementToCheckName, Class<? extends EditPart> expectedEditPartType) {
+        testContainerBounds(LIST_CONTAINER_REPRESENTATION_NAME, elementToCheckName, expectedEditPartType);
+    }
+
+    private void testHStackContainerBounds(String elementToCheckName, Class<? extends EditPart> expectedEditPartType) {
+        testContainerBounds(HSTACK_CONTAINER_REPRESENTATION_NAME, elementToCheckName, expectedEditPartType);
+    }
+
+    private void testVStackContainerBounds(String elementToCheckName, Class<? extends EditPart> expectedEditPartType) {
+        testContainerBounds(VSTACK_CONTAINER_REPRESENTATION_NAME, elementToCheckName, expectedEditPartType);
+    }
+
+    private void testContainerBounds(String representationName, String elementToCheckName, Class<? extends EditPart> expectedEditPartType) {
+        openEditor(representationName);
+        SWTBotGefEditPart swtBotEditPart = editor.getEditPart(elementToCheckName, expectedEditPartType);
+        Rectangle draw2DAbsoluteBounds = editor.getAbsoluteBounds(swtBotEditPart);
+        // It's strange, the above method does not return absolute bounds. To check in another commit. And the method
+        // GraphicalHelper.getAbsoluteBoundsIn100Percent consider handleBounds and this is not what is expected here.
+        ((GraphicalEditPart) swtBotEditPart.part()).getFigure().translateToAbsolute(draw2DAbsoluteBounds);
+        Rectangle gmfAbsoluteBounds = GMFHelper.getAbsoluteBounds((Node) swtBotEditPart.part().getModel(), true);
+        assertEquals("The GMF width of " + elementToCheckName + " in " + representationName + " does not correspond to the Draw2D one.", draw2DAbsoluteBounds.preciseWidth(),
+                gmfAbsoluteBounds.preciseWidth());
+        assertEquals("The GMF height of " + elementToCheckName + " in " + representationName + " does not correspond to the Draw2D one.", draw2DAbsoluteBounds.preciseHeight(),
+                gmfAbsoluteBounds.preciseHeight());
+        assertEquals("The GMF x coordinate of " + elementToCheckName + " in " + representationName + " does not correspond to the Draw2D one.", draw2DAbsoluteBounds.preciseX(),
+                gmfAbsoluteBounds.preciseX());
+        assertEquals("The GMF y coordinate of " + elementToCheckName + " in " + representationName + " does not correspond to the Draw2D one.", draw2DAbsoluteBounds.preciseY(),
+                gmfAbsoluteBounds.preciseY());
+    }
+}

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
@@ -56,6 +56,7 @@ import org.eclipse.sirius.tests.swtbot.layout.EdgeCopyPasteFormatTest;
 import org.eclipse.sirius.tests.swtbot.layout.EdgeLabelsAlignAndDistributeTests;
 import org.eclipse.sirius.tests.swtbot.layout.EdgeLayoutStabilityWithToolWizardTest;
 import org.eclipse.sirius.tests.swtbot.layout.EdgeStabilityOnCopyPasteLayoutTest;
+import org.eclipse.sirius.tests.swtbot.layout.GMFHelperTest;
 import org.eclipse.sirius.tests.swtbot.layout.LayoutStabilityOnManualRefreshTest;
 import org.eclipse.sirius.tests.swtbot.layout.ModifyEdgeLayoutAfterRefreshTest;
 import org.eclipse.sirius.tests.swtbot.layout.PackageLayoutStabilityOnManyViewsCreationToolTest;
@@ -445,6 +446,7 @@ public class AllTestSuite extends TestCase {
         suite.addTestSuite(PackageLayoutStabilityOnManyViewsCreationToolTest.class);
         suite.addTestSuite(ResetOriginTest.class);
         suite.addTestSuite(LayoutStabilityOnManualRefreshTest.class);
+        suite.addTestSuite(GMFHelperTest.class);
         suite.addTestSuite(EdgeAndPortStabilityOnSemanticChangeTest.class);
         suite.addTestSuite(SessionSaveableTest.class);
         suite.addTest(new JUnit4TestAdapter(DragAndDropFromControlledResourceTest.class));

--- a/plugins/org.eclipse.sirius.ui.debug/src/org/eclipse/sirius/ui/debug/SiriusDebugView.java
+++ b/plugins/org.eclipse.sirius.ui.debug/src/org/eclipse/sirius/ui/debug/SiriusDebugView.java
@@ -311,10 +311,10 @@ public class SiriusDebugView extends AbstractDebugView {
             sb.append("Location (GMF):                    Location(" + location.getX() + ", " + location.getY() + ")\n");
         }
 
-        Rectangle absoluteBounds = GMFHelper.getAbsoluteBounds(node, true);
+        Rectangle absoluteBounds = GMFHelper.getAbsoluteBounds(node, true, false, false, false);
         sb.append("Bounds (GMF absolute - insets):    " + absoluteBounds + "\n");
 
-        absoluteBounds = GMFHelper.getAbsoluteBounds(node, false);
+        absoluteBounds = GMFHelper.getAbsoluteBounds(node, false, false, false, false);
         sb.append("Bounds (GMF absolute - no insets): " + absoluteBounds + "\n");
 
         Option<ISequenceElement> elt = ISequenceElementAccessor.getISequenceElement(part.getNotationView());

--- a/plugins/org.eclipse.sirius.ui.debug/src/org/eclipse/sirius/ui/debug/SiriusDebugView.java
+++ b/plugins/org.eclipse.sirius.ui.debug/src/org/eclipse/sirius/ui/debug/SiriusDebugView.java
@@ -124,6 +124,7 @@ import org.eclipse.sirius.diagram.ui.business.api.query.ViewQuery;
 import org.eclipse.sirius.diagram.ui.business.internal.query.EdgeTargetQuery;
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramContainerEditPart;
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramElementContainerEditPart;
+import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramListEditPart;
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNameEditPart;
 import org.eclipse.sirius.diagram.ui.edit.api.part.IAbstractDiagramNodeEditPart;
 import org.eclipse.sirius.diagram.ui.edit.api.part.IDiagramEdgeEditPart;
@@ -257,7 +258,12 @@ public class SiriusDebugView extends AbstractDebugView {
             appendSequenceEventInfo(part, sb);
             appendBoundsDetails(part, sb);
 
-            if (part instanceof AbstractDiagramContainerEditPart && ((AbstractDiagramContainerEditPart) part).isRegionContainer()) {
+            if (part instanceof AbstractDiagramListEditPart) {
+                part.getChildren().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).forEach(child -> {
+                    sb.append("Children bounds (" + child.getClass().getSimpleName() + "):\n");
+                    appendBoundsDetails(child, sb);
+                });
+            } else if (part instanceof AbstractDiagramContainerEditPart && ((AbstractDiagramContainerEditPart) part).isRegionContainer()) {
                 IGraphicalEditPart compartment = null;
                 for (IGraphicalEditPart child : Iterables.filter(part.getChildren(), IGraphicalEditPart.class)) {
                     sb.append("Children bounds:\n");


### PR DESCRIPTION
Several points are handled in this commit. It should maybe split in several commit to facilitate reviewing...

* Border nodes are wrongly considered in GMFHelper.getBottomRight

Because of typo, the border nodes are considered in org.eclipse.sirius.diagram.ui.internal.refresh.GMFHelper.getBottomRight(Node) when they should be ignored.

* Other cases to details

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/426