### PR TITLE
[test] improves the restoration of preferences in the test

### DIFF
--- a/plugins/org.eclipse.sirius.tests.junit.support/src/org/eclipse/sirius/tests/support/api/SiriusTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.junit.support/src/org/eclipse/sirius/tests/support/api/SiriusTestCase.java
@@ -1620,8 +1620,6 @@ public abstract class SiriusTestCase extends TestCase {
     /**
      * Change a preference and store the old value. It will be automatically reset during tear down.
      * 
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     * 
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -1631,7 +1629,7 @@ public abstract class SiriusTestCase extends TestCase {
         SiriusAssert.assertNoDiagramUIPreferenceChangedinDiagramCoreStore(preferenceKey);
 
         int oldValue = Platform.getPreferencesService().getInt(DiagramPlugin.ID, preferenceKey, 0, null);
-        oldValueDiagramPreferences.put(preferenceKey, oldValue);
+        oldValueDiagramPreferences.putIfAbsent(preferenceKey, oldValue);
 
         IEclipsePreferences diagramCorePreferences = InstanceScope.INSTANCE.getNode(DiagramPlugin.ID);
         diagramCorePreferences.putInt(preferenceKey, newValue);
@@ -1643,8 +1641,6 @@ public abstract class SiriusTestCase extends TestCase {
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      * 
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     * 
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -1654,7 +1650,7 @@ public abstract class SiriusTestCase extends TestCase {
         SiriusAssert.assertNoDiagramUIPreferenceChangedinDiagramCoreStore(preferenceKey);
 
         boolean oldValue = Platform.getPreferencesService().getBoolean(DiagramPlugin.ID, preferenceKey, false, null);
-        oldValueDiagramPreferences.put(preferenceKey, oldValue);
+        oldValueDiagramPreferences.putIfAbsent(preferenceKey, oldValue);
 
         IEclipsePreferences diagramCorePreferences = InstanceScope.INSTANCE.getNode(DiagramPlugin.ID);
         diagramCorePreferences.putBoolean(preferenceKey, newValue);
@@ -1698,8 +1694,6 @@ public abstract class SiriusTestCase extends TestCase {
     /**
      * Change a preference and store the old value. It will be automatically reset during tear down.
      * 
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     * 
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -1707,15 +1701,14 @@ public abstract class SiriusTestCase extends TestCase {
      */
     protected void changeDiagramUIPreference(String preferenceKey, Integer newValue) {
         SiriusAssert.assertNoDiagramCorePreferenceChangedinDiagramUIStore(preferenceKey);
+
         final IPreferenceStore prefs = DiagramUIPlugin.getPlugin().getPreferenceStore();
-        oldValueDiagramUiPreferences.put(preferenceKey, prefs.getInt(preferenceKey));
+        oldValueDiagramUiPreferences.putIfAbsent(preferenceKey, prefs.getInt(preferenceKey));
         prefs.setValue(preferenceKey, newValue);
     }
 
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
-     * 
-     * TO CALL ONLY ONCE PER TEST (set up + test)
      * 
      * @param preferenceKey
      *            The key of the preference.
@@ -1724,8 +1717,9 @@ public abstract class SiriusTestCase extends TestCase {
      */
     protected void changeDiagramUIPreference(String preferenceKey, Boolean newValue) {
         SiriusAssert.assertNoDiagramCorePreferenceChangedinDiagramUIStore(preferenceKey);
+
         final IPreferenceStore prefs = DiagramUIPlugin.getPlugin().getPreferenceStore();
-        oldValueDiagramUiPreferences.put(preferenceKey, prefs.getBoolean(preferenceKey));
+        oldValueDiagramUiPreferences.putIfAbsent(preferenceKey, prefs.getBoolean(preferenceKey));
         prefs.setValue(preferenceKey, newValue);
     }
 
@@ -1778,8 +1772,6 @@ public abstract class SiriusTestCase extends TestCase {
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      * 
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     * 
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -1787,7 +1779,8 @@ public abstract class SiriusTestCase extends TestCase {
      */
     protected void changeSiriusPreference(String preferenceKey, Boolean newValue) {
         boolean oldValue = Platform.getPreferencesService().getBoolean(SiriusPlugin.ID, preferenceKey, false, null);
-        oldValueSiriusPreferences.put(preferenceKey, oldValue);
+
+        oldValueSiriusPreferences.putIfAbsent(preferenceKey, oldValue);
 
         IEclipsePreferences corePreferences = InstanceScope.INSTANCE.getNode(SiriusPlugin.ID);
         corePreferences.putBoolean(preferenceKey, newValue);
@@ -1799,8 +1792,6 @@ public abstract class SiriusTestCase extends TestCase {
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      * 
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     * 
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -1810,7 +1801,7 @@ public abstract class SiriusTestCase extends TestCase {
         SiriusAssert.assertNoSiriusCorePreferenceChangedinSiriusUIStore(preferenceKey);
 
         IPreferenceStore viewpointUIPrefs = SiriusEditPlugin.getPlugin().getPreferenceStore();
-        oldValueSiriusUIPreferences.put(preferenceKey, viewpointUIPrefs.getBoolean(preferenceKey));
+        oldValueSiriusUIPreferences.putIfAbsent(preferenceKey, viewpointUIPrefs.getBoolean(preferenceKey));
         viewpointUIPrefs.setValue(preferenceKey, newValue);
     }
 

--- a/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/AbstractSiriusSwtBotGefTestCase.java
@@ -588,8 +588,6 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
     /**
      * Change a preference and store the old value. It will be automatically reset during tear down.
      *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     *
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -599,7 +597,7 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         assertNoDiagramUIPreferenceChangedinDiagramCoreStore(preferenceKey);
 
         int oldValue = Platform.getPreferencesService().getInt(DiagramPlugin.ID, preferenceKey, 0, null);
-        oldValueDiagramPreferences.put(preferenceKey, oldValue);
+        oldValueDiagramPreferences.putIfAbsent(preferenceKey, oldValue);
 
         IEclipsePreferences diagramCorePreferences = InstanceScope.INSTANCE.getNode(DiagramPlugin.ID);
         diagramCorePreferences.putInt(preferenceKey, newValue);
@@ -611,8 +609,6 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     *
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -622,7 +618,7 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         assertNoDiagramUIPreferenceChangedinDiagramCoreStore(preferenceKey);
 
         boolean oldValue = Platform.getPreferencesService().getBoolean(DiagramPlugin.ID, preferenceKey, false, null);
-        oldValueDiagramPreferences.put(preferenceKey, oldValue);
+        oldValueDiagramPreferences.putIfAbsent(preferenceKey, oldValue);
 
         IEclipsePreferences diagramCorePreferences = InstanceScope.INSTANCE.getNode(DiagramPlugin.ID);
         diagramCorePreferences.putBoolean(preferenceKey, newValue);
@@ -664,8 +660,6 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     *
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -675,14 +669,12 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         assertNoDiagramCorePreferenceChangedinDiagramUIStore(preferenceKey);
 
         final IPreferenceStore prefs = DiagramUIPlugin.getPlugin().getPreferenceStore();
-        oldValueDiagramUIPreferences.put(preferenceKey, prefs.getBoolean(preferenceKey));
+        oldValueDiagramUIPreferences.putIfAbsent(preferenceKey, prefs.getBoolean(preferenceKey));
         UIThreadRunnable.syncExec(() -> prefs.setValue(preferenceKey, newValue));
     }
 
     /**
      * Change an int preference and store the old value. It will be automatically reset during tear down.
-     *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
      *
      * @param preferenceKey
      *            The key of the preference.
@@ -693,14 +685,12 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         assertNoDiagramCorePreferenceChangedinDiagramUIStore(preferenceKey);
 
         final IPreferenceStore prefs = DiagramUIPlugin.getPlugin().getPreferenceStore();
-        oldValueDiagramUIPreferences.put(preferenceKey, prefs.getInt(preferenceKey));
+        oldValueDiagramUIPreferences.putIfAbsent(preferenceKey, prefs.getInt(preferenceKey));
         UIThreadRunnable.syncExec(() -> prefs.setValue(preferenceKey, newValue));
     }
 
     /**
      * Change a double preference and store the old value. It will be automatically reset during tear down.
-     *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
      *
      * @param preferenceKey
      *            The key of the preference.
@@ -711,7 +701,7 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         assertNoDiagramCorePreferenceChangedinDiagramUIStore(preferenceKey);
 
         final IPreferenceStore prefs = DiagramUIPlugin.getPlugin().getPreferenceStore();
-        oldValueDiagramUIPreferences.put(preferenceKey, prefs.getDouble(preferenceKey));
+        oldValueDiagramUIPreferences.putIfAbsent(preferenceKey, prefs.getDouble(preferenceKey));
         UIThreadRunnable.syncExec(() -> prefs.setValue(preferenceKey, newValue));
     }
 
@@ -748,8 +738,6 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     *
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -757,7 +745,7 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
      */
     protected void changeSiriusPreference(String preferenceKey, Boolean newValue) {
         boolean oldValue = Platform.getPreferencesService().getBoolean(SiriusPlugin.ID, preferenceKey, false, null);
-        oldValueSiriusPreferences.put(preferenceKey, oldValue);
+        oldValueSiriusPreferences.putIfAbsent(preferenceKey, oldValue);
 
         IEclipsePreferences corePreferences = InstanceScope.INSTANCE.getNode(SiriusPlugin.ID);
         corePreferences.putBoolean(preferenceKey, newValue);
@@ -769,8 +757,6 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     *
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -778,7 +764,7 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
      */
     protected void changeSiriusCommonPreference(String preferenceKey, Boolean newValue) {
         boolean oldValue = Platform.getPreferencesService().getBoolean(SiriusPlugin.ID, preferenceKey, false, null);
-        oldValueCommonPreferences.put(preferenceKey, oldValue);
+        oldValueCommonPreferences.putIfAbsent(preferenceKey, oldValue);
 
         IEclipsePreferences corePreferences = InstanceScope.INSTANCE.getNode(SiriusTransPlugin.PLUGIN_ID);
         corePreferences.putBoolean(preferenceKey, newValue);
@@ -790,8 +776,6 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
     /**
      * Change a boolean preference and store the old value. It will be automatically reset during tear down.
      *
-     * TO CALL ONLY ONCE PER TEST (set up + test)
-     *
      * @param preferenceKey
      *            The key of the preference.
      * @param newValue
@@ -801,7 +785,7 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
         assertNoSiriusCorePreferenceChangedinSiriusUIStore(preferenceKey);
 
         IPreferenceStore viewpointUIPrefs = SiriusEditPlugin.getPlugin().getPreferenceStore();
-        oldValueSiriusUIPreferences.put(preferenceKey, viewpointUIPrefs.getBoolean(preferenceKey));
+        oldValueSiriusUIPreferences.putIfAbsent(preferenceKey, viewpointUIPrefs.getBoolean(preferenceKey));
         viewpointUIPrefs.setValue(preferenceKey, newValue);
     }
 
@@ -815,7 +799,7 @@ public abstract class AbstractSiriusSwtBotGefTestCase extends SWTBotGefTestCase 
      */
     protected void changePlatformUIPreference(String preferenceKey, Boolean newValue) {
         IPreferenceStore viewpointUIPrefs = PlatformUI.getPreferenceStore();
-        oldPlatformUIPreferences.put(preferenceKey, viewpointUIPrefs.getBoolean(preferenceKey));
+        oldPlatformUIPreferences.putIfAbsent(preferenceKey, viewpointUIPrefs.getBoolean(preferenceKey));
         viewpointUIPrefs.setValue(preferenceKey, newValue);
     }
 


### PR DESCRIPTION
This commit improves the preference change methods, so that it can be called several times without any problem to restore the initial value.