### PR TITLE
[467] Fix edge creation tool regressions

### DIFF
--- a/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/helper/task/CreateDEdgeTask.java
+++ b/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/helper/task/CreateDEdgeTask.java
@@ -121,9 +121,11 @@ public class CreateDEdgeTask extends AbstractCommandTask implements ICreationTas
         for (EObject semanticElt : getAllSemantics()) {
             BestMappingGetter bestMappingGetter = new BestMappingGetter(sourceView, targetView, semanticElt);
             EdgeMapping bestEdgeMapping = bestMappingGetter.getBestEdgeMapping(tool.getEdgeMappings());
+
             if (bestEdgeMapping != null) {
+
                 Option<DEdge> createdDEdgeOption = dDiagramSynchronizer.createEdgeMapping(mappingManager, mappingsToEdgeTargets, bestEdgeMapping, edgeToMappingBasedDecoration,
-                        edgeToSemanticBasedDecoration, sourceView, targetView);
+                        edgeToSemanticBasedDecoration, semanticElt);
                 if (createdDEdgeOption.some()) {
                     createdDEdges.add(createdDEdgeOption.get());
                 }

--- a/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/sync/DDiagramSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram/src/org/eclipse/sirius/diagram/business/internal/sync/DDiagramSynchronizer.java
@@ -98,7 +98,6 @@ import org.eclipse.sirius.ecore.extender.business.api.accessor.ModelAccessor;
 import org.eclipse.sirius.ecore.extender.business.api.accessor.exception.FeatureNotFoundException;
 import org.eclipse.sirius.ecore.extender.business.api.accessor.exception.MetaClassNotFoundException;
 import org.eclipse.sirius.ext.base.Option;
-import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.sirius.ext.base.cache.KeyCache;
 import org.eclipse.sirius.ext.base.collect.GSetIntersection;
 import org.eclipse.sirius.ext.base.collect.MultipleCollection;
@@ -1176,27 +1175,23 @@ public class DDiagramSynchronizer {
      *            mapping based decorations.
      * @param edgeToSemanticBasedDecoration
      *            semantic based decorations
-     * @param expectedSemantic
-     *            the expected semantic target of the created DEdge elements
+     * @param expectedSemantics
+     *            the expected semantic targets of the created DEdge elements
      * @return an Option on DEdge
      */
-    public Option<DEdge> createEdgeMapping(DiagramMappingsManager mappingManager, final Map<DiagramElementMapping, Collection<EdgeTarget>> mappingsToEdgeTargets, final EdgeMapping mapping,
+    public Collection<DEdge> createEdgeMapping(DiagramMappingsManager mappingManager, final Map<DiagramElementMapping, Collection<EdgeTarget>> mappingsToEdgeTargets, final EdgeMapping mapping,
             final Map<EdgeMapping, Collection<MappingBasedDecoration>> edgeToMappingBasedDecoration, final Map<String, Collection<SemanticBasedDecoration>> edgeToSemanticBasedDecoration,
-            EObject expectedSemantic) {
-
-        edgesDones = new HashSet<DDiagramElement>();
-        Collection<DEdge> newEdges = createDEdgeOnMapping(mappingManager, mappingsToEdgeTargets, mapping, edgeToMappingBasedDecoration, edgeToSemanticBasedDecoration, expectedSemantic);
+            Collection<EObject> expectedSemantics) {
+        edgesDones = new LinkedHashSet<DDiagramElement>();
+        Collection<DEdge> newEdges = createDEdgeOnMapping(mappingManager, mappingsToEdgeTargets, mapping, edgeToMappingBasedDecoration, edgeToSemanticBasedDecoration, expectedSemantics);
         edgesDones.clear();
-        if (!newEdges.isEmpty()) {
-            return Options.newSome(newEdges.iterator().next());
-        }
-        return Options.newNone();
+        return newEdges;
     }
 
     private Collection<DEdge> createDEdgeOnMapping(DiagramMappingsManager mappingManager, final Map<DiagramElementMapping, Collection<EdgeTarget>> mappingsToEdgeTargets, final EdgeMapping mapping,
             final Map<EdgeMapping, Collection<MappingBasedDecoration>> edgeToMappingBasedDecoration, final Map<String, Collection<SemanticBasedDecoration>> edgeToSemanticBasedDecoration,
-            EObject expectedSemantic) {
-        Collection<DEdge> newEdges = new HashSet<DEdge>();
+            Collection<EObject> expectedSemantics) {
+        Collection<DEdge> newEdges = new LinkedHashSet<DEdge>();
         if (this.accessor.getPermissionAuthority().canEditInstance(this.diagram)) {
             final SetIntersection<DEdgeCandidate> status = createEdgeCandidates(mappingsToEdgeTargets, mapping, edgeToMappingBasedDecoration, edgeToSemanticBasedDecoration);
 
@@ -1213,7 +1208,7 @@ public class DDiagramSynchronizer {
                 // created or affected by the model operation,
                 // specifier has to use on CreateEdgeView model operations instead of relying on automatic creation by
                 // the EdgeCreationTool (automatic refresh will not create such element either).
-                if (candidateIsSync || candidate.getSemantic() == expectedSemantic) {
+                if (candidateIsSync || expectedSemantics.contains(candidate.getSemantic())) {
                     newEdges.add(this.sync.createNewEdge(mappingManager, candidate, mappingsToEdgeTargets, edgeToMappingBasedDecoration, edgeToSemanticBasedDecoration));
                 }
 


### PR DESCRIPTION
Bug: #467 

Fix regressions introduced with #470 :
- Regression identified in
  - HideRevealEdgeLabelsTest
  - EdgeCreationPositionTest
  - EdgeCreationPositionWithSnapToGridTest
  - EdgeWithBorderNodeCreationPositionWithSnapToGridTest
- The provided fix does not handle the extra mapping cases (edge tool creation two border nodes + an edge for example)
  - completing the introduced validation on  source/target would be touchy : extra mappings, mappings imports, complex structure created by tools.
- The validation of the createDEdgeTask which automatically creates an edge from the EdgeCreationTool should check the semanticElement of the edgeCandidates rather than the correspondance of the clicked sourceView/targetView and the candidate sourceView/targetView.


The idea of the new fix is not follow the previous logic of CreateDEdgeTask 
- it is slightly different from CreateDNodeTask/CreateContainerTask which directly creates the DNodeCandidate from the detected created elements.
- the CreateDEdgeTask analyses the semantic elements which are created or affected by its model operations in order to find possible EdgeMapping for those semantic elements using the BestMappingGetter
  - the use of sourceView/targetView in this object is partially unclear: it depends on the number of mappings referenced by the tools, the mapping precondition is not checked if there is only one mapping,  ...
- Then it asks a DDiagramSynchronizer to compute EdgeCandidates
- in AutoRefresh / tools::forceRefresh : the refresh task will potentially add new elements or delete invalid created DEdges. 

In #470, the check added on clicked sourceView/targetView is too restrictive.
Regarding how the edge mapping to "refresh" are found, checking that candidates for those mapping have the expected semantic candidates seems to be a better approach.

I have proposed avoid multiple coputation of DEdgeCandidates if several semantics have the same mapping, and to ensure reproductibility by replacing some HashSet with LinkedHashSet.