### PR TITLE
[460] Add extension point for color palette popup providers

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/plugin.properties
+++ b/plugins/org.eclipse.sirius.diagram.ui/plugin.properties
@@ -94,6 +94,7 @@ command.validateDiagram.label = Validate diagram
 command.validateDiagram.name = Validate Diagram
 command.setLinkNoteTarget.label = Set target representation ...
 command.setLinkNoteTarget.name = Set target representation
+extension-point.colorPalettePopupProvider.name = org.eclipse.sirius.diagram.ui.colorPalettePopupProvider
 extension-point.diagramIdentifierProvider.name = org.eclipse.sirius.diagram.ui.diagramIdentifierProvider
 extension-point.formatDataManager.name = org.eclipse.sirius.diagram.ui.formatDataManager
 extension-point.imageSelector.name = org.eclipse.sirius.diagram.ui.imageSelector

--- a/plugins/org.eclipse.sirius.diagram.ui/plugin.xml
+++ b/plugins/org.eclipse.sirius.diagram.ui/plugin.xml
@@ -23,6 +23,7 @@
    <extension-point id="imageSelector" name="%extension-point.imageSelector.name" schema="schema/imageSelector.exsd"/>
    <extension-point id="tabbarContributor" name="%extension-point.tabbarContributor.name" schema="schema/tabbarContributor.exsd"/>
    <extension-point id="customLayoutAlgorithmProvider" name="%extension-point.customLayoutAlgorithmProvider.name" schema="schema/customLayoutAlgorithmProvider.exsd"/>
+   <extension-point id="colorPalettePopupProvider" name="%extension-point.colorPalettePopupProvider.name" schema="schema/colorPalettePopupProvider.exsd"/>
 
    <extension point="org.eclipse.ui.elementFactories">
      <factory

