### PR TITLE
[428] Fix PaletteViewManagementTest regression

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/palette/PaletteManagerImpl.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/palette/PaletteManagerImpl.java
@@ -232,8 +232,10 @@ public class PaletteManagerImpl implements PaletteManager {
 
                 // Apply existing customizations to the palette
                 final PaletteViewer paletteViewer = editDomain.getPaletteViewer();
-                Optional.ofNullable((PaletteCustomizerEx) paletteViewer.getCustomizer()) //
-                        .ifPresent(custo -> custo.applyCustomizationsToPalette(paletteRoot));
+                if (paletteViewer != null) {
+                    Optional.ofNullable((PaletteCustomizerEx) paletteViewer.getCustomizer()) //
+                            .ifPresent(custo -> custo.applyCustomizationsToPalette(paletteRoot));
+                }
             }
         }
     }


### PR DESCRIPTION
Since enhancement #428, the test
PaletteViewManagementTest.testOpenPaletteOpenTwoDiagram() fails in tiemout. This commit fixes this problem.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/428