### PR TITLE
[527] Add a "force refresh" for Combined Fragment create tool

### DIFF
--- a/plugins/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign
+++ b/plugins/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign
@@ -833,7 +833,7 @@
             <finishingEndPredecessor name="finishingEndPredecessor"/>
             <coveredLifelines name="coverage"/>
           </ownedTools>
-          <ownedTools xsi:type="tool:CombinedFragmentCreationTool" name="Combined Fragment" containerMappings="//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']" extraMappings="//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']">
+          <ownedTools xsi:type="tool:CombinedFragmentCreationTool" name="Combined Fragment" forceRefresh="true" containerMappings="//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']" extraMappings="//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']">
             <variable name="container"/>
             <viewVariable name="containerView"/>
             <initialOperation>


### PR DESCRIPTION
"Force refresh" avoids the potential bug seen in this issue, even though "auto-refresh" is, in theory, a requirement for sequence diagram.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/527