--- a/plugins/org.eclipse.sirius.diagram.ui/schema/colorPalettePopupProvider.exsd
+++ b/plugins/org.eclipse.sirius.diagram.ui/schema/colorPalettePopupProvider.exsd
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.sirius.diagram.ui" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.eclipse.sirius.diagram.ui" id="colorPalettePopupProvider" name="%extension-point.colorPalettePopupProvider.name"/>
+      </appInfo>
+      <documentation>
+         This extension allows to provide a custom color palette popup by registering a color palette popup provider.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="colorPalettePopupProvider" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="colorPalettePopupProvider">
+      <annotation>
+         <documentation>
+            This element defines new Color Palette Popup Provider.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="providerClass" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The provider implementation.
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.sirius.diagram.ui.tools.api.color.ColorPalettePopupProvider"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The identifier of the provider instance
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         7.4.3
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         The following is an example of a color palette popup provider:
+&lt;p&gt;
+&lt;pre&gt;
+   &lt;extension
+         point=&quot;org.eclipse.sirius.diagram.ui.colorPalettePopupProvider&quot;&gt;
+      &lt;colorPalettePopupProvider
+             id=&quot;viewpoint.sample.customizedColorPalettePopupProvider&quot;
+             providerClass=&quot;org.eclipse.sirius.sample.CustomizedColorPalettePopupProvider&quot;&gt;
+      &lt;/colorPalettePopupProvider&gt;
+   &lt;/extension&gt;
+&lt;/pre&gt;
+&lt;/p&gt;
+&lt;p&gt;
+Here is the sample provider implementation :
+&lt;pre&gt;
+package org.eclipse.sirius.sample.analysis;
+
+import java.util.List;
+
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.diagram.ui.tools.api.color.ColorPalettePopupProvider;
+import org.eclipse.sirius.diagram.ui.tools.api.color.IColorPalettePopup;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Simple implementation.
+ */
+public class CustomizedColorPalettePopupProvider implements ColorPalettePopupProvider {
+
+    public CustomizedColorPalettePopupProvider() {
+    }
+
+    @Override
+    public boolean provides(Session session) {
+        return true;
+    }
+
+    @Override
+    public IColorPalettePopup getColorPalettePopup(Shell parent, Session session, List&lt;IGraphicalEditPart&gt; editParts, String propertyId) {
+        return new CustomizedColorPalettePopup(parent, session, editParts, propertyId);
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+
+}
+
+&lt;/pre&gt;
+&lt;/p&gt;
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="copyright"/>
+      </appInfo>
+      <documentation>
+         Copyright (c) 2024 Obeo&lt;br&gt;
+
+ This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+which accompanies this distribution, and is available at
+&lt;a href=&quot;https://www.eclipse.org/legal/epl-2.0&quot;&gt;https://www.eclipse.org/legal/epl-v20.html&lt;/a&gt;/
+
+SPDX-License-Identifier: EPL-2.0
+      </documentation>
+   </annotation>
+
+</schema>

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/ColorPalettePopupProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/ColorPalettePopupProvider.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.tools.api.color;
+
+import java.util.List;
+
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Interface for providing a {@link IColorPalettePopup}.
+ * 
+ * @author <a href="mailto:glenn.plouhinec@obeo.fr">Glenn Plouhinec</a>
+ */
+public interface ColorPalettePopupProvider {
+
+    /**
+     * Determines if this provider can supply a {@link IColorPalettePopup} for the specified session.
+     * 
+     * @param session
+     *            the active Sirius session.
+     * @return <code>true</code> if this provider supports the given session, <code>false</code> otherwise.
+     */
+    boolean provides(Session session);
+
+    /**
+     * Creates and returns an instance of {@link IColorPalettePopup}.
+     * 
+     * @param parent
+     *            the parent shell where the popup should appear on.
+     * @param session
+     *            the current sirius session.
+     * @param editParts
+     *            the list of selected edit parts.
+     * @param propertyId
+     *            the propertyID, which could be "notation.FillStyle.fillColor", "notation.LineStyle.lineColor", or
+     *            "notation.FontStyle.fontColor".
+     * @return the appropriate {@link IColorPalettePopup} instance.
+     */
+    IColorPalettePopup getColorPalettePopup(Shell parent, Session session, List<IGraphicalEditPart> editParts, String propertyId);
+
+    /**
+     * Returns the priority of this provider. Providers with higher priority are selected first by the
+     * {@link ColorPalettePopupService#getColorPalettePopup}.
+     * 
+     * @return the priority, where zero indicates the lowest priority.
+     */
+    int getPriority();
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/ColorPalettePopupService.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/ColorPalettePopupService.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.tools.api.color;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.common.tools.api.util.EclipseUtil;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Service responsible for retrieving an {@link IColorPalettePopup} implementation. This service allows dynamic
+ * selection of a color palette popup based on available providers, which can be either custom or the default Sirius
+ * provider. The popup helps users select colors for graphical elements.
+ * <p>
+ * It selects the appropriate {@link ColorPalettePopupProvider} according to priority, with the ability to fall back on
+ * the default provider when no custom one is available.
+ * </p>
+ * 
+ * @author <a href="mailto:glenn.plouhinec@obeo.fr">Glenn Plouhinec</a>
+ */
+public final class ColorPalettePopupService {
+
+    /**
+     * Extension point ID for {@link ColorPalettePopupProvider}.
+     */
+    public static final String ID = "org.eclipse.sirius.diagram.ui.colorPalettePopupProvider"; //$NON-NLS-1$
+
+    /**
+     * Extension point attribute for the {@link ColorPalettePopupProvider} class.
+     */
+    public static final String CLASS_ATTRIBUTE = "providerClass"; //$NON-NLS-1$
+
+    private static ColorPalettePopupProvider defaultSiriusProvider;
+
+    private static List<ColorPalettePopupProvider> customProviders;
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ColorPalettePopupService() {
+    }
+
+    /**
+     * Retrieves the appropriate {@link IColorPalettePopup} to display based on the given session, edit parts, and
+     * property ID. The method first checks custom providers sorted by priority and falls back on the default provider
+     * if necessary.
+     * 
+     * @param parent
+     *            the parent shell where the popup should appear on.
+     * @param session
+     *            the current sirius session.
+     * @param editParts
+     *            the list of selected edit parts.
+     * @param propertyId
+     *            the propertyID, which could be "notation.FillStyle.fillColor", "notation.LineStyle.lineColor", or
+     *            "notation.FontStyle.fontColor".
+     * @return the {@link IColorPalettePopup} instance to be used
+     */
+    public static IColorPalettePopup getColorPalettePopup(Shell parent, Session session, List<IGraphicalEditPart> editParts, String propertyId) {
+        List<ColorPalettePopupProvider> sortedCustomProviders = ColorPalettePopupService.getCustomProviders().stream() //
+                .sorted(Comparator.comparingInt(ColorPalettePopupProvider::getPriority).reversed()) //
+                .toList();
+        for (ColorPalettePopupProvider provider : sortedCustomProviders) {
+            if (provider.provides(session)) {
+                return provider.getColorPalettePopup(parent, session, editParts, propertyId);
+            }
+        }
+        return ColorPalettePopupService.getDefaultProvider().getColorPalettePopup(parent, session, editParts, propertyId);
+    }
+
+    /**
+     * Retrieves the default Sirius {@link ColorPalettePopupProvider} that is used when no custom provider is available.
+     *
+     * @return the default Sirius provider
+     */
+    private static ColorPalettePopupProvider getDefaultProvider() {
+        if (defaultSiriusProvider == null) {
+            initializeProviders();
+        }
+        return defaultSiriusProvider;
+    }
+
+    /**
+     * Retrieves the list of all custom {@link ColorPalettePopupProvider} instances available.
+     *
+     * @return the list of custom providers
+     */
+    private static List<ColorPalettePopupProvider> getCustomProviders() {
+        if (customProviders == null) {
+            initializeProviders();
+        }
+        return customProviders;
+    }
+
+    /**
+     * Initializes both the custom and default {@link ColorPalettePopupProvider} instances by loading them from the
+     * defined extension points.
+     */
+    private static void initializeProviders() {
+        Map<String, Collection<ColorPalettePopupProvider>> providers = EclipseUtil.getExtensionPluginsByKey(ColorPalettePopupProvider.class, ID, CLASS_ATTRIBUTE, "id"); //$NON-NLS-1$
+        defaultSiriusProvider = new DefaultColorPalettePopupProvider();
+
+        customProviders = new ArrayList<>();
+        for (Entry<String, Collection<ColorPalettePopupProvider>> entry : providers.entrySet()) {
+            customProviders.addAll(entry.getValue());
+        }
+    }
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/DefaultColorPalettePopupProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/DefaultColorPalettePopupProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.tools.api.color;
+
+import java.util.List;
+
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.diagram.ui.tools.internal.dialogs.ColorPalettePopup;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Defines the default provider for ColorPalettePopup.
+ * 
+ * @author <a href="mailto:glenn.plouhinec@obeo.fr">Glenn Plouhinec</a>
+ */
+public class DefaultColorPalettePopupProvider implements ColorPalettePopupProvider {
+
+    @Override
+    public boolean provides(Session session) {
+        return true;
+    }
+
+    @Override
+    public IColorPalettePopup getColorPalettePopup(Shell parent, Session session, List<IGraphicalEditPart> editParts, String propertyId) {
+        return new ColorPalettePopup(parent, session, editParts, propertyId);
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/IColorPalettePopup.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/color/IColorPalettePopup.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.tools.api.color;
+
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.RGB;
+
+/**
+ * Interface representing a color palette popup used for color selection in a graphical user interface.
+ * Implementations of this interface provide customizable behavior for initializing and displaying the palette
+ * and selecting colors.
+ *
+ * <p>Classes implementing this interface should define the logic for palette initialization, user color selection,
+ * and palette display.</p>
+ * 
+ * @author <a href="mailto:glenn.plouhinec@obeo.fr">Glenn Plouhinec</a>
+ */
+public interface IColorPalettePopup {
+
+    /**
+     * Initializes the layout of the popup.
+     */
+    void init();
+
+    /**
+     * Opens the popup, waits for an item to be selected and then closes popup.
+     * 
+     * @param location
+     *            the initial location of the popup.
+     * 
+     * @return the selected color or null if none selected
+     */
+    RGB open(Point location);
+
+    /**
+     * Gets the color the user selected. Could be null as the user may have cancelled the gesture or they may have
+     * selected the default color button.
+     * 
+     * @return selectedColor
+     */
+    RGB getSelectedColor();
+
+    /**
+     * Sets the previous color.
+     * 
+     * @param previousColor
+     *            the previous color.
+     */
+    void setPreviousColor(int previousColor);
+
+    /**
+     * Returns the previous color.
+     * 
+     * @return previousColor
+     */
+    int getPreviousColor();
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/ColorPalettePopup.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/ColorPalettePopup.java
@@ -27,6 +27,7 @@ import org.eclipse.sirius.diagram.ui.provider.Messages;
 import org.eclipse.sirius.diagram.ui.tools.api.color.ColorCategoryManager;
 import org.eclipse.sirius.diagram.ui.tools.api.color.ColorCategoryManagerProvider;
 import org.eclipse.sirius.diagram.ui.tools.api.color.ColorManager;
+import org.eclipse.sirius.diagram.ui.tools.api.color.IColorPalettePopup;
 import org.eclipse.sirius.ui.business.api.preferences.SiriusUIPreferencesKeys;
 import org.eclipse.sirius.viewpoint.provider.SiriusEditPlugin;
 import org.eclipse.swt.SWT;
@@ -67,7 +68,7 @@ import org.eclipse.swt.widgets.ToolItem;
  * 
  * @author <a href="mailto:glenn.plouhinec@obeo.fr">Glenn Plouhinec</a>
  */
-public class ColorPalettePopup {
+public class ColorPalettePopup implements IColorPalettePopup {
 
     /**
      * The height of the popup used to compute its location to open it.
@@ -159,6 +160,7 @@ public class ColorPalettePopup {
     /**
      * Initializes the layout of the popup, creates and configure the four color palette categories.
      */
+    @Override
     public void init() {
         shell.setText(Messages.ColorPalettePopup_title);
         GridLayout layout = new GridLayout(1, true);
@@ -510,14 +512,9 @@ public class ColorPalettePopup {
     }
 
     /**
-     * Opens the popup, waits for an item to be selected and then closes popup.
-     * 
-     * @param location
-     *            the initial size and location of the PopupList; the dialog will be positioned so that it does not run
-     *            off the screen and the largest number of items are visible
-     * 
-     * @return the selected color or null if none selected
+     * {@inheritDoc}
      */
+    @Override
     public RGB open(Point location) {
         Point listSize = shell.computeSize(SWT.DEFAULT, SWT.DEFAULT, false);
         shell.setBounds(location.x, location.y, listSize.x, listSize.y);
@@ -537,30 +534,25 @@ public class ColorPalettePopup {
     }
 
     /**
-     * Gets the color the user selected. Could be null as the user may have cancelled the gesture or they may have
-     * selected the default color button.
-     * 
-     * @return selectedColor
+     * {@inheritDoc}
      */
+    @Override
     public RGB getSelectedColor() {
         return selectedColor;
     }
 
     /**
-     * Returns the previous color.
-     * 
-     * @return previousColor
+     * {@inheritDoc}
      */
+    @Override
     public int getPreviousColor() {
         return previousColor;
     }
 
     /**
-     * Sets the previous color.
-     * 
-     * @param previousColor
-     *            the previous color.
+     * {@inheritDoc}
      */
+    @Override
     public void setPreviousColor(int previousColor) {
         this.previousColor = previousColor;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/ColorPropertyContributionItem.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/actions/ColorPropertyContributionItem.java
@@ -19,6 +19,8 @@ import org.eclipse.gmf.runtime.diagram.ui.actions.internal.l10n.DiagramUIActions
 import org.eclipse.gmf.runtime.diagram.ui.internal.properties.Properties;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.FigureUtilities;
 import org.eclipse.jface.resource.CompositeImageDescriptor;
+import org.eclipse.sirius.diagram.ui.tools.api.color.ColorPalettePopupService;
+import org.eclipse.sirius.diagram.ui.tools.api.color.IColorPalettePopup;
 import org.eclipse.sirius.diagram.ui.tools.api.editor.DDiagramEditor;
 import org.eclipse.sirius.diagram.ui.tools.internal.dialogs.ColorPalettePopup;
 import org.eclipse.swt.SWT;
@@ -263,7 +265,7 @@ public class ColorPropertyContributionItem extends PropertyChangeContributionIte
      *            the item clicked on the tabbar.
      */
     private void invokeColorPalettePopup(Item item) {
-        final ColorPalettePopup popup = new ColorPalettePopup(Display.getCurrent().getActiveShell(), ((DDiagramEditor) getWorkbenchPart()).getSession(), getOperationSet(), getPropertyId());
+        final IColorPalettePopup popup = ColorPalettePopupService.getColorPalettePopup(Display.getCurrent().getActiveShell(), ((DDiagramEditor) getWorkbenchPart()).getSession(), getOperationSet(), getPropertyId());
         popup.init();
         popup.open(computePopupLocation(item));
 

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramColorAndFontPropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramColorAndFontPropertySection.java
@@ -52,6 +52,8 @@ import org.eclipse.sirius.diagram.ui.business.internal.query.ColorStyleQuery;
 import org.eclipse.sirius.diagram.ui.internal.refresh.diagram.ViewPropertiesSynchronizer;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
+import org.eclipse.sirius.diagram.ui.tools.api.color.ColorPalettePopupService;
+import org.eclipse.sirius.diagram.ui.tools.api.color.IColorPalettePopup;
 import org.eclipse.sirius.diagram.ui.tools.api.image.DiagramImagesPath;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.ResetStylePropertiesToDefaultValuesAction;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.SetStyleToWorkspaceImageAction;
@@ -119,7 +121,7 @@ public class DiagramColorAndFontPropertySection extends DiagramColorsAndFontsPro
         } else {
             Session session = new EObjectQuery(eObject).getSession();
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
-            ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
+            IColorPalettePopup popup = ColorPalettePopupService.getColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
             popup.setPreviousColor(previousColor);
             popup.open(ColorPalettePopup.getValidPopupLocation(button));

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramConnectionAppearancePropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramConnectionAppearancePropertySection.java
@@ -44,6 +44,8 @@ import org.eclipse.sirius.diagram.ui.business.internal.query.ColorStyleQuery;
 import org.eclipse.sirius.diagram.ui.internal.refresh.diagram.ViewPropertiesSynchronizer;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
+import org.eclipse.sirius.diagram.ui.tools.api.color.ColorPalettePopupService;
+import org.eclipse.sirius.diagram.ui.tools.api.color.IColorPalettePopup;
 import org.eclipse.sirius.diagram.ui.tools.api.image.DiagramImagesPath;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.ResetStylePropertiesToDefaultValuesAction;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.SetStyleToWorkspaceImageAction;
@@ -110,7 +112,7 @@ public class DiagramConnectionAppearancePropertySection extends ConnectionAppear
         } else {
             Session session = new EObjectQuery(eObject).getSession();
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
-            ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
+            IColorPalettePopup popup = ColorPalettePopupService.getColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
             popup.setPreviousColor(previousColor);
             popup.open(ColorPalettePopup.getValidPopupLocation(button));

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramShapeColorAndFontPropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/DiagramShapeColorAndFontPropertySection.java
@@ -62,6 +62,8 @@ import org.eclipse.sirius.diagram.ui.edit.api.part.IDiagramElementEditPart;
 import org.eclipse.sirius.diagram.ui.internal.refresh.diagram.ViewPropertiesSynchronizer;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
+import org.eclipse.sirius.diagram.ui.tools.api.color.ColorPalettePopupService;
+import org.eclipse.sirius.diagram.ui.tools.api.color.IColorPalettePopup;
 import org.eclipse.sirius.diagram.ui.tools.api.image.DiagramImagesPath;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.ResetStylePropertiesToDefaultValuesAction;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.SetStyleToWorkspaceImageAction;
@@ -133,7 +135,7 @@ public class DiagramShapeColorAndFontPropertySection extends ShapeColorsAndFonts
         } else {
             Session session = new EObjectQuery(eObject).getSession();
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
-            ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
+            IColorPalettePopup popup = ColorPalettePopupService.getColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
             popup.setPreviousColor(previousColor);
             popup.open(ColorPalettePopup.getValidPopupLocation(button));

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/LabelColorAndFontPropertySection.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/properties/LabelColorAndFontPropertySection.java
@@ -42,6 +42,8 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.AbstractDEdgeNameEditPa
 import org.eclipse.sirius.diagram.ui.internal.refresh.diagram.ViewPropertiesSynchronizer;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.diagram.ui.provider.Messages;
+import org.eclipse.sirius.diagram.ui.tools.api.color.ColorPalettePopupService;
+import org.eclipse.sirius.diagram.ui.tools.api.color.IColorPalettePopup;
 import org.eclipse.sirius.diagram.ui.tools.api.image.DiagramImagesPath;
 import org.eclipse.sirius.diagram.ui.tools.internal.actions.style.ResetStylePropertiesToDefaultValuesAction;
 import org.eclipse.sirius.diagram.ui.tools.internal.dialogs.ColorPalettePopup;
@@ -94,7 +96,7 @@ public class LabelColorAndFontPropertySection extends ColorsAndFontsPropertySect
         } else {
             Session session = new EObjectQuery(eObject).getSession();
             List<IGraphicalEditPart> editParts = getInput().stream().filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast).toList();
-            ColorPalettePopup popup = new ColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
+            IColorPalettePopup popup = ColorPalettePopupService.getColorPalettePopup(button.getParent().getShell(), session, editParts, propertyId);
             popup.init();
             popup.setPreviousColor(previousColor);
             popup.open(ColorPalettePopup.getValidPopupLocation(button));


### PR DESCRIPTION
A new Eclipse extension point
"org.eclipse.sirius.diagram.ui.colorPalettePopupProvider" has been added to handle a flexible provider mechanism for IColorPalettePopup. The default provider DefaultColorPalettePopupProvider is used if no custom providers are registered, allowing customization of the color palette popup.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/460