### PR TITLE
[341] Adapt to recent GEF Classic changes

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/tool/internal/edit/operation/SequenceEditPartsOperations.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/tool/internal/edit/operation/SequenceEditPartsOperations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -200,7 +200,7 @@ public final class SequenceEditPartsOperations {
      *            the key of the registry entry to remove.
      */
     public static void unregisterDiagramElement(IGraphicalEditPart self, EObject element) {
-        Map<Object, Object> registry = self.getViewer().getEditPartRegistry();
+        Map<?, ?> registry = self.getViewer().getEditPartRegistry();
         if (registry.get(element) == self) {
             registry.remove(element);
         }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/view/SiriusLayoutDataManagerImpl.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/business/internal/view/SiriusLayoutDataManagerImpl.java
@@ -737,7 +737,7 @@ public final class SiriusLayoutDataManagerImpl implements SiriusLayoutDataManage
             }
         }
         if (borderedCreatedViews != null && borderedCreatedViews.size() > 0) {
-            Map<View, EditPart> editPartRegistry = host.getRoot().getViewer().getEditPartRegistry();
+            Map<Object, EditPart> editPartRegistry = host.getRoot().getViewer().getEditPartRegistry();
 
             List<EditPart> editPartToLayout = borderedCreatedViews.stream() //
                     .map(adaptable -> adaptable.getAdapter(View.class)) //

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/internal/part/DiagramEdgeEditPartOperation.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/edit/internal/part/DiagramEdgeEditPartOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2021, 2023 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -413,7 +413,7 @@ public final class DiagramEdgeEditPartOperation {
     private static Point getPointFor(final EdgeTarget edgeTarget, final IDiagramEdgeEditPart self) {
         // Retrieve the view.
         View view = null;
-        final Map<View, EditPart> editPartRegistry = self.getRoot().getViewer().getEditPartRegistry();
+        final Map<Object, EditPart> editPartRegistry = self.getRoot().getViewer().getEditPartRegistry();
 
         for (final View currentView : DiagramEdgeEditPartOperation.getViews(edgeTarget, self)) {
             if (currentView.isVisible()) {

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/SiriusRulerEditPartFactory.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/SiriusRulerEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2018, 2024 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,15 @@ public class SiriusRulerEditPartFactory extends RulerEditPartFactory {
     }
 
     @Override
-    protected EditPart createRulerEditPart(EditPart parentEditPart, Object model) {
-        return new SiriusRulerEditPart(model);
+    public EditPart createEditPart(EditPart parentEditPart, Object model) {
+        // the model can be null when the contents of the root edit part are set
+        // to null
+        EditPart part = null;
+        if (isRuler(model)) {
+            part = new SiriusRulerEditPart(model);
+        } else if (model != null) {
+            part = new GuideEditPart(model);
+        }
+        return part;
     }
 }


### PR DESCRIPTION
The recent changes in question are:
* https://github.com/eclipse/gef-classic/commit/e5d6bac76ff38625b7c04877c0582452f04055ff#diff-07534b33eaa5ec93832be67ba799518320ca49589ed53976a24a66481e54e36e which changes the return type of `EditPartView.getEditPartRegistry()` from a plain/untyped `Map` into a `Map<Object, EditPart>`. The adaptation is trivial.
* https://github.com/eclipse/gef-classic/commit/4fce72b354db7af98cdb169d19b785a362560c81#diff-e157353a244e432d229f6caf980c2d097558bdd72baf4d3f9beb1d3162ec8bb3 is slightly more subtle as it removes a `protected` method we used to override (`createRulerEditPart`). To get a version which works with both old and new GEF versions, we now override the whole `createEditPart()` method instead. Hopefully its definition in GEF will not change in ways that would require us to update our own version in the future (we might not see it).

Locally these changes compile both with the 2023-03 and canary target platforms.
