### PR TITLE
#518 Improve InteractionContainer layout

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/layout/vertical/SequenceVerticalLayout.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/layout/vertical/SequenceVerticalLayout.java
@@ -773,36 +773,37 @@ public class SequenceVerticalLayout extends AbstractSequenceOrderingLayout<ISequ
         Optional<InteractionContainer> optionalInteractionContainer = this.sequenceDiagram.getInteractionContainer();
         if (optionalInteractionContainer.isPresent()) {
             // Reset height of the interaction container
+            Rectangle rectangle = new Rectangle(0, 0, InteractionContainer.DEFAULT_WIDTH, InteractionContainer.DEFAULT_HEIGHT);
+            for (InstanceRole instanceRole : this.sequenceDiagram.getAllInstanceRoles()) {
+                // Gather instance role bounds
+                final Node instanceRoleNode = instanceRole.getNotationNode();
+                LayoutConstraint layoutConstraint = instanceRoleNode.getLayoutConstraint();
+                // Check that the lifeline is within bounds of the interaction container, resize it otherwise
+                if (layoutConstraint instanceof Bounds instanceRoleBounds && instanceRole.getLifeline().some()) {
+                    Lifeline lifeline = instanceRole.getLifeline().get();
+                    Option<EndOfLife> endOfLife = lifeline.getEndOfLife();
+                    Node lifelineNode = lifeline.getNotationNode();
+
+                    int top = instanceRoleBounds.getY();
+                    if (top - InteractionContainer.MARGIN < rectangle.y()) {
+                        rectangle.setY(top - InteractionContainer.MARGIN);
+                    }
+
+                    int bottom = lifeline.getVerticalRange().getUpperBound();
+                    if (endOfLife.some()) {
+                        bottom = bottom + endOfLife.get().getProperLogicalBounds().height;
+                    }
+                    // lifeline position is relative to the parent instance role position
+                    if (bottom + InteractionContainer.MARGIN > rectangle.bottom()) {
+                        rectangle.setBottom(bottom + InteractionContainer.MARGIN);
+                    }
+                }
+            }
+
             InteractionContainer interactionContainer = optionalInteractionContainer.get();
             Node node = interactionContainer.getNotationNode();
             LayoutConstraint interactionContainerLayoutConstraint = node.getLayoutConstraint();
             if (interactionContainerLayoutConstraint instanceof Bounds interactionContainerBounds) {
-                Rectangle rectangle = new Rectangle(0, 0, InteractionContainer.DEFAULT_WIDTH, InteractionContainer.DEFAULT_HEIGHT);
-                for (InstanceRole instanceRole : this.sequenceDiagram.getAllInstanceRoles()) {
-                    // Gather instance role bounds
-                    final Node instanceRoleNode = instanceRole.getNotationNode();
-                    LayoutConstraint layoutConstraint = instanceRoleNode.getLayoutConstraint();
-                    // Check that the lifeline is within bounds of the interaction container, resize it otherwise
-                    if (layoutConstraint instanceof Bounds instanceRoleBounds && instanceRole.getLifeline().some()) {
-                        Lifeline lifeline = instanceRole.getLifeline().get();
-                        Option<EndOfLife> endOfLife = lifeline.getEndOfLife();
-                        Node lifelineNode = lifeline.getNotationNode();
-
-                        int top = instanceRoleBounds.getY();
-                        if (top - InteractionContainer.MARGIN < rectangle.y()) {
-                            rectangle.setY(top - InteractionContainer.MARGIN);
-                        }
-
-                        int bottom = lifeline.getVerticalRange().getUpperBound();
-                        if (endOfLife.some()) {
-                            bottom = bottom + endOfLife.get().getProperLogicalBounds().height;
-                        }
-                        // lifeline position is relative to the parent instance role position
-                        if (bottom + InteractionContainer.MARGIN > rectangle.bottom()) {
-                            rectangle.setBottom(bottom + InteractionContainer.MARGIN);
-                        }
-                    }
-                }
                 interactionContainerBounds.setY(rectangle.y);
                 interactionContainerBounds.setHeight(rectangle.height);
                 applied = true;

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/sequence/navigation/fixture.aird
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/sequence/navigation/fixture.aird
@@ -1,3096 +1,2792 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<viewpoint:DAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0" xmlns:description_2="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:interactions="http://www.eclipse.org/sirius/sample/interactions" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sequence="http://www.eclipse.org/sirius/diagram/sequence/2.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0 http://www.eclipse.org/sirius/diagram/sequence/2.0.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//diagram/description http://www.eclipse.org/sirius/diagram/1.1.0 http://www.eclipse.org/sirius/1.1.0#//diagram http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/1.1.0#//diagram/description/style" xmi:id="_8aRfEN2zEd-ZhcM4sDvRBQ" selectedViews="_9W1N8N2zEd-ZhcM4sDvRBQ" version="8.0.0">
-  <models xmi:type="interactions:Model" href="fixture.interactions#/"/>
-  <models xmi:type="ecore:EPackage" href="types.ecore#/"/>
-  <ownedViews xmi:type="viewpoint:DRepresentationContainer" xmi:id="_9W1N8N2zEd-ZhcM4sDvRBQ" initialized="true">
-    <ownedRepresentations xmi:type="sequence:SequenceDDiagram" xmi:id="_-pfIoN2zEd-ZhcM4sDvRBQ" name="Basic Messages Diagram">
-      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_-qE-gN2zEd-ZhcM4sDvRBQ" source="GMF_DIAGRAMS">
-        <data xmi:type="notation:Diagram" xmi:id="_-qE-gd2zEd-ZhcM4sDvRBQ" type="Sirius" element="_-pfIoN2zEd-ZhcM4sDvRBQ" measurementUnit="Pixel">
-          <children xmi:type="notation:Node" xmi:id="_-sR98N2zEd-ZhcM4sDvRBQ" type="2001" element="_TgM7gPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_-sXdgN2zEd-ZhcM4sDvRBQ" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_-sXdgd2zEd-ZhcM4sDvRBQ" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_-8RhwN2zEd-ZhcM4sDvRBQ" type="3001" element="_Tiv5MPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_-8TW8N2zEd-ZhcM4sDvRBQ" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_-8TW8d2zEd-ZhcM4sDvRBQ" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_-8pVMN2zEd-ZhcM4sDvRBQ" type="3003" element="_TixHUPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_-8pVMd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8pVMt2zEd-ZhcM4sDvRBQ"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_nIqTQE5cEeCHObKOrZ_h3Q" type="3001" element="_TjankPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_nIqTQ05cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nIqTRE5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_nIsIcE5cEeCHObKOrZ_h3Q" type="3002" element="_Tjb1sPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_nIsIcU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIsIck5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_nIqTQU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIqTQk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_-8Rhwd2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8Rhwt2zEd-ZhcM4sDvRBQ" y="42" width="10" height="510"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_-8T-AN2zEd-ZhcM4sDvRBQ" type="3003" element="_ThqUEPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_-8T-Ad2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8T-At2zEd-ZhcM4sDvRBQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_-sR98d2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-sR98t2zEd-ZhcM4sDvRBQ" x="50" y="50" width="120" height="50"/>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0" xmlns:description_2="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:interactions="http://www.eclipse.org/sirius/sample/interactions" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:sequence="http://www.eclipse.org/sirius/diagram/sequence/2.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0 http://www.eclipse.org/sirius/diagram/sequence/2.0.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_8aRfEN2zEd-ZhcM4sDvRBQ" selectedViews="_9W1N8N2zEd-ZhcM4sDvRBQ" version="15.4.3.202406261640">
+    <semanticResources>fixture.interactions</semanticResources>
+    <semanticResources>types.ecore</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_9W1N8N2zEd-ZhcM4sDvRBQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ig6hLm3Ee-UXMFld_STMg" name="Basic Messages Diagram" repPath="#_-pfIoN2zEd-ZhcM4sDvRBQ" changeId="1734138523195">
+        <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+        <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.0"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ioPRLm3Ee-UXMFld_STMg" name="Basic Executions Diagram" repPath="#_OHyPgN6tEd-_dMn5_cB9Xw" changeId="1734138523195">
+        <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+        <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.1"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ioPSbm3Ee-UXMFld_STMg" name="Complex" repPath="#_Fni5MOUCEd-BEJhxHErs5g" changeId="1734138523195">
+        <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+        <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.2"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2VLm3Ee-UXMFld_STMg" name="Basic Interaction Use Diagram" repPath="#_3c2zYOc2Ed-ci9l1AsdpKw" changeId="1734138523195">
+        <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+        <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.3"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2Wbm3Ee-UXMFld_STMg" name="Complex with CF" repPath="#_48qywOdWEd-EjZA2qI8iFQ" changeId="1734138523195">
+        <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+        <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.5"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2Xrm3Ee-UXMFld_STMg" name="Basic Combined Fragment Diagram" repPath="#_W42gYOdcEd-EjZA2qI8iFQ" changeId="1734138523195">
+        <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+        <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <sequence:SequenceDDiagram uid="_-pfIoN2zEd-ZhcM4sDvRBQ">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_-qE-gN2zEd-ZhcM4sDvRBQ" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_-qE-gd2zEd-ZhcM4sDvRBQ" type="Sirius" element="_-pfIoN2zEd-ZhcM4sDvRBQ" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_-sR98N2zEd-ZhcM4sDvRBQ" type="2001" element="_TgM7gPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_-sXdgN2zEd-ZhcM4sDvRBQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_-sXdgd2zEd-ZhcM4sDvRBQ" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_-sbH4N2zEd-ZhcM4sDvRBQ" type="2001" element="_TimvQPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_-sbu8N2zEd-ZhcM4sDvRBQ" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_-sbu8d2zEd-ZhcM4sDvRBQ" y="5"/>
+          <children xmi:type="notation:Node" xmi:id="_-8RhwN2zEd-ZhcM4sDvRBQ" type="3001" element="_Tiv5MPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_-8TW8N2zEd-ZhcM4sDvRBQ" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_-8TW8d2zEd-ZhcM4sDvRBQ" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_-9BvsN2zEd-ZhcM4sDvRBQ" type="3001" element="_Tjdq4PWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_-9CWwN2zEd-ZhcM4sDvRBQ" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_-9CWwd2zEd-ZhcM4sDvRBQ" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_-9FaEN2zEd-ZhcM4sDvRBQ" type="3003" element="_TjeR8PWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_-9FaEd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9FaEt2zEd-ZhcM4sDvRBQ"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_nIvy0E5cEeCHObKOrZ_h3Q" type="3001" element="_TjjxgPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_nIvy005cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nIvy1E5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_nIxA8E5cEeCHObKOrZ_h3Q" type="3002" element="_TjkYkPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_nIxA8U5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIxA8k5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_nIvy0U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIvy0k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_-9Bvsd2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9Bvst2zEd-ZhcM4sDvRBQ" y="42" width="10" height="510"/>
+            <children xmi:type="notation:Node" xmi:id="_-8pVMN2zEd-ZhcM4sDvRBQ" type="3003" element="_TixHUPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_-8pVMd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8pVMt2zEd-ZhcM4sDvRBQ"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_-9CWwt2zEd-ZhcM4sDvRBQ" type="3003" element="_TipLgPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_-9CWw92zEd-ZhcM4sDvRBQ" fontName="Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9CWxN2zEd-ZhcM4sDvRBQ"/>
+            <children xmi:type="notation:Node" xmi:id="_nIqTQE5cEeCHObKOrZ_h3Q" type="3001" element="_TjankPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_nIqTQ05cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_nIqTRE5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_nIsIcE5cEeCHObKOrZ_h3Q" type="3002" element="_Tjb1sPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_nIsIcU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIsIck5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nIqTQU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIqTQk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_-sbH4d2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-sbH4t2zEd-ZhcM4sDvRBQ" x="330" y="50" width="120" height="50"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_-8Rhwd2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8Rhwt2zEd-ZhcM4sDvRBQ" y="42" width="10" height="510"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_-sbu8t2zEd-ZhcM4sDvRBQ" type="2001" element="_TipykPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_-scWAN2zEd-ZhcM4sDvRBQ" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_-sc9EN2zEd-ZhcM4sDvRBQ" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_-9RAQN2zEd-ZhcM4sDvRBQ" type="3001" element="_Tjp4IPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_-9RnUt2zEd-ZhcM4sDvRBQ" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_-9RnU92zEd-ZhcM4sDvRBQ" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_-9VRsN2zEd-ZhcM4sDvRBQ" type="3003" element="_TjrGQPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_-9VRsd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9VRst2zEd-ZhcM4sDvRBQ"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_nI0rUE5cEeCHObKOrZ_h3Q" type="3001" element="_TjtigPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_nI1SYE5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nI1SYU5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_nI2ggE5cEeCHObKOrZ_h3Q" type="3002" element="_TjuJkPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_nI2ggU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nI2ggk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_nI0rUU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nI0rUk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_-9RnUN2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9RnUd2zEd-ZhcM4sDvRBQ" x="52" y="42" width="10" height="510"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_-9SOYN2zEd-ZhcM4sDvRBQ" type="3003" element="_TirAsPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_-9SOYd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9SOYt2zEd-ZhcM4sDvRBQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_-sbu892zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-sbu9N2zEd-ZhcM4sDvRBQ" x="550" y="50" width="120" height="50"/>
+          <children xmi:type="notation:Node" xmi:id="_-8T-AN2zEd-ZhcM4sDvRBQ" type="3003" element="_ThqUEPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_-8T-Ad2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8T-At2zEd-ZhcM4sDvRBQ"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_b37F8N6qEd-_dMn5_cB9Xw" type="2001" element="_TirAtPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_b37tAN6qEd-_dMn5_cB9Xw" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_b37tAd6qEd-_dMn5_cB9Xw" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_b3_XYN6qEd-_dMn5_cB9Xw" type="3001" element="_TjuwoPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_b3_-cN6qEd-_dMn5_cB9Xw" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_b3_-cd6qEd-_dMn5_cB9Xw" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_b4Do0N6qEd-_dMn5_cB9Xw" type="3003" element="_TjvXsPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_b4Do0d6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b4Do0t6qEd-_dMn5_cB9Xw"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_hjh94N6qEd-_dMn5_cB9Xw" type="3001" element="_Tjxz8PWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_hjik8N6qEd-_dMn5_cB9Xw" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_hjik8d6qEd-_dMn5_cB9Xw" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_nHJ3YE5cEeCHObKOrZ_h3Q" type="3005" element="_TjzCEPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_nHJ3YU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHJ3Yk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_hjh94d6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hjh94t6qEd-_dMn5_cB9Xw" x="2" y="141" width="50" height="50"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_b3_XYd6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b3_XYt6qEd-_dMn5_cB9Xw" y="42" width="10" height="141"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_b3_-ct6qEd-_dMn5_cB9Xw" type="3003" element="_TiuEAPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_b3_-c96qEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b3_-dN6qEd-_dMn5_cB9Xw"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_b37F8d6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b37F8t6qEd-_dMn5_cB9Xw" x="902" y="312" width="120" height="50"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_-sR98d2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-sR98t2zEd-ZhcM4sDvRBQ" x="50" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_-sbH4N2zEd-ZhcM4sDvRBQ" type="2001" element="_TimvQPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_-sbu8N2zEd-ZhcM4sDvRBQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_-sbu8d2zEd-ZhcM4sDvRBQ" y="5"/>
           </children>
-          <styles xmi:type="notation:DiagramStyle" xmi:id="_-qE-gt2zEd-ZhcM4sDvRBQ"/>
-          <edges xmi:type="notation:Edge" xmi:id="_ZjeXEN6qEd-_dMn5_cB9Xw" type="4001" element="_Tk7DcPWhEeG4Wag4JBRK3A" source="_-8RhwN2zEd-ZhcM4sDvRBQ" target="_-9BvsN2zEd-ZhcM4sDvRBQ">
-            <children xmi:type="notation:Node" xmi:id="_ZjhaYN6qEd-_dMn5_cB9Xw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZjhaYd6qEd-_dMn5_cB9Xw" y="-10"/>
+          <children xmi:type="notation:Node" xmi:id="_-9BvsN2zEd-ZhcM4sDvRBQ" type="3001" element="_Tjdq4PWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_-9CWwN2zEd-ZhcM4sDvRBQ" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_-9CWwd2zEd-ZhcM4sDvRBQ" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OU0j8FGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OU0j8VGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_-9FaEN2zEd-ZhcM4sDvRBQ" type="3003" element="_TjeR8PWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_-9FaEd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9FaEt2zEd-ZhcM4sDvRBQ"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVB_UFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVB_UVGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_nIvy0E5cEeCHObKOrZ_h3Q" type="3001" element="_TjjxgPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_nIvy005cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_nIvy1E5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_nIxA8E5cEeCHObKOrZ_h3Q" type="3002" element="_TjkYkPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_nIxA8U5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIxA8k5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nIvy0U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIvy0k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_ZjeXEd6qEd-_dMn5_cB9Xw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_ZjeXEt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZjeXE96qEd-_dMn5_cB9Xw" points="[0, -2, -280, -2]$[280, -2, 0, -2]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZjiogN6qEd-_dMn5_cB9Xw" id="(0.5,0.12627292)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zjiogd6qEd-_dMn5_cB9Xw" id="(0.5,0.12627292)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_aSWPQN6qEd-_dMn5_cB9Xw" type="4001" element="_TlGCkPWhEeG4Wag4JBRK3A" source="_-9BvsN2zEd-ZhcM4sDvRBQ" target="_-9RAQN2zEd-ZhcM4sDvRBQ">
-            <children xmi:type="notation:Node" xmi:id="_aSW2UN6qEd-_dMn5_cB9Xw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aSW2Ud6qEd-_dMn5_cB9Xw" y="-10"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_-9Bvsd2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9Bvst2zEd-ZhcM4sDvRBQ" y="42" width="10" height="510"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_-9CWwt2zEd-ZhcM4sDvRBQ" type="3003" element="_TipLgPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_-9CWw92zEd-ZhcM4sDvRBQ" fontName="Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9CWxN2zEd-ZhcM4sDvRBQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_-sbH4d2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-sbH4t2zEd-ZhcM4sDvRBQ" x="330" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_-sbu8t2zEd-ZhcM4sDvRBQ" type="2001" element="_TipykPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_-scWAN2zEd-ZhcM4sDvRBQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_-sc9EN2zEd-ZhcM4sDvRBQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_-9RAQN2zEd-ZhcM4sDvRBQ" type="3001" element="_Tjp4IPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_-9RnUt2zEd-ZhcM4sDvRBQ" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_-9RnU92zEd-ZhcM4sDvRBQ" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVDNcFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVDNcVGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_-9VRsN2zEd-ZhcM4sDvRBQ" type="3003" element="_TjrGQPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_-9VRsd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9VRst2zEd-ZhcM4sDvRBQ"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVDNclGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVDNc1GCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_nI0rUE5cEeCHObKOrZ_h3Q" type="3001" element="_TjtigPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_nI1SYE5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_nI1SYU5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_nI2ggE5cEeCHObKOrZ_h3Q" type="3002" element="_TjuJkPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_nI2ggU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nI2ggk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nI0rUU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nI0rUk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_aSWPQd6qEd-_dMn5_cB9Xw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_aSWPQt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aSWPQ96qEd-_dMn5_cB9Xw" points="[0, -4, -344, -4]$[344, -4, 0, -4]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aSW2Ut6qEd-_dMn5_cB9Xw" id="(0.5,0.22606924)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aSW2U96qEd-_dMn5_cB9Xw" id="(0.5,0.22606924)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_arcEsN6qEd-_dMn5_cB9Xw" type="4001" element="_TlJF4PWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_-9RAQN2zEd-ZhcM4sDvRBQ">
-            <children xmi:type="notation:Node" xmi:id="_arcrwN6qEd-_dMn5_cB9Xw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arcrwd6qEd-_dMn5_cB9Xw" y="-10"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_-9RnUN2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9RnUd2zEd-ZhcM4sDvRBQ" x="52" y="42" width="10" height="510"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_-9SOYN2zEd-ZhcM4sDvRBQ" type="3003" element="_TirAsPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_-9SOYd2zEd-ZhcM4sDvRBQ" fontName="Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9SOYt2zEd-ZhcM4sDvRBQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_-sbu892zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-sbu9N2zEd-ZhcM4sDvRBQ" x="550" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_b37F8N6qEd-_dMn5_cB9Xw" type="2001" element="_TirAtPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_b37tAN6qEd-_dMn5_cB9Xw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_b37tAd6qEd-_dMn5_cB9Xw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_b3_XYN6qEd-_dMn5_cB9Xw" type="3001" element="_TjuwoPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_b3_-cN6qEd-_dMn5_cB9Xw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_b3_-cd6qEd-_dMn5_cB9Xw" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVD0gFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVD0gVGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_b4Do0N6qEd-_dMn5_cB9Xw" type="3003" element="_TjvXsPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_b4Do0d6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b4Do0t6qEd-_dMn5_cB9Xw"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVD0glGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVD0g1GCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_hjh94N6qEd-_dMn5_cB9Xw" type="3001" element="_Tjxz8PWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_hjik8N6qEd-_dMn5_cB9Xw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_hjik8d6qEd-_dMn5_cB9Xw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_nHJ3YE5cEeCHObKOrZ_h3Q" type="3005" element="_TjzCEPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_nHJ3YU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHJ3Yk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_hjh94d6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hjh94t6qEd-_dMn5_cB9Xw" x="2" y="141" width="50" height="50"/>
             </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_arcEsd6qEd-_dMn5_cB9Xw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_arcEst6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_arcEs96qEd-_dMn5_cB9Xw" points="[0, 136, 0, 136]$[30, 136, 0, 136]$[30, 178, 0, 178]$[0, 178, 0, 178]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bP-VIN6qEd-_dMn5_cB9Xw" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bP-VId6qEd-_dMn5_cB9Xw" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_dvpckN6qEd-_dMn5_cB9Xw" type="4001" element="_TlXvYPWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_b37F8N6qEd-_dMn5_cB9Xw">
-            <children xmi:type="notation:Node" xmi:id="_dvqDoN6qEd-_dMn5_cB9Xw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dvqDod6qEd-_dMn5_cB9Xw" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVD0hFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVEbkFGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVEbkVGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVEbklGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_dvpckd6qEd-_dMn5_cB9Xw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_dvpckt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dvpck96qEd-_dMn5_cB9Xw" points="[0, -5, -1214, 0]$[2188, -5, 974, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dvqqsN6qEd-_dMn5_cB9Xw" id="(0.5,0.4749499)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dvqqsd6qEd-_dMn5_cB9Xw" id="(0.5,0.5) ice(974,262)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_fXZdgN6qEd-_dMn5_cB9Xw" type="4001" element="_TlLiIPWhEeG4Wag4JBRK3A" source="_b3_XYN6qEd-_dMn5_cB9Xw" target="_b3_XYN6qEd-_dMn5_cB9Xw">
-            <children xmi:type="notation:Node" xmi:id="_fXZdhN6qEd-_dMn5_cB9Xw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fXZdhd6qEd-_dMn5_cB9Xw" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVEbk1GCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVEblFGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVFCoFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFCoVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_fXZdgd6qEd-_dMn5_cB9Xw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_fXZdgt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fXZdg96qEd-_dMn5_cB9Xw" points="[0, -2, 0, -17]$[0, 24, 0, 9]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fXaEkN6qEd-_dMn5_cB9Xw" id="(0.5,0.19831224)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fXaEkd6qEd-_dMn5_cB9Xw" id="(0.5,0.30801687)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_hjru4N6qEd-_dMn5_cB9Xw" type="4001" element="_TlfEIPWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_hjh94N6qEd-_dMn5_cB9Xw">
-            <children xmi:type="notation:Node" xmi:id="_hjsV8N6qEd-_dMn5_cB9Xw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hjsV8d6qEd-_dMn5_cB9Xw" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVFColGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFCo1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVFpsFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFpsVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_hjru4d6qEd-_dMn5_cB9Xw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_hjru4t6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hjru496qEd-_dMn5_cB9Xw" points="[2, 0, -350, 0]$[327, 0, -25, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hjsV8t6qEd-_dMn5_cB9Xw" id="(0.5,0.83967936)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hjsV896qEd-_dMn5_cB9Xw" id="(0.5,0.5) ice(916,494)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_lxJN0N6qEd-_dMn5_cB9Xw" type="4001" element="_TlN-YPWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_-8RhwN2zEd-ZhcM4sDvRBQ">
-            <children xmi:type="notation:Node" xmi:id="_lxJN1N6qEd-_dMn5_cB9Xw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lxJN1d6qEd-_dMn5_cB9Xw" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVFpslGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFps1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVGQwFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVGQwVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_lxJN0d6qEd-_dMn5_cB9Xw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_lxJN0t6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lxJN096qEd-_dMn5_cB9Xw" points="[0, -10, 500, -10]$[-500, -10, 0, -10]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lxJ04N6qEd-_dMn5_cB9Xw" id="(0.5,0.9218437)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lxJ04d6qEd-_dMn5_cB9Xw" id="(0.5,0.9218437)"/>
-          </edges>
-        </data>
-      </ownedAnnotationEntries>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TgM7gPWhEeG4Wag4JBRK3A" name="a : A" width="12" height="5" resizeKind="NSEW">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_b3_XYd6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b3_XYt6qEd-_dMn5_cB9Xw" y="42" width="10" height="141"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_b3_-ct6qEd-_dMn5_cB9Xw" type="3003" element="_TiuEAPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_b3_-c96qEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b3_-dN6qEd-_dMn5_cB9Xw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_b37F8d6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b37F8t6qEd-_dMn5_cB9Xw" x="902" y="312" width="120" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_-qE-gt2zEd-ZhcM4sDvRBQ"/>
+        <edges xmi:type="notation:Edge" xmi:id="_ZjeXEN6qEd-_dMn5_cB9Xw" type="4001" element="_Tk7DcPWhEeG4Wag4JBRK3A" source="_-8RhwN2zEd-ZhcM4sDvRBQ" target="_-9BvsN2zEd-ZhcM4sDvRBQ">
+          <children xmi:type="notation:Node" xmi:id="_ZjhaYN6qEd-_dMn5_cB9Xw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZjhaYd6qEd-_dMn5_cB9Xw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OU0j8FGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OU0j8VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVB_UFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVB_UVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ZjeXEd6qEd-_dMn5_cB9Xw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ZjeXEt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZjeXE96qEd-_dMn5_cB9Xw" points="[0, -2, -280, -2]$[280, -2, 0, -2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZjiogN6qEd-_dMn5_cB9Xw" id="(0.5,0.12627292)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zjiogd6qEd-_dMn5_cB9Xw" id="(0.5,0.12627292)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_lxJN0N6qEd-_dMn5_cB9Xw" type="4001" element="_TlN-YPWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_-8RhwN2zEd-ZhcM4sDvRBQ">
+          <children xmi:type="notation:Node" xmi:id="_lxJN1N6qEd-_dMn5_cB9Xw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lxJN1d6qEd-_dMn5_cB9Xw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVFpslGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFps1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVGQwFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVGQwVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lxJN0d6qEd-_dMn5_cB9Xw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lxJN0t6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lxJN096qEd-_dMn5_cB9Xw" points="[0, -10, 500, -10]$[-500, -10, 0, -10]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lxJ04N6qEd-_dMn5_cB9Xw" id="(0.5,0.9218437)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lxJ04d6qEd-_dMn5_cB9Xw" id="(0.5,0.9218437)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_aSWPQN6qEd-_dMn5_cB9Xw" type="4001" element="_TlGCkPWhEeG4Wag4JBRK3A" source="_-9BvsN2zEd-ZhcM4sDvRBQ" target="_-9RAQN2zEd-ZhcM4sDvRBQ">
+          <children xmi:type="notation:Node" xmi:id="_aSW2UN6qEd-_dMn5_cB9Xw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aSW2Ud6qEd-_dMn5_cB9Xw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVDNcFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVDNcVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVDNclGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVDNc1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_aSWPQd6qEd-_dMn5_cB9Xw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_aSWPQt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aSWPQ96qEd-_dMn5_cB9Xw" points="[0, -4, -344, -4]$[344, -4, 0, -4]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aSW2Ut6qEd-_dMn5_cB9Xw" id="(0.5,0.22606924)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aSW2U96qEd-_dMn5_cB9Xw" id="(0.5,0.22606924)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_arcEsN6qEd-_dMn5_cB9Xw" type="4001" element="_TlJF4PWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_-9RAQN2zEd-ZhcM4sDvRBQ">
+          <children xmi:type="notation:Node" xmi:id="_arcrwN6qEd-_dMn5_cB9Xw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_arcrwd6qEd-_dMn5_cB9Xw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVD0gFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVD0gVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVD0glGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVD0g1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_arcEsd6qEd-_dMn5_cB9Xw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_arcEst6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_arcEs96qEd-_dMn5_cB9Xw" points="[0, 136, 0, 136]$[30, 136, 0, 136]$[30, 178, 0, 178]$[0, 178, 0, 178]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bP-VIN6qEd-_dMn5_cB9Xw" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bP-VId6qEd-_dMn5_cB9Xw" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_dvpckN6qEd-_dMn5_cB9Xw" type="4001" element="_TlXvYPWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_b37F8N6qEd-_dMn5_cB9Xw">
+          <children xmi:type="notation:Node" xmi:id="_dvqDoN6qEd-_dMn5_cB9Xw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dvqDod6qEd-_dMn5_cB9Xw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVD0hFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVEbkFGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVEbkVGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVEbklGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_dvpckd6qEd-_dMn5_cB9Xw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_dvpckt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dvpck96qEd-_dMn5_cB9Xw" points="[0, -5, -1214, 0]$[2188, -5, 974, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dvqqsN6qEd-_dMn5_cB9Xw" id="(0.5,0.4749499)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dvqqsd6qEd-_dMn5_cB9Xw" id="(0.5,0.5) ice(974,262)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_hjru4N6qEd-_dMn5_cB9Xw" type="4001" element="_TlfEIPWhEeG4Wag4JBRK3A" source="_-9RAQN2zEd-ZhcM4sDvRBQ" target="_hjh94N6qEd-_dMn5_cB9Xw">
+          <children xmi:type="notation:Node" xmi:id="_hjsV8N6qEd-_dMn5_cB9Xw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hjsV8d6qEd-_dMn5_cB9Xw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVFColGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFCo1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVFpsFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFpsVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_hjru4d6qEd-_dMn5_cB9Xw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_hjru4t6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hjru496qEd-_dMn5_cB9Xw" points="[2, 0, -350, 0]$[327, 0, -25, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hjsV8t6qEd-_dMn5_cB9Xw" id="(0.5,0.83967936)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hjsV896qEd-_dMn5_cB9Xw" id="(0.5,0.5) ice(916,494)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_fXZdgN6qEd-_dMn5_cB9Xw" type="4001" element="_TlLiIPWhEeG4Wag4JBRK3A" source="_b3_XYN6qEd-_dMn5_cB9Xw" target="_b3_XYN6qEd-_dMn5_cB9Xw">
+          <children xmi:type="notation:Node" xmi:id="_fXZdhN6qEd-_dMn5_cB9Xw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fXZdhd6qEd-_dMn5_cB9Xw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVEbk1GCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVEblFGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVFCoFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVFCoVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fXZdgd6qEd-_dMn5_cB9Xw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_fXZdgt6qEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fXZdg96qEd-_dMn5_cB9Xw" points="[0, -2, 0, -17]$[0, 24, 0, 9]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fXaEkN6qEd-_dMn5_cB9Xw" id="(0.5,0.19831224)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fXaEkd6qEd-_dMn5_cB9Xw" id="(0.5,0.30801687)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_9ipdYLm3Ee-UXMFld_STMg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_9ipdYbm3Ee-UXMFld_STMg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TgM7gPWhEeG4Wag4JBRK3A" name="a : A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_UQskUPWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tiv5MPWhEeG4Wag4JBRK3A" outgoingEdges="_Tk7DcPWhEeG4Wag4JBRK3A" incomingEdges="_TlN-YPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_UQskUPWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tiv5MPWhEeG4Wag4JBRK3A" outgoingEdges="_Tk7DcPWhEeG4Wag4JBRK3A" incomingEdges="_TlN-YPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TjankPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TjankPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_Tjb1sPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tjb1sfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tjb1svWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tjb1s_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TixHUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TixHUfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TixHUvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TixHU_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_Tjb1sPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_ThqUEPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Thq7IPWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Thq7IfWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_Thq7IvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TixHUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TimvQPWhEeG4Wag4JBRK3A" name="b : B" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ThqUEPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TimvQPWhEeG4Wag4JBRK3A" name="b : B" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_UQskUfWhEeG4Wag4JBRK3A" x="330" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tjdq4PWhEeG4Wag4JBRK3A" outgoingEdges="_TlGCkPWhEeG4Wag4JBRK3A" incomingEdges="_Tk7DcPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_UQskUfWhEeG4Wag4JBRK3A" x="330" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tjdq4PWhEeG4Wag4JBRK3A" outgoingEdges="_TlGCkPWhEeG4Wag4JBRK3A" incomingEdges="_Tk7DcPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TjjxgPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TjjxgPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TjkYkPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TjkYkfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TjkYkvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TjkYk_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TjeR8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TjeR8fWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TjeR8vWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TjeR8_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TjkYkPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TipLgPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TipLgfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TipLgvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TipLg_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TjeR8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TipykPWhEeG4Wag4JBRK3A" name="c : C" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TipLgPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TipykPWhEeG4Wag4JBRK3A" name="c : C" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_UQskUvWhEeG4Wag4JBRK3A" x="550" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tjp4IPWhEeG4Wag4JBRK3A" outgoingEdges="_TlJF4PWhEeG4Wag4JBRK3A _TlN-YPWhEeG4Wag4JBRK3A _TlXvYPWhEeG4Wag4JBRK3A _TlfEIPWhEeG4Wag4JBRK3A" incomingEdges="_TlGCkPWhEeG4Wag4JBRK3A _TlJF4PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_UQskUvWhEeG4Wag4JBRK3A" x="550" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tjp4IPWhEeG4Wag4JBRK3A" outgoingEdges="_TlJF4PWhEeG4Wag4JBRK3A _TlN-YPWhEeG4Wag4JBRK3A _TlXvYPWhEeG4Wag4JBRK3A _TlfEIPWhEeG4Wag4JBRK3A" incomingEdges="_TlGCkPWhEeG4Wag4JBRK3A _TlJF4PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TjtigPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TjtigPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TjuJkPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TjuJkfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TjuJkvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TjuJk_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TjrGQPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TjrGQfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TjrGQvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TjrGQ_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TjuJkPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TirAsPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TirAsfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TirAsvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TirAs_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TjrGQPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TirAtPWhEeG4Wag4JBRK3A" name="d : " incomingEdges="_TlXvYPWhEeG4Wag4JBRK3A" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TirAsPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TirAtPWhEeG4Wag4JBRK3A" name="d : " incomingEdges="_TlXvYPWhEeG4Wag4JBRK3A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_UQskU_WhEeG4Wag4JBRK3A" x="902" y="312" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TjuwoPWhEeG4Wag4JBRK3A" outgoingEdges="_TlLiIPWhEeG4Wag4JBRK3A" incomingEdges="_TlLiIPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_UQskU_WhEeG4Wag4JBRK3A" x="902" y="312" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TjuwoPWhEeG4Wag4JBRK3A" outgoingEdges="_TlLiIPWhEeG4Wag4JBRK3A" incomingEdges="_TlLiIPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tjxz8PWhEeG4Wag4JBRK3A" incomingEdges="_TlfEIPWhEeG4Wag4JBRK3A" width="5" height="5">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tjxz8PWhEeG4Wag4JBRK3A" incomingEdges="_TlfEIPWhEeG4Wag4JBRK3A" width="5" height="5">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
-            <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_TjzCEPWhEeG4Wag4JBRK3A" showIcon="false" workspacePath="/org.eclipse.sirius.sample.interactions.design/description/eol.png">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TjzCEfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TjzCEvWhEeG4Wag4JBRK3A"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TjvXsPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TjvXsfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TjvXsvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TjvXs_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_TjzCEPWhEeG4Wag4JBRK3A" showIcon="false" workspacePath="/org.eclipse.sirius.sample.interactions.design/description/eol.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TiuEAPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TiurEPWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TiurEfWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TiurEvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TjvXsPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_Tk7DcPWhEeG4Wag4JBRK3A" name="m1" sourceNode="_Tiv5MPWhEeG4Wag4JBRK3A" targetNode="_Tjdq4PWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.0"/>
-        <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.0"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.0"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.1"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-UUBl8EeCKOMpCHXRNLw" x="0" y="162" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_ZilmQN6qEd-_dMn5_cB9Xw" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_ZilmQt6qEd-_dMn5_cB9Xw" red="77" green="137" blue="20"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSF0_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSGE_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TlGCkPWhEeG4Wag4JBRK3A" name="m2" sourceNode="_Tjdq4PWhEeG4Wag4JBRK3A" targetNode="_Tjp4IPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.1"/>
-        <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.1"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.2"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.3"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-UURl8EeCKOMpCHXRNLw" x="0" y="211" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_aSBfId6qEd-_dMn5_cB9Xw" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_aSBfI96qEd-_dMn5_cB9Xw" red="77" green="137" blue="20"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSFU_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSFk_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TlJF4PWhEeG4Wag4JBRK3A" name="m3" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_Tjp4IPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.2"/>
-        <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.2"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.4"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.5"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-UUhl8EeCKOMpCHXRNLw" x="0" y="236" height="42" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_arH7od6qEd-_dMn5_cB9Xw" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_arH7o96qEd-_dMn5_cB9Xw" red="77" green="137" blue="20"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrHE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrHU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TlLiIPWhEeG4Wag4JBRK3A" name="m5" sourceNode="_TjuwoPWhEeG4Wag4JBRK3A" targetNode="_TjuwoPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.4"/>
-        <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.4"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.8"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.9"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-7YBl8EeCKOMpCHXRNLw" x="0" y="388" height="26" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_fXDfQd6qEd-_dMn5_cB9Xw" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_fXDfQ96qEd-_dMn5_cB9Xw" red="77" green="137" blue="20"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrBE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrBU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TlN-YPWhEeG4Wag4JBRK3A" name="m7" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_Tiv5MPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.6"/>
-        <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.6"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.12"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.13"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-7Yhl8EeCKOMpCHXRNLw" x="0" y="560" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_lwxaYd6qEd-_dMn5_cB9Xw" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_lwxaY96qEd-_dMn5_cB9Xw" red="77" green="137" blue="20"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSEU_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSEk_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TlXvYPWhEeG4Wag4JBRK3A" name="m_create4" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_TirAtPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.3"/>
-        <semanticElements xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.3"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.6"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.7"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-UUxl8EeCKOMpCHXRNLw" x="0" y="337" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_du3Zcd6qEd-_dMn5_cB9Xw" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_du3Zc96qEd-_dMn5_cB9Xw" red="138" green="226" blue="52"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSIU_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSIk_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:CreationMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TlfEIPWhEeG4Wag4JBRK3A" name="m_destroy6" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_Tjxz8PWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.5"/>
-        <semanticElements xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.5"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.10"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.11"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-7YRl8EeCKOMpCHXRNLw" x="0" y="528" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_hjT7cd6qEd-_dMn5_cB9Xw" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_hjT7c96qEd-_dMn5_cB9Xw" red="246" green="139" blue="139"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrGE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrGU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:DestructionMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']"/>
-      </ownedDiagramElements>
-      <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
-      <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_-pfIod2zEd-ZhcM4sDvRBQ"/>
-      <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
-      <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.0"/>
-    </ownedRepresentations>
-    <ownedRepresentations xmi:type="sequence:SequenceDDiagram" xmi:id="_OHyPgN6tEd-_dMn5_cB9Xw" name="Basic Executions Diagram">
-      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_OH0EsN6tEd-_dMn5_cB9Xw" source="GMF_DIAGRAMS">
-        <data xmi:type="notation:Diagram" xmi:id="_OH0Esd6tEd-_dMn5_cB9Xw" type="Sirius" element="_OHyPgN6tEd-_dMn5_cB9Xw" measurementUnit="Pixel">
-          <children xmi:type="notation:Node" xmi:id="_OIEjYN6tEd-_dMn5_cB9Xw" type="2001" element="_TmLnsPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_OIFKcN6tEd-_dMn5_cB9Xw" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_OIFKcd6tEd-_dMn5_cB9Xw" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OI638N6tEd-_dMn5_cB9Xw" type="3001" element="_TmPSEPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_OI7fAN6tEd-_dMn5_cB9Xw" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_OI7fAd6tEd-_dMn5_cB9Xw" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_OI9UMN6tEd-_dMn5_cB9Xw" type="3003" element="_TmP5IPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_OI9UMd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OI9UMt6tEd-_dMn5_cB9Xw"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_QBSHwN6tEd-_dMn5_cB9Xw" type="3001" element="_TmRuUPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_QBSu0N6tEd-_dMn5_cB9Xw" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_QBSu0d6tEd-_dMn5_cB9Xw" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_QBWZMN6tEd-_dMn5_cB9Xw" type="3003" element="_TmWm0PWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_QBWZMd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBWZMt6tEd-_dMn5_cB9Xw"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_QBSHwd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBSHwt6tEd-_dMn5_cB9Xw" x="2" y="49" width="20" height="45"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_QffGsN6tEd-_dMn5_cB9Xw" type="3001" element="_Tmg-4PWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_QffGs96tEd-_dMn5_cB9Xw" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_QffGtN6tEd-_dMn5_cB9Xw" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_Qfg74N6tEd-_dMn5_cB9Xw" type="3003" element="_TmjbIPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_Qfg74d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qfg74t6tEd-_dMn5_cB9Xw"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_QffGsd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QffGst6tEd-_dMn5_cB9Xw" x="2" y="179" width="20" height="49"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_Sf44MN6tEd-_dMn5_cB9Xw" type="3001" element="_TmkpQPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_Sf44M96tEd-_dMn5_cB9Xw" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_Sf44NN6tEd-_dMn5_cB9Xw" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_Sf6GUN6tEd-_dMn5_cB9Xw" type="3003" element="_Tml3YPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_Sf6GUd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sf6GUt6tEd-_dMn5_cB9Xw"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_UvEFgN6tEd-_dMn5_cB9Xw" type="3001" element="_TmphwPWhEeG4Wag4JBRK3A">
-                  <children xmi:type="notation:Node" xmi:id="_UvEskN6tEd-_dMn5_cB9Xw" type="5001">
-                    <layoutConstraint xmi:type="notation:Location" xmi:id="_UvEskd6tEd-_dMn5_cB9Xw" y="5"/>
-                  </children>
-                  <children xmi:type="notation:Node" xmi:id="_UvF6sN6tEd-_dMn5_cB9Xw" type="3003" element="_TmtzMPWhEeG4Wag4JBRK3A">
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_UvF6sd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UvF6st6tEd-_dMn5_cB9Xw"/>
-                  </children>
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_UvEFgd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UvEFgt6tEd-_dMn5_cB9Xw" x="12" y="22" width="20" height="65"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_Sf44Md6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sf44Mt6tEd-_dMn5_cB9Xw" x="2" y="357" width="20" height="141"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_msHhME5cEeCHObKOrZ_h3Q" type="3001" element="_TmzSwPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_msIIQE5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_msIIQU5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_msJWYE5cEeCHObKOrZ_h3Q" type="3002" element="_Tm1vAPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_msJWYU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msJWYk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_msHhMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msHhMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_OI638d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OI638t6tEd-_dMn5_cB9Xw" y="42" width="10" height="548"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OI7fAt6tEd-_dMn5_cB9Xw" type="3003" element="_TmM10PWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_OI7fA96tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OI7fBN6tEd-_dMn5_cB9Xw"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_OIEjYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OIEjYt6tEd-_dMn5_cB9Xw" x="50" y="50" width="120" height="50"/>
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TiuEAPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Tk7DcPWhEeG4Wag4JBRK3A" name="m1" sourceNode="_Tiv5MPWhEeG4Wag4JBRK3A" targetNode="_Tjdq4PWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.0"/>
+      <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.0"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.0"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-UUBl8EeCKOMpCHXRNLw" y="162" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ZilmQN6qEd-_dMn5_cB9Xw" size="2" strokeColor="77,137,20">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSF0_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TlGCkPWhEeG4Wag4JBRK3A" name="m2" sourceNode="_Tjdq4PWhEeG4Wag4JBRK3A" targetNode="_Tjp4IPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.1"/>
+      <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.1"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.2"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.3"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-UURl8EeCKOMpCHXRNLw" y="211" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_aSBfId6qEd-_dMn5_cB9Xw" size="2" strokeColor="77,137,20">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSFU_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TlJF4PWhEeG4Wag4JBRK3A" name="m3" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_Tjp4IPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.2"/>
+      <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.2"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.4"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.5"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-UUhl8EeCKOMpCHXRNLw" y="236" height="42"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_arH7od6qEd-_dMn5_cB9Xw" size="2" strokeColor="77,137,20">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrHE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TlLiIPWhEeG4Wag4JBRK3A" name="m5" sourceNode="_TjuwoPWhEeG4Wag4JBRK3A" targetNode="_TjuwoPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.4"/>
+      <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.4"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.8"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.9"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-7YBl8EeCKOMpCHXRNLw" y="388" height="26"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fXDfQd6qEd-_dMn5_cB9Xw" size="2" strokeColor="77,137,20">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrBE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TlN-YPWhEeG4Wag4JBRK3A" name="m7" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_Tiv5MPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.6"/>
+      <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.6"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.12"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.13"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-7Yhl8EeCKOMpCHXRNLw" y="560" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_lwxaYd6qEd-_dMn5_cB9Xw" size="2" strokeColor="77,137,20">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSEU_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TlXvYPWhEeG4Wag4JBRK3A" name="m_create4" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_TirAtPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.3"/>
+      <semanticElements xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.3"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.6"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.7"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-UUxl8EeCKOMpCHXRNLw" y="337" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_du3Zcd6qEd-_dMn5_cB9Xw" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2" strokeColor="138,226,52">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSIU_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:CreationMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TlfEIPWhEeG4Wag4JBRK3A" name="m_destroy6" sourceNode="_Tjp4IPWhEeG4Wag4JBRK3A" targetNode="_Tjxz8PWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.5"/>
+      <semanticElements xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.0/@messages.5"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.10"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.0/@ends.11"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.2"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.0/@participants.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-7YRl8EeCKOMpCHXRNLw" y="528" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_hjT7cd6qEd-_dMn5_cB9Xw" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2" strokeColor="246,139,139">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrGE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:DestructionMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_-pfIod2zEd-ZhcM4sDvRBQ"/>
+    <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
+    <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.0"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_OHyPgN6tEd-_dMn5_cB9Xw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_OH0EsN6tEd-_dMn5_cB9Xw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_OH0Esd6tEd-_dMn5_cB9Xw" type="Sirius" element="_OHyPgN6tEd-_dMn5_cB9Xw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_OIEjYN6tEd-_dMn5_cB9Xw" type="2001" element="_TmLnsPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_OIFKcN6tEd-_dMn5_cB9Xw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_OIFKcd6tEd-_dMn5_cB9Xw" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_OIFKct6tEd-_dMn5_cB9Xw" type="2001" element="_TmNc4PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_OIFKdd6tEd-_dMn5_cB9Xw" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_OIFKdt6tEd-_dMn5_cB9Xw" y="5"/>
+          <children xmi:type="notation:Node" xmi:id="_OI638N6tEd-_dMn5_cB9Xw" type="3001" element="_TmPSEPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_OI7fAN6tEd-_dMn5_cB9Xw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_OI7fAd6tEd-_dMn5_cB9Xw" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OJEB4N6tEd-_dMn5_cB9Xw" type="3001" element="_Tm29IPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_OJEB496tEd-_dMn5_cB9Xw" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_OJEB5N6tEd-_dMn5_cB9Xw" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_OJF3EN6tEd-_dMn5_cB9Xw" type="3003" element="_Tm4LQPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_OJF3Ed6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJF3Et6tEd-_dMn5_cB9Xw"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_RTxqYN6tEd-_dMn5_cB9Xw" type="3001" element="_Tm6ngPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_RTyRcN6tEd-_dMn5_cB9Xw" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_RTyRcd6tEd-_dMn5_cB9Xw" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_RTzfkN6tEd-_dMn5_cB9Xw" type="3003" element="_Tm71oPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_RTzfkd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RTzfkt6tEd-_dMn5_cB9Xw"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_R1IrAN6tEd-_dMn5_cB9Xw" type="3001" element="_TnBVMPWhEeG4Wag4JBRK3A">
-                  <children xmi:type="notation:Node" xmi:id="_R1JSEN6tEd-_dMn5_cB9Xw" type="5001">
-                    <layoutConstraint xmi:type="notation:Location" xmi:id="_R1JSEd6tEd-_dMn5_cB9Xw" y="5"/>
-                  </children>
-                  <children xmi:type="notation:Node" xmi:id="_R1LHQN6tEd-_dMn5_cB9Xw" type="3003" element="_TnB8QPWhEeG4Wag4JBRK3A">
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_R1LHQd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R1LHQt6tEd-_dMn5_cB9Xw"/>
-                  </children>
-                  <children xmi:type="notation:Node" xmi:id="_WGd9UN6tEd-_dMn5_cB9Xw" type="3001" element="_TnM7YPWhEeG4Wag4JBRK3A">
-                    <children xmi:type="notation:Node" xmi:id="_WGekYN6tEd-_dMn5_cB9Xw" type="5001">
-                      <layoutConstraint xmi:type="notation:Location" xmi:id="_WGekYd6tEd-_dMn5_cB9Xw" y="5"/>
-                    </children>
-                    <children xmi:type="notation:Node" xmi:id="_WGgZkN6tEd-_dMn5_cB9Xw" type="3003" element="_TnOJgPWhEeG4Wag4JBRK3A">
-                      <styles xmi:type="notation:ShapeStyle" xmi:id="_WGgZkd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WGgZkt6tEd-_dMn5_cB9Xw"/>
-                    </children>
-                    <children xmi:type="notation:Node" xmi:id="_WWBcQN6tEd-_dMn5_cB9Xw" type="3001" element="_TnQlwPWhEeG4Wag4JBRK3A">
-                      <children xmi:type="notation:Node" xmi:id="_WWBcQ96tEd-_dMn5_cB9Xw" type="5001">
-                        <layoutConstraint xmi:type="notation:Location" xmi:id="_WWBcRN6tEd-_dMn5_cB9Xw" y="5"/>
-                      </children>
-                      <children xmi:type="notation:Node" xmi:id="_WWDRcN6tEd-_dMn5_cB9Xw" type="3003" element="_TnRz4PWhEeG4Wag4JBRK3A">
-                        <styles xmi:type="notation:ShapeStyle" xmi:id="_WWDRcd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WWDRct6tEd-_dMn5_cB9Xw"/>
-                      </children>
-                      <children xmi:type="notation:Node" xmi:id="_WlusMN6tEd-_dMn5_cB9Xw" type="3001" element="_TnU3MPWhEeG4Wag4JBRK3A">
-                        <children xmi:type="notation:Node" xmi:id="_WlvTQN6tEd-_dMn5_cB9Xw" type="5001">
-                          <layoutConstraint xmi:type="notation:Location" xmi:id="_WlvTQd6tEd-_dMn5_cB9Xw" y="5"/>
-                        </children>
-                        <children xmi:type="notation:Node" xmi:id="_WlwhYN6tEd-_dMn5_cB9Xw" type="3003" element="_TnWFUPWhEeG4Wag4JBRK3A">
-                          <styles xmi:type="notation:ShapeStyle" xmi:id="_WlwhYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WlwhYt6tEd-_dMn5_cB9Xw"/>
-                        </children>
-                        <styles xmi:type="notation:ShapeStyle" xmi:id="_WlusMd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WlusMt6tEd-_dMn5_cB9Xw" x="12" y="5" width="20" height="30"/>
-                      </children>
-                      <styles xmi:type="notation:ShapeStyle" xmi:id="_WWBcQd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WWBcQt6tEd-_dMn5_cB9Xw" x="12" y="5" width="20" height="43"/>
-                    </children>
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_WGd9Ud6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WGd9Ut6tEd-_dMn5_cB9Xw" x="12" y="5" width="20" height="56"/>
-                  </children>
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_R1IrAd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R1IrAt6tEd-_dMn5_cB9Xw" x="12" y="46" width="20" height="69"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_SFhQYN6tEd-_dMn5_cB9Xw" type="3001" element="_TnDxcPWhEeG4Wag4JBRK3A">
-                  <children xmi:type="notation:Node" xmi:id="_SFhQY96tEd-_dMn5_cB9Xw" type="5001">
-                    <layoutConstraint xmi:type="notation:Location" xmi:id="_SFhQZN6tEd-_dMn5_cB9Xw" y="5"/>
-                  </children>
-                  <children xmi:type="notation:Node" xmi:id="_SFjFkN6tEd-_dMn5_cB9Xw" type="3003" element="_TnG0wPWhEeG4Wag4JBRK3A">
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_SFjFkd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SFjFkt6tEd-_dMn5_cB9Xw"/>
-                  </children>
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_SFhQYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SFhQYt6tEd-_dMn5_cB9Xw" x="12" y="134" width="20" height="30"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_RTxqYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RTxqYt6tEd-_dMn5_cB9Xw" x="2" y="59" width="20" height="184"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_TzJ24N6tEd-_dMn5_cB9Xw" type="3001" element="_Tm-R4PWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_TzKd8N6tEd-_dMn5_cB9Xw" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_TzKd8d6tEd-_dMn5_cB9Xw" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_TzMTIN6tEd-_dMn5_cB9Xw" type="3003" element="_Tm_gAPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_TzMTId6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzMTIt6tEd-_dMn5_cB9Xw"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_TzJ24d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzJ24t6tEd-_dMn5_cB9Xw" x="2" y="390" width="20" height="59"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_msOO4E5cEeCHObKOrZ_h3Q" type="3001" element="_TnhEcPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_msOO405cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_msOO5E5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_msQEEE5cEeCHObKOrZ_h3Q" type="3002" element="_TnhEcfWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_msQEEU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msQEEk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_msOO4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msOO4k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_OJEB4d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJEB4t6tEd-_dMn5_cB9Xw" y="42" width="10" height="548"/>
+            <children xmi:type="notation:Node" xmi:id="_OI9UMN6tEd-_dMn5_cB9Xw" type="3003" element="_TmP5IPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_OI9UMd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OI9UMt6tEd-_dMn5_cB9Xw"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OJEB5d6tEd-_dMn5_cB9Xw" type="3003" element="_TmOrAPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_OJEB5t6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJEB596tEd-_dMn5_cB9Xw"/>
+            <children xmi:type="notation:Node" xmi:id="_QBSHwN6tEd-_dMn5_cB9Xw" type="3001" element="_TmRuUPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_QBSu0N6tEd-_dMn5_cB9Xw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_QBSu0d6tEd-_dMn5_cB9Xw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_QBWZMN6tEd-_dMn5_cB9Xw" type="3003" element="_TmWm0PWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_QBWZMd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBWZMt6tEd-_dMn5_cB9Xw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_QBSHwd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QBSHwt6tEd-_dMn5_cB9Xw" x="2" y="49" width="20" height="45"/>
             </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_OIFKc96tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OIFKdN6tEd-_dMn5_cB9Xw" x="451" y="50" width="120" height="50"/>
+            <children xmi:type="notation:Node" xmi:id="_QffGsN6tEd-_dMn5_cB9Xw" type="3001" element="_Tmg-4PWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_QffGs96tEd-_dMn5_cB9Xw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_QffGtN6tEd-_dMn5_cB9Xw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_Qfg74N6tEd-_dMn5_cB9Xw" type="3003" element="_TmjbIPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_Qfg74d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qfg74t6tEd-_dMn5_cB9Xw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_QffGsd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QffGst6tEd-_dMn5_cB9Xw" x="2" y="179" width="20" height="49"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Sf44MN6tEd-_dMn5_cB9Xw" type="3001" element="_TmkpQPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_Sf44M96tEd-_dMn5_cB9Xw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_Sf44NN6tEd-_dMn5_cB9Xw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_Sf6GUN6tEd-_dMn5_cB9Xw" type="3003" element="_Tml3YPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_Sf6GUd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sf6GUt6tEd-_dMn5_cB9Xw"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_UvEFgN6tEd-_dMn5_cB9Xw" type="3001" element="_TmphwPWhEeG4Wag4JBRK3A">
+                <children xmi:type="notation:Node" xmi:id="_UvEskN6tEd-_dMn5_cB9Xw" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_UvEskd6tEd-_dMn5_cB9Xw" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_UvF6sN6tEd-_dMn5_cB9Xw" type="3003" element="_TmtzMPWhEeG4Wag4JBRK3A">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_UvF6sd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UvF6st6tEd-_dMn5_cB9Xw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_UvEFgd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UvEFgt6tEd-_dMn5_cB9Xw" x="12" y="22" width="20" height="65"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Sf44Md6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sf44Mt6tEd-_dMn5_cB9Xw" x="2" y="357" width="20" height="141"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_msHhME5cEeCHObKOrZ_h3Q" type="3001" element="_TmzSwPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_msIIQE5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_msIIQU5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_msJWYE5cEeCHObKOrZ_h3Q" type="3002" element="_Tm1vAPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_msJWYU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msJWYk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_msHhMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msHhMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_OI638d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OI638t6tEd-_dMn5_cB9Xw" y="42" width="10" height="548"/>
           </children>
-          <styles xmi:type="notation:DiagramStyle" xmi:id="_OH0Est6tEd-_dMn5_cB9Xw"/>
-        </data>
-      </ownedAnnotationEntries>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TmLnsPWhEeG4Wag4JBRK3A" name="a : A" width="12" height="5" resizeKind="NSEW">
+          <children xmi:type="notation:Node" xmi:id="_OI7fAt6tEd-_dMn5_cB9Xw" type="3003" element="_TmM10PWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_OI7fA96tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OI7fBN6tEd-_dMn5_cB9Xw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_OIEjYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OIEjYt6tEd-_dMn5_cB9Xw" x="50" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_OIFKct6tEd-_dMn5_cB9Xw" type="2001" element="_TmNc4PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_OIFKdd6tEd-_dMn5_cB9Xw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_OIFKdt6tEd-_dMn5_cB9Xw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OJEB4N6tEd-_dMn5_cB9Xw" type="3001" element="_Tm29IPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_OJEB496tEd-_dMn5_cB9Xw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_OJEB5N6tEd-_dMn5_cB9Xw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_OJF3EN6tEd-_dMn5_cB9Xw" type="3003" element="_Tm4LQPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_OJF3Ed6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJF3Et6tEd-_dMn5_cB9Xw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_RTxqYN6tEd-_dMn5_cB9Xw" type="3001" element="_Tm6ngPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_RTyRcN6tEd-_dMn5_cB9Xw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_RTyRcd6tEd-_dMn5_cB9Xw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_RTzfkN6tEd-_dMn5_cB9Xw" type="3003" element="_Tm71oPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_RTzfkd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RTzfkt6tEd-_dMn5_cB9Xw"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_R1IrAN6tEd-_dMn5_cB9Xw" type="3001" element="_TnBVMPWhEeG4Wag4JBRK3A">
+                <children xmi:type="notation:Node" xmi:id="_R1JSEN6tEd-_dMn5_cB9Xw" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_R1JSEd6tEd-_dMn5_cB9Xw" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_R1LHQN6tEd-_dMn5_cB9Xw" type="3003" element="_TnB8QPWhEeG4Wag4JBRK3A">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_R1LHQd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R1LHQt6tEd-_dMn5_cB9Xw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_WGd9UN6tEd-_dMn5_cB9Xw" type="3001" element="_TnM7YPWhEeG4Wag4JBRK3A">
+                  <children xmi:type="notation:Node" xmi:id="_WGekYN6tEd-_dMn5_cB9Xw" type="5001">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_WGekYd6tEd-_dMn5_cB9Xw" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_WGgZkN6tEd-_dMn5_cB9Xw" type="3003" element="_TnOJgPWhEeG4Wag4JBRK3A">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_WGgZkd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WGgZkt6tEd-_dMn5_cB9Xw"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_WWBcQN6tEd-_dMn5_cB9Xw" type="3001" element="_TnQlwPWhEeG4Wag4JBRK3A">
+                    <children xmi:type="notation:Node" xmi:id="_WWBcQ96tEd-_dMn5_cB9Xw" type="5001">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_WWBcRN6tEd-_dMn5_cB9Xw" y="5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_WWDRcN6tEd-_dMn5_cB9Xw" type="3003" element="_TnRz4PWhEeG4Wag4JBRK3A">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_WWDRcd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WWDRct6tEd-_dMn5_cB9Xw"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_WlusMN6tEd-_dMn5_cB9Xw" type="3001" element="_TnU3MPWhEeG4Wag4JBRK3A">
+                      <children xmi:type="notation:Node" xmi:id="_WlvTQN6tEd-_dMn5_cB9Xw" type="5001">
+                        <layoutConstraint xmi:type="notation:Location" xmi:id="_WlvTQd6tEd-_dMn5_cB9Xw" y="5"/>
+                      </children>
+                      <children xmi:type="notation:Node" xmi:id="_WlwhYN6tEd-_dMn5_cB9Xw" type="3003" element="_TnWFUPWhEeG4Wag4JBRK3A">
+                        <styles xmi:type="notation:ShapeStyle" xmi:id="_WlwhYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WlwhYt6tEd-_dMn5_cB9Xw"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_WlusMd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WlusMt6tEd-_dMn5_cB9Xw" x="12" y="5" width="20" height="30"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_WWBcQd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WWBcQt6tEd-_dMn5_cB9Xw" x="12" y="5" width="20" height="43"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_WGd9Ud6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WGd9Ut6tEd-_dMn5_cB9Xw" x="12" y="5" width="20" height="56"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_R1IrAd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R1IrAt6tEd-_dMn5_cB9Xw" x="12" y="46" width="20" height="69"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_SFhQYN6tEd-_dMn5_cB9Xw" type="3001" element="_TnDxcPWhEeG4Wag4JBRK3A">
+                <children xmi:type="notation:Node" xmi:id="_SFhQY96tEd-_dMn5_cB9Xw" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_SFhQZN6tEd-_dMn5_cB9Xw" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_SFjFkN6tEd-_dMn5_cB9Xw" type="3003" element="_TnG0wPWhEeG4Wag4JBRK3A">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_SFjFkd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SFjFkt6tEd-_dMn5_cB9Xw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_SFhQYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SFhQYt6tEd-_dMn5_cB9Xw" x="12" y="134" width="20" height="30"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_RTxqYd6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RTxqYt6tEd-_dMn5_cB9Xw" x="2" y="59" width="20" height="184"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_TzJ24N6tEd-_dMn5_cB9Xw" type="3001" element="_Tm-R4PWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_TzKd8N6tEd-_dMn5_cB9Xw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_TzKd8d6tEd-_dMn5_cB9Xw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_TzMTIN6tEd-_dMn5_cB9Xw" type="3003" element="_Tm_gAPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_TzMTId6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzMTIt6tEd-_dMn5_cB9Xw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_TzJ24d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TzJ24t6tEd-_dMn5_cB9Xw" x="2" y="390" width="20" height="59"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_msOO4E5cEeCHObKOrZ_h3Q" type="3001" element="_TnhEcPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_msOO405cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_msOO5E5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_msQEEE5cEeCHObKOrZ_h3Q" type="3002" element="_TnhEcfWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_msQEEU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msQEEk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_msOO4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msOO4k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_OJEB4d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJEB4t6tEd-_dMn5_cB9Xw" y="42" width="10" height="548"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OJEB5d6tEd-_dMn5_cB9Xw" type="3003" element="_TmOrAPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_OJEB5t6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJEB596tEd-_dMn5_cB9Xw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_OIFKc96tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OIFKdN6tEd-_dMn5_cB9Xw" x="451" y="50" width="120" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_OH0Est6tEd-_dMn5_cB9Xw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_9iqEcLm3Ee-UXMFld_STMg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_9iqEcbm3Ee-UXMFld_STMg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmLnsPWhEeG4Wag4JBRK3A" name="a : A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_UQuZgPWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TmPSEPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_UQuZgPWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TmPSEPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TmRuUPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.0"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.0"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.0"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.2"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP-7Yxl8EeCKOMpCHXRNLw" x="100" y="149" height="45" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TmWm0PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tmg-4PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.6"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.6"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.11"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.14"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP_icBl8EeCKOMpCHXRNLw" x="100" y="279" height="49" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TmjbIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TmkpQPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.8"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.8"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.16"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.21"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP_icRl8EeCKOMpCHXRNLw" x="100" y="457" height="141" width="20"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TmphwPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.9"/>
+            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.9"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.17"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.19"/>
+            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
+            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP_ichl8EeCKOMpCHXRNLw" x="115" y="479" height="65" width="20"/>
+            <ownedStyle xmi:type="diagram:Square" uid="_TmtzMPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="181,228,225">
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+          </ownedBorderedNodes>
+          <ownedStyle xmi:type="diagram:Square" uid="_Tml3YPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TmzSwPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TmRuUPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.0"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.0"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.0"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.2"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP-7Yxl8EeCKOMpCHXRNLw" x="100" y="149" height="45" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TmWm0PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TmWm0fWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TmWm0vWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TmgX0PWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tmg-4PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.6"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.6"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.11"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.14"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP_icBl8EeCKOMpCHXRNLw" x="100" y="279" height="49" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TmjbIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TmjbIfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TmjbIvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TmjbJPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TmkpQPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.8"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.8"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.16"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.21"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP_icRl8EeCKOMpCHXRNLw" x="100" y="457" height="141" width="20"/>
-            <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TmphwPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.9"/>
-              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.9"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.17"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.19"/>
-              <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP_ichl8EeCKOMpCHXRNLw" x="115" y="479" height="65" width="20"/>
-              <ownedStyle xmi:type="diagram:Square" xmi:id="_TmtzMPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TmtzMfWhEeG4Wag4JBRK3A"/>
-                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TmtzMvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                <color xmi:type="viewpoint:RGBValues" xmi:id="_TmtzNPWhEeG4Wag4JBRK3A" red="181" green="228" blue="225"/>
-              </ownedStyle>
-              <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-            </ownedBorderedNodes>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_Tml3YPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tml3YfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tml3YvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TmmecfWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TmzSwPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.0"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_Tm1vAPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm1vAfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm1vAvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm1vA_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TmP5IPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TmP5IfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TmP5IvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TmP5I_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_Tm1vAPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TmM10PWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TmM10fWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TmM10vWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TmM10_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TmP5IPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TmNc4PWhEeG4Wag4JBRK3A" name="b : B" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TmM10PWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmNc4PWhEeG4Wag4JBRK3A" name="b : B" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_UQuZgfWhEeG4Wag4JBRK3A" x="451" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tm29IPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_UQuZgfWhEeG4Wag4JBRK3A" x="451" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tm29IPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
-          <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tm6ngPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.1"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.1"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.1"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.15"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tm6ngPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.1"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.1"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.1"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.15"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP_icxl8EeCKOMpCHXRNLw" x="501" y="159" height="184" width="20"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TnBVMPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.2"/>
+            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.2"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.3"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.10"/>
             <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP_icxl8EeCKOMpCHXRNLw" x="501" y="159" height="184" width="20"/>
-            <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TnBVMPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.2"/>
-              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.2"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.3"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.10"/>
+            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MP_idBl8EeCKOMpCHXRNLw" x="516" y="205" height="69" width="20"/>
+            <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TnM7YPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.3"/>
+              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.3"/>
+              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.4"/>
+              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.9"/>
               <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MP_idBl8EeCKOMpCHXRNLw" x="516" y="205" height="69" width="20"/>
-              <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TnM7YPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-                <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.3"/>
-                <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.3"/>
-                <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.4"/>
-                <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.9"/>
+              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAJgBl8EeCKOMpCHXRNLw" x="531" y="210" height="56" width="20"/>
+              <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TnQlwPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+                <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.4"/>
+                <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.4"/>
+                <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.5"/>
+                <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.8"/>
                 <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-                <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAJgBl8EeCKOMpCHXRNLw" x="531" y="210" height="56" width="20"/>
-                <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TnQlwPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-                  <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.4"/>
-                  <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.4"/>
-                  <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.5"/>
-                  <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.8"/>
+                <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAJgRl8EeCKOMpCHXRNLw" x="546" y="215" height="43" width="20"/>
+                <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TnU3MPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+                  <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.5"/>
+                  <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.5"/>
+                  <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.6"/>
+                  <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.7"/>
                   <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-                  <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAJgRl8EeCKOMpCHXRNLw" x="546" y="215" height="43" width="20"/>
-                  <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TnU3MPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-                    <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.5"/>
-                    <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.5"/>
-                    <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.6"/>
-                    <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.7"/>
-                    <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-                    <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAJghl8EeCKOMpCHXRNLw" x="561" y="220" height="30" width="20"/>
-                    <ownedStyle xmi:type="diagram:Square" xmi:id="_TnWFUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                      <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TnWFUfWhEeG4Wag4JBRK3A"/>
-                      <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                      <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TnWFUvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                      <color xmi:type="viewpoint:RGBValues" xmi:id="_TnWsYPWhEeG4Wag4JBRK3A" red="128" green="201" blue="205"/>
-                    </ownedStyle>
-                    <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-                  </ownedBorderedNodes>
-                  <ownedStyle xmi:type="diagram:Square" xmi:id="_TnRz4PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                    <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TnRz4fWhEeG4Wag4JBRK3A"/>
+                  <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAJghl8EeCKOMpCHXRNLw" x="561" y="220" height="30" width="20"/>
+                  <ownedStyle xmi:type="diagram:Square" uid="_TnWFUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="128,201,205">
                     <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                    <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TnRz4vWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                    <color xmi:type="viewpoint:RGBValues" xmi:id="_TnTCAPWhEeG4Wag4JBRK3A" red="145" green="210" blue="211"/>
                   </ownedStyle>
                   <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
                 </ownedBorderedNodes>
-                <ownedStyle xmi:type="diagram:Square" xmi:id="_TnOJgPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                  <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TnOJgfWhEeG4Wag4JBRK3A"/>
+                <ownedStyle xmi:type="diagram:Square" uid="_TnRz4PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="145,210,211">
                   <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                  <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TnOJgvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                  <color xmi:type="viewpoint:RGBValues" xmi:id="_TnOwkPWhEeG4Wag4JBRK3A" red="163" green="219" blue="218"/>
                 </ownedStyle>
                 <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
               </ownedBorderedNodes>
-              <ownedStyle xmi:type="diagram:Square" xmi:id="_TnB8QPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TnB8QfWhEeG4Wag4JBRK3A"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_TnOJgPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="163,219,218">
                 <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TnB8QvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                <color xmi:type="viewpoint:RGBValues" xmi:id="_TnCjUPWhEeG4Wag4JBRK3A" red="181" green="228" blue="225"/>
               </ownedStyle>
               <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
             </ownedBorderedNodes>
-            <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TnDxcPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.7"/>
-              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.7"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.12"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.13"/>
-              <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAJgxl8EeCKOMpCHXRNLw" x="516" y="293" height="30" width="20"/>
-              <ownedStyle xmi:type="diagram:Square" xmi:id="_TnG0wPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TnG0wfWhEeG4Wag4JBRK3A"/>
-                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TnG0wvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                <color xmi:type="viewpoint:RGBValues" xmi:id="_TnG0xPWhEeG4Wag4JBRK3A" red="181" green="228" blue="225"/>
-              </ownedStyle>
-              <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-            </ownedBorderedNodes>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_Tm71oPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm71ofWhEeG4Wag4JBRK3A"/>
+            <ownedStyle xmi:type="diagram:Square" uid="_TnB8QPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="181,228,225">
               <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm71ovWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_Tm71pPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
             </ownedStyle>
             <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
           </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tm-R4PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.10"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.10"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.18"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.20"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TnDxcPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.7"/>
+            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.7"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.12"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.13"/>
             <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAJhBl8EeCKOMpCHXRNLw" x="501" y="490" height="59" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_Tm_gAPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm_gAfWhEeG4Wag4JBRK3A"/>
+            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAJgxl8EeCKOMpCHXRNLw" x="516" y="293" height="30" width="20"/>
+            <ownedStyle xmi:type="diagram:Square" uid="_TnG0wPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="181,228,225">
               <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm_gAvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TnAHEPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
             </ownedStyle>
             <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
           </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TnhEcPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TnhEcfWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TnhEcvWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TnhEc_WhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TnhEdPWhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_Tm4LQPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm4LQfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tm4LQvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_Tm4LQ_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_Tm71oPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TmOrAPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TmOrAfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TmOrAvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TmOrA_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tm-R4PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.10"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.1/@executions.10"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.18"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.1/@ends.20"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAJhBl8EeCKOMpCHXRNLw" x="501" y="490" height="59" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_Tm_gAPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TnhEcPWhEeG4Wag4JBRK3A" width="1" height="1">
+          <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.1/@participants.1"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TnhEcfWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_Tm4LQPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
-      <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_OHyPgd6tEd-_dMn5_cB9Xw"/>
-      <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
-      <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.1"/>
-    </ownedRepresentations>
-    <ownedRepresentations xmi:type="sequence:SequenceDDiagram" xmi:id="_Fni5MOUCEd-BEJhxHErs5g" name="Complex">
-      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_FnvGcOUCEd-BEJhxHErs5g" source="GMF_DIAGRAMS">
-        <data xmi:type="notation:Diagram" xmi:id="_FnvGceUCEd-BEJhxHErs5g" type="Sirius" element="_Fni5MOUCEd-BEJhxHErs5g" measurementUnit="Pixel">
-          <children xmi:type="notation:Node" xmi:id="_GwIR4OUCEd-BEJhxHErs5g" type="2001" element="_ToBawPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_GwKuIOUCEd-BEJhxHErs5g" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_GwKuIeUCEd-BEJhxHErs5g" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_GwPmoOUCEd-BEJhxHErs5g" type="3001" element="_ToHhYPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_GwQNsOUCEd-BEJhxHErs5g" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_GwQNseUCEd-BEJhxHErs5g" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_GwUfIOUCEd-BEJhxHErs5g" type="3003" element="_ToIIcPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_GwUfIeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwUfIuUCEd-BEJhxHErs5g"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_lWpIMOUCEd-BEJhxHErs5g" type="3001" element="_ToIvgPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_lWpvQOUCEd-BEJhxHErs5g" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_lWpvQeUCEd-BEJhxHErs5g" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_lWrkcOUCEd-BEJhxHErs5g" type="3003" element="_ToJWkPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_lWrkceUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWrkcuUCEd-BEJhxHErs5g"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_lWpIMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWpIMuUCEd-BEJhxHErs5g" x="2" y="500" width="20" height="50"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_bdRqME5cEeCHObKOrZ_h3Q" type="3001" element="_TobDYPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_bdTfYE5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_bdTfYU5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_bdYX4E5cEeCHObKOrZ_h3Q" type="3002" element="_TobqcPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_bdYX4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdYX4k5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_bdRqMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdRqMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_GwPmoeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwPmouUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_GwQ0wOUCEd-BEJhxHErs5g" type="3003" element="_ToCB0PWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_GwQ0weUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwQ0wuUCEd-BEJhxHErs5g"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_GwIR4eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwIR4uUCEd-BEJhxHErs5g" x="60" y="50" width="120" height="50"/>
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TmOrAPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_OHyPgd6tEd-_dMn5_cB9Xw"/>
+    <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
+    <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.1"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_Fni5MOUCEd-BEJhxHErs5g">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_FnvGcOUCEd-BEJhxHErs5g" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_FnvGceUCEd-BEJhxHErs5g" type="Sirius" element="_Fni5MOUCEd-BEJhxHErs5g" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_GwIR4OUCEd-BEJhxHErs5g" type="2001" element="_ToBawPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_GwKuIOUCEd-BEJhxHErs5g" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_GwKuIeUCEd-BEJhxHErs5g" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_H79y4OUCEd-BEJhxHErs5g" type="2001" element="_ToCo4PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_H7-Z8OUCEd-BEJhxHErs5g" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_H7-Z8eUCEd-BEJhxHErs5g" y="5"/>
+          <children xmi:type="notation:Node" xmi:id="_GwPmoOUCEd-BEJhxHErs5g" type="3001" element="_ToHhYPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_GwQNsOUCEd-BEJhxHErs5g" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_GwQNseUCEd-BEJhxHErs5g" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_H8BdQOUCEd-BEJhxHErs5g" type="3001" element="_TocRgPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_H8CEUOUCEd-BEJhxHErs5g" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_H8CEUeUCEd-BEJhxHErs5g" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_H8GVwOUCEd-BEJhxHErs5g" type="3003" element="_TocRgfWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_H8GVweUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8GVwuUCEd-BEJhxHErs5g"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_MF6q0OUCEd-BEJhxHErs5g" type="3001" element="_ToetwPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_MF7R4OUCEd-BEJhxHErs5g" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_MF7R4eUCEd-BEJhxHErs5g" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_MGBYgOUCEd-BEJhxHErs5g" type="3003" element="_TofU0PWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_MGBYgeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MGBYguUCEd-BEJhxHErs5g"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_MmVQQOUCEd-BEJhxHErs5g" type="3001" element="_Tof74PWhEeG4Wag4JBRK3A">
-                  <children xmi:type="notation:Node" xmi:id="_MmV3UOUCEd-BEJhxHErs5g" type="5001">
-                    <layoutConstraint xmi:type="notation:Location" xmi:id="_MmV3UeUCEd-BEJhxHErs5g" y="5"/>
-                  </children>
-                  <children xmi:type="notation:Node" xmi:id="_MmYTkOUCEd-BEJhxHErs5g" type="3003" element="_Togi8PWhEeG4Wag4JBRK3A">
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_MmYTkeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmYTkuUCEd-BEJhxHErs5g"/>
-                  </children>
-                  <children xmi:type="notation:Node" xmi:id="_NH0MsOUCEd-BEJhxHErs5g" type="3001" element="_TohKAPWhEeG4Wag4JBRK3A">
-                    <children xmi:type="notation:Node" xmi:id="_NH0zwOUCEd-BEJhxHErs5g" type="5001">
-                      <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0zweUCEd-BEJhxHErs5g" y="5"/>
-                    </children>
-                    <children xmi:type="notation:Node" xmi:id="_NH2o8OUCEd-BEJhxHErs5g" type="3003" element="_TohxEPWhEeG4Wag4JBRK3A">
-                      <styles xmi:type="notation:ShapeStyle" xmi:id="_NH2o8eUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH2o8uUCEd-BEJhxHErs5g"/>
-                    </children>
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_NH0MseUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH0MsuUCEd-BEJhxHErs5g" x="12" y="20" width="20" height="230"/>
-                  </children>
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_MmVQQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmVQQuUCEd-BEJhxHErs5g" x="12" y="20" width="20" height="270"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_MF6q0eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MF6q0uUCEd-BEJhxHErs5g" x="2" y="30" width="20" height="310"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_bdiI4E5cEeCHObKOrZ_h3Q" type="3001" element="_To3IQPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_bdiv8E5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_bdiv8U5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_bdklIE5cEeCHObKOrZ_h3Q" type="3002" element="_To3vUPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_bdklIU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdklIk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_bdiI4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdiI4k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_H8BdQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8BdQuUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
+            <children xmi:type="notation:Node" xmi:id="_GwUfIOUCEd-BEJhxHErs5g" type="3003" element="_ToIIcPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_GwUfIeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwUfIuUCEd-BEJhxHErs5g"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_H8CrYOUCEd-BEJhxHErs5g" type="3003" element="_ToDP8PWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_H8CrYeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8CrYuUCEd-BEJhxHErs5g"/>
+            <children xmi:type="notation:Node" xmi:id="_lWpIMOUCEd-BEJhxHErs5g" type="3001" element="_ToIvgPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_lWpvQOUCEd-BEJhxHErs5g" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_lWpvQeUCEd-BEJhxHErs5g" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_lWrkcOUCEd-BEJhxHErs5g" type="3003" element="_ToJWkPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_lWrkceUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWrkcuUCEd-BEJhxHErs5g"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lWpIMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWpIMuUCEd-BEJhxHErs5g" x="2" y="500" width="20" height="50"/>
             </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_H79y4eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H79y4uUCEd-BEJhxHErs5g" x="264" y="50" width="120" height="50"/>
+            <children xmi:type="notation:Node" xmi:id="_bdRqME5cEeCHObKOrZ_h3Q" type="3001" element="_TobDYPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_bdTfYE5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_bdTfYU5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_bdYX4E5cEeCHObKOrZ_h3Q" type="3002" element="_TobqcPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_bdYX4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdYX4k5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_bdRqMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdRqMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_GwPmoeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwPmouUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_IzQAMOUCEd-BEJhxHErs5g" type="2001" element="_ToD3APWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_IzQnQOUCEd-BEJhxHErs5g" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_IzQnQeUCEd-BEJhxHErs5g" y="5"/>
+          <children xmi:type="notation:Node" xmi:id="_GwQ0wOUCEd-BEJhxHErs5g" type="3003" element="_ToCB0PWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_GwQ0weUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwQ0wuUCEd-BEJhxHErs5g"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_GwIR4eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwIR4uUCEd-BEJhxHErs5g" x="60" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_H79y4OUCEd-BEJhxHErs5g" type="2001" element="_ToCo4PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_H7-Z8OUCEd-BEJhxHErs5g" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_H7-Z8eUCEd-BEJhxHErs5g" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_H8BdQOUCEd-BEJhxHErs5g" type="3001" element="_TocRgPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_H8CEUOUCEd-BEJhxHErs5g" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_H8CEUeUCEd-BEJhxHErs5g" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_IzTDgOUCEd-BEJhxHErs5g" type="3001" element="_To49cPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_IzTqkOUCEd-BEJhxHErs5g" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_IzTqkeUCEd-BEJhxHErs5g" y="5"/>
+            <children xmi:type="notation:Node" xmi:id="_H8GVwOUCEd-BEJhxHErs5g" type="3003" element="_TocRgfWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_H8GVweUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8GVwuUCEd-BEJhxHErs5g"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_MF6q0OUCEd-BEJhxHErs5g" type="3001" element="_ToetwPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_MF7R4OUCEd-BEJhxHErs5g" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_MF7R4eUCEd-BEJhxHErs5g" y="5"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_IzWt4OUCEd-BEJhxHErs5g" type="3003" element="_To5kgPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_IzXU8OUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzXU8eUCEd-BEJhxHErs5g"/>
+              <children xmi:type="notation:Node" xmi:id="_MGBYgOUCEd-BEJhxHErs5g" type="3003" element="_TofU0PWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_MGBYgeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MGBYguUCEd-BEJhxHErs5g"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_jHV_EOUCEd-BEJhxHErs5g" type="3001" element="_To6LkPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_jHV_E-UCEd-BEJhxHErs5g" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_jHV_FOUCEd-BEJhxHErs5g" y="5"/>
+              <children xmi:type="notation:Node" xmi:id="_MmVQQOUCEd-BEJhxHErs5g" type="3001" element="_Tof74PWhEeG4Wag4JBRK3A">
+                <children xmi:type="notation:Node" xmi:id="_MmV3UOUCEd-BEJhxHErs5g" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_MmV3UeUCEd-BEJhxHErs5g" y="5"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_jHYbUOUCEd-BEJhxHErs5g" type="3003" element="_To7ZsPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_jHYbUeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHYbUuUCEd-BEJhxHErs5g"/>
+                <children xmi:type="notation:Node" xmi:id="_MmYTkOUCEd-BEJhxHErs5g" type="3003" element="_Togi8PWhEeG4Wag4JBRK3A">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_MmYTkeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmYTkuUCEd-BEJhxHErs5g"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_kloiAOUCEd-BEJhxHErs5g" type="3001" element="_To-dAPWhEeG4Wag4JBRK3A">
-                  <children xmi:type="notation:Node" xmi:id="_klpJEOUCEd-BEJhxHErs5g" type="5001">
-                    <layoutConstraint xmi:type="notation:Location" xmi:id="_klpJEeUCEd-BEJhxHErs5g" y="5"/>
+                <children xmi:type="notation:Node" xmi:id="_NH0MsOUCEd-BEJhxHErs5g" type="3001" element="_TohKAPWhEeG4Wag4JBRK3A">
+                  <children xmi:type="notation:Node" xmi:id="_NH0zwOUCEd-BEJhxHErs5g" type="5001">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_NH0zweUCEd-BEJhxHErs5g" y="5"/>
                   </children>
-                  <children xmi:type="notation:Node" xmi:id="_klqXMOUCEd-BEJhxHErs5g" type="3003" element="_To_rIPWhEeG4Wag4JBRK3A">
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_klqXMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_klqXMuUCEd-BEJhxHErs5g"/>
+                  <children xmi:type="notation:Node" xmi:id="_NH2o8OUCEd-BEJhxHErs5g" type="3003" element="_TohxEPWhEeG4Wag4JBRK3A">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_NH2o8eUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH2o8uUCEd-BEJhxHErs5g"/>
                   </children>
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_kloiAeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kloiAuUCEd-BEJhxHErs5g" x="12" y="30" width="20" height="90"/>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_NH0MseUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH0MsuUCEd-BEJhxHErs5g" x="12" y="20" width="20" height="230"/>
                 </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_jHV_EeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHV_EuUCEd-BEJhxHErs5g" x="2" y="450" width="20" height="150"/>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_MmVQQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmVQQuUCEd-BEJhxHErs5g" x="12" y="20" width="20" height="270"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_bdqEsE5cEeCHObKOrZ_h3Q" type="3001" element="_TpG_4PWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_bdqrwE5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_bdqrwU5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_bdsg8E5cEeCHObKOrZ_h3Q" type="3002" element="_TpI1EPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_bdsg8U5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdsg8k5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_bdqEsU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdqEsk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_MF6q0eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MF6q0uUCEd-BEJhxHErs5g" x="2" y="30" width="20" height="310"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_bdiI4E5cEeCHObKOrZ_h3Q" type="3001" element="_To3IQPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_bdiv8E5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_bdiv8U5cEeCHObKOrZ_h3Q" y="5"/>
               </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_IzTDgeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzTDguUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
+              <children xmi:type="notation:Node" xmi:id="_bdklIE5cEeCHObKOrZ_h3Q" type="3002" element="_To3vUPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_bdklIU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdklIk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_bdiI4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdiI4k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_IzTqkuUCEd-BEJhxHErs5g" type="3003" element="_ToD3AfWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_IzTqk-UCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzTqlOUCEd-BEJhxHErs5g"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_IzQAMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzQAMuUCEd-BEJhxHErs5g" x="696" y="50" width="120" height="50"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_H8BdQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8BdQuUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_KCFK0OUCEd-BEJhxHErs5g" type="2001" element="_ToEeEPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_KCFx4OUCEd-BEJhxHErs5g" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_KCFx4eUCEd-BEJhxHErs5g" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_KCI1MOUCEd-BEJhxHErs5g" type="3001" element="_TpKDMPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_KCJcQOUCEd-BEJhxHErs5g" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_KCJcQeUCEd-BEJhxHErs5g" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_KCNGoOUCEd-BEJhxHErs5g" type="3003" element="_TpLRUPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_KCNGoeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCNGouUCEd-BEJhxHErs5g"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_OFk1cOUCEd-BEJhxHErs5g" type="3001" element="_TpNtkPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_OFlcgOUCEd-BEJhxHErs5g" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_OFlcgeUCEd-BEJhxHErs5g" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_OFnRsOUCEd-BEJhxHErs5g" type="3003" element="_TpOUoPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_OFnRseUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OFnRsuUCEd-BEJhxHErs5g"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_OFk1ceUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OFk1cuUCEd-BEJhxHErs5g" x="2" y="90" width="20" height="190"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_jy2aMOUCEd-BEJhxHErs5g" type="3001" element="_TpPiwPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_jy3BQOUCEd-BEJhxHErs5g" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_jy3BQeUCEd-BEJhxHErs5g" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_jy4PYOUCEd-BEJhxHErs5g" type="3003" element="_TpQw4PWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_jy4PYeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy4PYuUCEd-BEJhxHErs5g"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_jy2aMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy2aMuUCEd-BEJhxHErs5g" x="2" y="370" width="20" height="50"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_bdyAgE5cEeCHObKOrZ_h3Q" type="3001" element="_TpXekPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_bdyAg05cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_bdyAhE5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_bd0cwE5cEeCHObKOrZ_h3Q" type="3002" element="_TpYssPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_bd0cwU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bd0cwk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_bdyAgU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdyAgk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_KCI1MeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCI1MuUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_KCKDUOUCEd-BEJhxHErs5g" type="3003" element="_ToFFIPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_KCKDUeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCKDUuUCEd-BEJhxHErs5g"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_KCFK0eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCFK0uUCEd-BEJhxHErs5g" x="940" y="50" width="120" height="50"/>
+          <children xmi:type="notation:Node" xmi:id="_H8CrYOUCEd-BEJhxHErs5g" type="3003" element="_ToDP8PWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_H8CrYeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8CrYuUCEd-BEJhxHErs5g"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_OqECkOUCEd-BEJhxHErs5g" type="2001" element="_ToFsMPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_OqEpoOUCEd-BEJhxHErs5g" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_OqEpoeUCEd-BEJhxHErs5g" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OqHF4OUCEd-BEJhxHErs5g" type="3001" element="_Tpah4PWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_OqHs8OUCEd-BEJhxHErs5g" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_OqHs8eUCEd-BEJhxHErs5g" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_OqKwQOUCEd-BEJhxHErs5g" type="3003" element="_TpbI8PWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_OqKwQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqKwQuUCEd-BEJhxHErs5g"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_UMeiQOUCEd-BEJhxHErs5g" type="3001" element="_Tpjr0PWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_UMeiQ-UCEd-BEJhxHErs5g" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_UMeiROUCEd-BEJhxHErs5g" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_bIj-cE5cEeCHObKOrZ_h3Q" type="3005" element="_TpkS4PWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_bIj-cU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bIj-ck5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_UMeiQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UMeiQuUCEd-BEJhxHErs5g" x="2" y="100" width="50" height="50"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_gZHeQOUCEd-BEJhxHErs5g" type="3001" element="_TpcXEPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_gZIFUOUCEd-BEJhxHErs5g" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_gZIFUeUCEd-BEJhxHErs5g" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_gZJ6gOUCEd-BEJhxHErs5g" type="3003" element="_TpdlMPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_gZJ6geUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZJ6guUCEd-BEJhxHErs5g"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_gZHeQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZHeQuUCEd-BEJhxHErs5g" x="2" y="30" width="20" height="50"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_OqHF4eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqHF4uUCEd-BEJhxHErs5g" y="42" width="10" height="100"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OqHs8uUCEd-BEJhxHErs5g" type="3003" element="_ToGTQPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_OqHs8-UCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqHs9OUCEd-BEJhxHErs5g"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_OqECkeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqECkuUCEd-BEJhxHErs5g" x="1300" y="185" width="120" height="50"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_H79y4eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H79y4uUCEd-BEJhxHErs5g" x="264" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_IzQAMOUCEd-BEJhxHErs5g" type="2001" element="_ToD3APWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_IzQnQOUCEd-BEJhxHErs5g" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_IzQnQeUCEd-BEJhxHErs5g" y="5"/>
           </children>
-          <styles xmi:type="notation:DiagramStyle" xmi:id="_FnvGcuUCEd-BEJhxHErs5g"/>
-          <edges xmi:type="notation:Edge" xmi:id="_MGHfIOUCEd-BEJhxHErs5g" type="4001" element="_Tp0xkPWhEeG4Wag4JBRK3A" source="_GwPmoOUCEd-BEJhxHErs5g" target="_MF6q0OUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_MGItQOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MGItQeUCEd-BEJhxHErs5g" y="-10"/>
+          <children xmi:type="notation:Node" xmi:id="_IzTDgOUCEd-BEJhxHErs5g" type="3001" element="_To49cPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_IzTqkOUCEd-BEJhxHErs5g" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_IzTqkeUCEd-BEJhxHErs5g" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVGQwlGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVGQw1GCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_IzWt4OUCEd-BEJhxHErs5g" type="3003" element="_To5kgPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_IzXU8OUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzXU8eUCEd-BEJhxHErs5g"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVG30FGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVG30VGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_jHV_EOUCEd-BEJhxHErs5g" type="3001" element="_To6LkPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_jHV_E-UCEd-BEJhxHErs5g" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_jHV_FOUCEd-BEJhxHErs5g" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_jHYbUOUCEd-BEJhxHErs5g" type="3003" element="_To7ZsPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_jHYbUeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHYbUuUCEd-BEJhxHErs5g"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_kloiAOUCEd-BEJhxHErs5g" type="3001" element="_To-dAPWhEeG4Wag4JBRK3A">
+                <children xmi:type="notation:Node" xmi:id="_klpJEOUCEd-BEJhxHErs5g" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_klpJEeUCEd-BEJhxHErs5g" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_klqXMOUCEd-BEJhxHErs5g" type="3003" element="_To_rIPWhEeG4Wag4JBRK3A">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_klqXMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_klqXMuUCEd-BEJhxHErs5g"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_kloiAeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kloiAuUCEd-BEJhxHErs5g" x="12" y="30" width="20" height="90"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_jHV_EeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHV_EuUCEd-BEJhxHErs5g" x="2" y="450" width="20" height="150"/>
             </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_MGHfIeUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_MGHfIuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MGHfI-UCEd-BEJhxHErs5g" points="[0, 30, -248, 0]$[248, 30, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-QOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-QeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_MGKicOUCEd-BEJhxHErs5g" type="4001" element="_TqTSsPWhEeG4Wag4JBRK3A" source="_MF6q0OUCEd-BEJhxHErs5g" target="_GwPmoOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_MGLJgOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MGLJgeUCEd-BEJhxHErs5g" y="-10"/>
+            <children xmi:type="notation:Node" xmi:id="_bdqEsE5cEeCHObKOrZ_h3Q" type="3001" element="_TpG_4PWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_bdqrwE5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_bdqrwU5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_bdsg8E5cEeCHObKOrZ_h3Q" type="3002" element="_TpI1EPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_bdsg8U5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdsg8k5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_bdqEsU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdqEsk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVG30lGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVG301GCEeC1w6iasj3fZA" y="10"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_IzTDgeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzTDguUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_IzTqkuUCEd-BEJhxHErs5g" type="3003" element="_ToD3AfWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_IzTqk-UCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzTqlOUCEd-BEJhxHErs5g"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_IzQAMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzQAMuUCEd-BEJhxHErs5g" x="696" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_KCFK0OUCEd-BEJhxHErs5g" type="2001" element="_ToEeEPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_KCFx4OUCEd-BEJhxHErs5g" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_KCFx4eUCEd-BEJhxHErs5g" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_KCI1MOUCEd-BEJhxHErs5g" type="3001" element="_TpKDMPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_KCJcQOUCEd-BEJhxHErs5g" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_KCJcQeUCEd-BEJhxHErs5g" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVG31FGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVG31VGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_KCNGoOUCEd-BEJhxHErs5g" type="3003" element="_TpLRUPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_KCNGoeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCNGouUCEd-BEJhxHErs5g"/>
             </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_MGKiceUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_MGKicuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MGKic-UCEd-BEJhxHErs5g" points="[0, 310, 248, 340]$[-248, 310, 0, 340]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-QuUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-Q-UCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_Mmb98OUCEd-BEJhxHErs5g" type="4001" element="_Tp5DAPWhEeG4Wag4JBRK3A" source="_GwPmoOUCEd-BEJhxHErs5g" target="_MmVQQOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_Mmb99OUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mmb99eUCEd-BEJhxHErs5g" y="-10"/>
+            <children xmi:type="notation:Node" xmi:id="_OFk1cOUCEd-BEJhxHErs5g" type="3001" element="_TpNtkPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_OFlcgOUCEd-BEJhxHErs5g" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_OFlcgeUCEd-BEJhxHErs5g" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_OFnRsOUCEd-BEJhxHErs5g" type="3003" element="_TpOUoPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_OFnRseUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OFnRsuUCEd-BEJhxHErs5g"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_OFk1ceUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OFk1cuUCEd-BEJhxHErs5g" x="2" y="90" width="20" height="190"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVHe4FGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVHe4VGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_jy2aMOUCEd-BEJhxHErs5g" type="3001" element="_TpPiwPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_jy3BQOUCEd-BEJhxHErs5g" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_jy3BQeUCEd-BEJhxHErs5g" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_jy4PYOUCEd-BEJhxHErs5g" type="3003" element="_TpQw4PWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_jy4PYeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy4PYuUCEd-BEJhxHErs5g"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_jy2aMeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy2aMuUCEd-BEJhxHErs5g" x="2" y="370" width="20" height="50"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVHe4lGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVHe41GCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_bdyAgE5cEeCHObKOrZ_h3Q" type="3001" element="_TpXekPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_bdyAg05cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_bdyAhE5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_bd0cwE5cEeCHObKOrZ_h3Q" type="3002" element="_TpYssPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_bd0cwU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bd0cwk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_bdyAgU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdyAgk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_Mmb98eUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_Mmb98uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mmb98-UCEd-BEJhxHErs5g" points="[0, 50, -260, 0]$[260, 50, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsIOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsIeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_MmdzIOUCEd-BEJhxHErs5g" type="4001" element="_TqSEkPWhEeG4Wag4JBRK3A" source="_MmVQQOUCEd-BEJhxHErs5g" target="_GwPmoOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_MmeaMOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmeaMeUCEd-BEJhxHErs5g" y="-10"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_KCI1MeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCI1MuUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_KCKDUOUCEd-BEJhxHErs5g" type="3003" element="_ToFFIPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_KCKDUeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCKDUuUCEd-BEJhxHErs5g"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_KCFK0eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCFK0uUCEd-BEJhxHErs5g" x="940" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_OqECkOUCEd-BEJhxHErs5g" type="2001" element="_ToFsMPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_OqEpoOUCEd-BEJhxHErs5g" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_OqEpoeUCEd-BEJhxHErs5g" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OqHF4OUCEd-BEJhxHErs5g" type="3001" element="_Tpah4PWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_OqHs8OUCEd-BEJhxHErs5g" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_OqHs8eUCEd-BEJhxHErs5g" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVIF8FGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVIF8VGCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_OqKwQOUCEd-BEJhxHErs5g" type="3003" element="_TpbI8PWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_OqKwQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqKwQuUCEd-BEJhxHErs5g"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVIF8lGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVIF81GCEeC1w6iasj3fZA" y="10"/>
+            <children xmi:type="notation:Node" xmi:id="_UMeiQOUCEd-BEJhxHErs5g" type="3001" element="_Tpjr0PWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_UMeiQ-UCEd-BEJhxHErs5g" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_UMeiROUCEd-BEJhxHErs5g" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_bIj-cE5cEeCHObKOrZ_h3Q" type="3005" element="_TpkS4PWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_bIj-cU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bIj-ck5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_UMeiQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UMeiQuUCEd-BEJhxHErs5g" x="2" y="100" width="50" height="50"/>
             </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_MmdzIeUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_MmdzIuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MmdzI-UCEd-BEJhxHErs5g" points="[0, 270, 260, 320]$[-260, 270, 0, 320]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsIuUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsI-UCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_NH5sQOUCEd-BEJhxHErs5g" type="4001" element="_Tp7fQPWhEeG4Wag4JBRK3A" source="_IzTDgOUCEd-BEJhxHErs5g" target="_NH0MsOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_NH5sROUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH5sReUCEd-BEJhxHErs5g" y="-10"/>
+            <children xmi:type="notation:Node" xmi:id="_gZHeQOUCEd-BEJhxHErs5g" type="3001" element="_TpcXEPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_gZIFUOUCEd-BEJhxHErs5g" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_gZIFUeUCEd-BEJhxHErs5g" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_gZJ6gOUCEd-BEJhxHErs5g" type="3003" element="_TpdlMPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_gZJ6geUCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZJ6guUCEd-BEJhxHErs5g"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_gZHeQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZHeQuUCEd-BEJhxHErs5g" x="2" y="30" width="20" height="50"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVIF9FGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVItAFGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVItAVGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVItAlGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_NH5sQeUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_NH5sQuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NH5sQ-UCEd-BEJhxHErs5g" points="[0, 70, 276, 0]$[-276, 70, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SFoOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SFoeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_NH7hcOUCEd-BEJhxHErs5g" type="4001" element="_TqQPYPWhEeG4Wag4JBRK3A" source="_NH0MsOUCEd-BEJhxHErs5g" target="_IzTDgOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_NH8IgeUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH8IguUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVItA1GCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVItBFGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVJUEFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJUEVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_NH7hceUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_NH7hcuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NH8IgOUCEd-BEJhxHErs5g" points="[0, 230, -276, 300]$[276, 230, 0, 300]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SssOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SsseUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_OFpt8OUCEd-BEJhxHErs5g" type="4001" element="_Tp8tYPWhEeG4Wag4JBRK3A" source="_NH0MsOUCEd-BEJhxHErs5g" target="_OFk1cOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_OFqVAOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OFqVAeUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVJUElGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJUE1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVJ7IFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJ7IVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_OFpt8eUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_OFpt8uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OFpt8-UCEd-BEJhxHErs5g" points="[0, 20, -460, 0]$[460, 20, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fnYfUOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fnYfUeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_QGQ60OUCEd-BEJhxHErs5g" type="4001" element="_TqGeYPWhEeG4Wag4JBRK3A" source="_OFk1cOUCEd-BEJhxHErs5g" target="_OqECkOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_QGQ61OUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGQ61eUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVJ7IlGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJ7I1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVKiMFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVKiMVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_QGQ60eUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_QGQ60uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGQ60-UCEd-BEJhxHErs5g" points="[0, -48, -1652, 0]$[1652, -48, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGRh4OUCEd-BEJhxHErs5g" id="(0.5,0.36)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGRh4eUCEd-BEJhxHErs5g" id="(0.5,0.5) ice(1305,164)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_UMko4OUCEd-BEJhxHErs5g" type="4001" element="_TqJhsPWhEeG4Wag4JBRK3A" source="_OFk1cOUCEd-BEJhxHErs5g" target="_UMeiQOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_UMlP8uUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UMlP8-UCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVLwUFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVLwUVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVMXYFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVMXYVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_UMko4eUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_UMlP8OUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UMlP8eUCEd-BEJhxHErs5g" points="[10, -8, -337, 0]$[322, -8, -25, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl3AOUCEd-BEJhxHErs5g" id="(0.5,0.9375)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl3AeUCEd-BEJhxHErs5g" id="(0.5,0.5) ice(1247,286)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_gZMWwOUCEd-BEJhxHErs5g" type="4001" element="_Tp-ikPWhEeG4Wag4JBRK3A" source="_OFk1cOUCEd-BEJhxHErs5g" target="_gZHeQOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_gZM90OUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZM90eUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVM-cFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVM-cVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVNlgFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVNlgVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_gZMWweUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_gZMWwuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gZMWw-UCEd-BEJhxHErs5g" points="[0, -12, -309, 0]$[309, -12, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZM90uUCEd-BEJhxHErs5g" id="(0.5,0.45930232558139533)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZM90-UCEd-BEJhxHErs5g" id="(0.5,0.0) ice(1257,289)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_gZNk4OUCEd-BEJhxHErs5g" type="4001" element="_TqNzIPWhEeG4Wag4JBRK3A" source="_gZHeQOUCEd-BEJhxHErs5g" target="_OFk1cOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_gZOL8OUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZOL8eUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVNlglGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVNlg1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVNlhFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVNlhVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_gZNk4eUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_gZNk4uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gZNk4-UCEd-BEJhxHErs5g" points="[0, 0, 309, 30]$[-309, 0, 0, 30]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZOL8uUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(1257,339)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_jHaQgOUCEd-BEJhxHErs5g" type="4001" element="_TqA-0PWhEeG4Wag4JBRK3A" source="_H8BdQOUCEd-BEJhxHErs5g" target="_jHV_EOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_jHa3kOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHa3keUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVOMkFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOMkVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVOMklGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOMk1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_jHaQgeUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_jHaQguUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jHaQg-UCEd-BEJhxHErs5g" points="[0, -6, -224, 0]$[224, -6, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHa3kuUCEd-BEJhxHErs5g" id="(0.5,0.7016491754122939)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHa3k-UCEd-BEJhxHErs5g" id="(0.5,0.0) ice(644,568)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_jHbeoOUCEd-BEJhxHErs5g" type="4001" element="_Tqff8PWhEeG4Wag4JBRK3A" source="_jHV_EOUCEd-BEJhxHErs5g" target="_H8BdQOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_jHcFsOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHcFseUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVOzoFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOzoVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVOzolGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOzo1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_jHbeoeUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_jHbeouUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jHbeo-UCEd-BEJhxHErs5g" points="[0, 0, 224, 275]$[-224, 0, 0, 275]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHcFsuUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(644,618)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_jy6EkOUCEd-BEJhxHErs5g" type="4001" element="_TqAXwPWhEeG4Wag4JBRK3A" source="_KCI1MOUCEd-BEJhxHErs5g" target="_jy2aMOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_jy6roOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy6roeUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVPasFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVPasVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVPaslGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVPas1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_jy6EkeUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_jy6EkuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jy6Ek-UCEd-BEJhxHErs5g" points="[0, -56, 948, -60]$[-948, -46, 0, -50]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy6rouUCEd-BEJhxHErs5g" id="(0.5,0.6401799100449775)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy6ro-UCEd-BEJhxHErs5g" id="(0.5,1.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_jy7SsOUCEd-BEJhxHErs5g" type="4001" element="_TqVH4PWhEeG4Wag4JBRK3A" source="_jy2aMOUCEd-BEJhxHErs5g" target="_KCI1MOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_jy75wOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy75weUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVQBwFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQBwVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVQBwlGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQBw1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_jy7SseUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_jy7SsuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jy7Ss-UCEd-BEJhxHErs5g" points="[0, 0, -38, 420]$[38, 10, 0, 430]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy75wuUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(910,577)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy75w-UCEd-BEJhxHErs5g" id="(0.5,0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_klszcOUCEd-BEJhxHErs5g" type="4001" element="_TqC0APWhEeG4Wag4JBRK3A" source="_jHV_EOUCEd-BEJhxHErs5g" target="_kloiAOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_kltagOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kltageUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVQo0FGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQo0VGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVQo0lGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQo01GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_klszceUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_klszcuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_klszc-UCEd-BEJhxHErs5g" points="[0, -25, 682, -100]$[-682, -15, 0, -90]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kluBkOUCEd-BEJhxHErs5g" id="(0.5,0.3)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kluBkeUCEd-BEJhxHErs5g" id="(0.5,1.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_kluooOUCEd-BEJhxHErs5g" type="4001" element="_TqccoPWhEeG4Wag4JBRK3A" source="_kloiAOUCEd-BEJhxHErs5g" target="_jHV_EOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_kluopOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kluopeUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVQo1FGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQo1VGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVRP4FGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVRP4VGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_kluooeUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_kluoouUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kluoo-UCEd-BEJhxHErs5g" points="[0, 0, -26, 120]$[26, 10, 0, 130]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_klvPsOUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(656,644)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_klvPseUCEd-BEJhxHErs5g" id="(0.5,0.0)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_lWuAsOUCEd-BEJhxHErs5g" type="4001" element="_TqECIPWhEeG4Wag4JBRK3A" source="_kloiAOUCEd-BEJhxHErs5g" target="_lWpIMOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_lWuAtOUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWuAteUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVRP4lGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVRP41GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVRP5FGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVRP5VGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_lWuAseUCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_lWuAsuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lWuAs-UCEd-BEJhxHErs5g" points="[0, -16, 601, 0]$[-601, -16, 0, 0]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lWunwOUCEd-BEJhxHErs5g" id="(0.5,0.4)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lWunweUCEd-BEJhxHErs5g" id="(0.5,0.0) ice(96,647)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_lWunwuUCEd-BEJhxHErs5g" type="4001" element="_TqancPWhEeG4Wag4JBRK3A" source="_lWpIMOUCEd-BEJhxHErs5g" target="_kloiAOUCEd-BEJhxHErs5g">
-            <children xmi:type="notation:Node" xmi:id="_lWvO0OUCEd-BEJhxHErs5g" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWvO0eUCEd-BEJhxHErs5g" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVR28FGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVR28VGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVR28lGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVR281GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_lWunw-UCEd-BEJhxHErs5g"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_lWunxOUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lWunxeUCEd-BEJhxHErs5g" points="[0, 0, -601, 25]$[601, 0, 0, 25]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lWvO0uUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(96,697)"/>
-          </edges>
-        </data>
-      </ownedAnnotationEntries>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ToBawPWhEeG4Wag4JBRK3A" name="a : A" width="12" height="5" resizeKind="NSEW">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_OqHF4eUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqHF4uUCEd-BEJhxHErs5g" y="42" width="10" height="100"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OqHs8uUCEd-BEJhxHErs5g" type="3003" element="_ToGTQPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_OqHs8-UCEd-BEJhxHErs5g" fontName="DejaVu Sans"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqHs9OUCEd-BEJhxHErs5g"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_OqECkeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqECkuUCEd-BEJhxHErs5g" x="1300" y="185" width="120" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_FnvGcuUCEd-BEJhxHErs5g"/>
+        <edges xmi:type="notation:Edge" xmi:id="_lWunwuUCEd-BEJhxHErs5g" type="4001" element="_TqancPWhEeG4Wag4JBRK3A" source="_lWpIMOUCEd-BEJhxHErs5g" target="_kloiAOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_lWvO0OUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWvO0eUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVR28FGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVR28VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVR28lGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVR281GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lWunw-UCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lWunxOUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lWunxeUCEd-BEJhxHErs5g" points="[0, 0, -601, 25]$[601, 0, 0, 25]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lWvO0uUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(96,697)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_lWuAsOUCEd-BEJhxHErs5g" type="4001" element="_TqECIPWhEeG4Wag4JBRK3A" source="_kloiAOUCEd-BEJhxHErs5g" target="_lWpIMOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_lWuAtOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lWuAteUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVRP4lGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVRP41GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVRP5FGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVRP5VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lWuAseUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lWuAsuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lWuAs-UCEd-BEJhxHErs5g" points="[0, -16, 601, 0]$[-601, -16, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lWunwOUCEd-BEJhxHErs5g" id="(0.5,0.4)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lWunweUCEd-BEJhxHErs5g" id="(0.5,0.0) ice(96,647)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_MGHfIOUCEd-BEJhxHErs5g" type="4001" element="_Tp0xkPWhEeG4Wag4JBRK3A" source="_GwPmoOUCEd-BEJhxHErs5g" target="_MF6q0OUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_MGItQOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MGItQeUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVGQwlGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVGQw1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVG30FGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVG30VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_MGHfIeUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_MGHfIuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MGHfI-UCEd-BEJhxHErs5g" points="[0, 30, -248, 0]$[248, 30, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-QOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-QeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_Mmb98OUCEd-BEJhxHErs5g" type="4001" element="_Tp5DAPWhEeG4Wag4JBRK3A" source="_GwPmoOUCEd-BEJhxHErs5g" target="_MmVQQOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_Mmb99OUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mmb99eUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVHe4FGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVHe4VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVHe4lGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVHe41GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_Mmb98eUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_Mmb98uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mmb98-UCEd-BEJhxHErs5g" points="[0, 50, -260, 0]$[260, 50, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsIOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsIeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_MGKicOUCEd-BEJhxHErs5g" type="4001" element="_TqTSsPWhEeG4Wag4JBRK3A" source="_MF6q0OUCEd-BEJhxHErs5g" target="_GwPmoOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_MGLJgOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MGLJgeUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVG30lGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVG301GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVG31FGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVG31VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_MGKiceUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_MGKicuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MGKic-UCEd-BEJhxHErs5g" points="[0, 310, 248, 340]$[-248, 310, 0, 340]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-QuUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XKS-Q-UCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_MmdzIOUCEd-BEJhxHErs5g" type="4001" element="_TqSEkPWhEeG4Wag4JBRK3A" source="_MmVQQOUCEd-BEJhxHErs5g" target="_GwPmoOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_MmeaMOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MmeaMeUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVIF8FGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVIF8VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVIF8lGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVIF81GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_MmdzIeUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_MmdzIuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MmdzI-UCEd-BEJhxHErs5g" points="[0, 270, 260, 320]$[-260, 270, 0, 320]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsIuUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XdMsI-UCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_NH7hcOUCEd-BEJhxHErs5g" type="4001" element="_TqQPYPWhEeG4Wag4JBRK3A" source="_NH0MsOUCEd-BEJhxHErs5g" target="_IzTDgOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_NH8IgeUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH8IguUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVItA1GCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVItBFGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVJUEFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJUEVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_NH7hceUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_NH7hcuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NH8IgOUCEd-BEJhxHErs5g" points="[0, 230, -276, 300]$[276, 230, 0, 300]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SssOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SsseUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_OFpt8OUCEd-BEJhxHErs5g" type="4001" element="_Tp8tYPWhEeG4Wag4JBRK3A" source="_NH0MsOUCEd-BEJhxHErs5g" target="_OFk1cOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_OFqVAOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OFqVAeUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVJUElGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJUE1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVJ7IFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJ7IVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_OFpt8eUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_OFpt8uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OFpt8-UCEd-BEJhxHErs5g" points="[0, 20, -460, 0]$[460, 20, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fnYfUOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fnYfUeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_NH5sQOUCEd-BEJhxHErs5g" type="4001" element="_Tp7fQPWhEeG4Wag4JBRK3A" source="_IzTDgOUCEd-BEJhxHErs5g" target="_NH0MsOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_NH5sROUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NH5sReUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVIF9FGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVItAFGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVItAVGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVItAlGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_NH5sQeUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_NH5sQuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NH5sQ-UCEd-BEJhxHErs5g" points="[0, 70, 276, 0]$[-276, 70, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SFoOUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X4SFoeUCEd-BEJhxHErs5g" id="(0.5, 0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_jHaQgOUCEd-BEJhxHErs5g" type="4001" element="_TqA-0PWhEeG4Wag4JBRK3A" source="_H8BdQOUCEd-BEJhxHErs5g" target="_jHV_EOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_jHa3kOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHa3keUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVOMkFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOMkVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVOMklGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOMk1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_jHaQgeUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_jHaQguUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jHaQg-UCEd-BEJhxHErs5g" points="[0, -6, -224, 0]$[224, -6, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHa3kuUCEd-BEJhxHErs5g" id="(0.5,0.7016491754122939)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHa3k-UCEd-BEJhxHErs5g" id="(0.5,0.0) ice(644,568)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_jHbeoOUCEd-BEJhxHErs5g" type="4001" element="_Tqff8PWhEeG4Wag4JBRK3A" source="_jHV_EOUCEd-BEJhxHErs5g" target="_H8BdQOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_jHcFsOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jHcFseUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVOzoFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOzoVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVOzolGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVOzo1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_jHbeoeUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_jHbeouUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jHbeo-UCEd-BEJhxHErs5g" points="[0, 0, 224, 275]$[-224, 0, 0, 275]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHcFsuUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(644,618)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_kluooOUCEd-BEJhxHErs5g" type="4001" element="_TqccoPWhEeG4Wag4JBRK3A" source="_kloiAOUCEd-BEJhxHErs5g" target="_jHV_EOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_kluopOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kluopeUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVQo1FGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQo1VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVRP4FGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVRP4VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_kluooeUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_kluoouUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kluoo-UCEd-BEJhxHErs5g" points="[0, 0, -26, 120]$[26, 10, 0, 130]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_klvPsOUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(656,644)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_klvPseUCEd-BEJhxHErs5g" id="(0.5,0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_klszcOUCEd-BEJhxHErs5g" type="4001" element="_TqC0APWhEeG4Wag4JBRK3A" source="_jHV_EOUCEd-BEJhxHErs5g" target="_kloiAOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_kltagOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kltageUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVQo0FGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQo0VGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVQo0lGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQo01GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_klszceUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_klszcuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_klszc-UCEd-BEJhxHErs5g" points="[0, -25, 682, -100]$[-682, -15, 0, -90]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kluBkOUCEd-BEJhxHErs5g" id="(0.5,0.3)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kluBkeUCEd-BEJhxHErs5g" id="(0.5,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_QGQ60OUCEd-BEJhxHErs5g" type="4001" element="_TqGeYPWhEeG4Wag4JBRK3A" source="_OFk1cOUCEd-BEJhxHErs5g" target="_OqECkOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_QGQ61OUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QGQ61eUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVJ7IlGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVJ7I1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVKiMFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVKiMVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_QGQ60eUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_QGQ60uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QGQ60-UCEd-BEJhxHErs5g" points="[0, -48, -1652, 0]$[1652, -48, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGRh4OUCEd-BEJhxHErs5g" id="(0.5,0.36)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QGRh4eUCEd-BEJhxHErs5g" id="(0.5,0.5) ice(1305,164)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_UMko4OUCEd-BEJhxHErs5g" type="4001" element="_TqJhsPWhEeG4Wag4JBRK3A" source="_OFk1cOUCEd-BEJhxHErs5g" target="_UMeiQOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_UMlP8uUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UMlP8-UCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVLwUFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVLwUVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVMXYFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVMXYVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_UMko4eUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_UMlP8OUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UMlP8eUCEd-BEJhxHErs5g" points="[10, -8, -337, 0]$[322, -8, -25, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl3AOUCEd-BEJhxHErs5g" id="(0.5,0.9375)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UMl3AeUCEd-BEJhxHErs5g" id="(0.5,0.5) ice(1247,286)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_gZMWwOUCEd-BEJhxHErs5g" type="4001" element="_Tp-ikPWhEeG4Wag4JBRK3A" source="_OFk1cOUCEd-BEJhxHErs5g" target="_gZHeQOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_gZM90OUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZM90eUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVM-cFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVM-cVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVNlgFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVNlgVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_gZMWweUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_gZMWwuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gZMWw-UCEd-BEJhxHErs5g" points="[0, -12, -309, 0]$[309, -12, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZM90uUCEd-BEJhxHErs5g" id="(0.5,0.45930232558139533)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZM90-UCEd-BEJhxHErs5g" id="(0.5,0.0) ice(1257,289)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_gZNk4OUCEd-BEJhxHErs5g" type="4001" element="_TqNzIPWhEeG4Wag4JBRK3A" source="_gZHeQOUCEd-BEJhxHErs5g" target="_OFk1cOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_gZOL8OUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZOL8eUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVNlglGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVNlg1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVNlhFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVNlhVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_gZNk4eUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_gZNk4uUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gZNk4-UCEd-BEJhxHErs5g" points="[0, 0, 309, 30]$[-309, 0, 0, 30]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gZOL8uUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(1257,339)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_jy7SsOUCEd-BEJhxHErs5g" type="4001" element="_TqVH4PWhEeG4Wag4JBRK3A" source="_jy2aMOUCEd-BEJhxHErs5g" target="_KCI1MOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_jy75wOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy75weUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVQBwFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQBwVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVQBwlGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVQBw1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_jy7SseUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_jy7SsuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jy7Ss-UCEd-BEJhxHErs5g" points="[0, 0, -38, 420]$[38, 10, 0, 430]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy75wuUCEd-BEJhxHErs5g" id="(0.5,1.0) ice(910,577)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy75w-UCEd-BEJhxHErs5g" id="(0.5,0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_jy6EkOUCEd-BEJhxHErs5g" type="4001" element="_TqAXwPWhEeG4Wag4JBRK3A" source="_KCI1MOUCEd-BEJhxHErs5g" target="_jy2aMOUCEd-BEJhxHErs5g">
+          <children xmi:type="notation:Node" xmi:id="_jy6roOUCEd-BEJhxHErs5g" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jy6roeUCEd-BEJhxHErs5g" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVPasFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVPasVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVPaslGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVPas1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_jy6EkeUCEd-BEJhxHErs5g"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_jy6EkuUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jy6Ek-UCEd-BEJhxHErs5g" points="[0, -56, 948, -60]$[-948, -46, 0, -50]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy6rouUCEd-BEJhxHErs5g" id="(0.5,0.6401799100449775)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jy6ro-UCEd-BEJhxHErs5g" id="(0.5,1.0)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_9iqEcrm3Ee-UXMFld_STMg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_9iqEc7m3Ee-UXMFld_STMg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ToBawPWhEeG4Wag4JBRK3A" name="a : A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URE-0PWhEeG4Wag4JBRK3A" x="60" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ToHhYPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp0xkPWhEeG4Wag4JBRK3A _Tp5DAPWhEeG4Wag4JBRK3A" incomingEdges="_TqSEkPWhEeG4Wag4JBRK3A _TqTSsPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URE-0PWhEeG4Wag4JBRK3A" x="60" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_ToHhYPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp0xkPWhEeG4Wag4JBRK3A _Tp5DAPWhEeG4Wag4JBRK3A" incomingEdges="_TqSEkPWhEeG4Wag4JBRK3A _TqTSsPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ToIvgPWhEeG4Wag4JBRK3A" outgoingEdges="_TqancPWhEeG4Wag4JBRK3A" incomingEdges="_TqECIPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.32"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.33"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAwkBl8EeCKOMpCHXRNLw" x="110" y="600" height="50" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ToJWkPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TobDYPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_ToIvgPWhEeG4Wag4JBRK3A" outgoingEdges="_TqancPWhEeG4Wag4JBRK3A" incomingEdges="_TqECIPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.32"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.33"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAwkBl8EeCKOMpCHXRNLw" x="110" y="600" height="50" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_ToJWkPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ToJWkfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ToJWkvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_ToJWlPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TobDYPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TobqcPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TobqcfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TobqcvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tobqc_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_ToIIcPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ToIIcfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ToIIcvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_ToIIc_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TobqcPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_ToCB0PWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ToCB0fWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ToCB0vWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_ToCB0_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_ToIIcPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ToCo4PWhEeG4Wag4JBRK3A" name="b : B" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ToCB0PWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ToCo4PWhEeG4Wag4JBRK3A" name="b : B" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URE-0fWhEeG4Wag4JBRK3A" x="264" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TocRgPWhEeG4Wag4JBRK3A" outgoingEdges="_TqA-0PWhEeG4Wag4JBRK3A" incomingEdges="_Tqff8PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URE-0fWhEeG4Wag4JBRK3A" x="264" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TocRgPWhEeG4Wag4JBRK3A" outgoingEdges="_TqA-0PWhEeG4Wag4JBRK3A" incomingEdges="_Tqff8PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ToetwPWhEeG4Wag4JBRK3A" outgoingEdges="_TqTSsPWhEeG4Wag4JBRK3A" incomingEdges="_Tp0xkPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.1"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.21"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAwkRl8EeCKOMpCHXRNLw" x="314" y="130" height="310" width="20"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tof74PWhEeG4Wag4JBRK3A" outgoingEdges="_TqSEkPWhEeG4Wag4JBRK3A" incomingEdges="_Tp5DAPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
+            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
+            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.3"/>
+            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.19"/>
+            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
+            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAwkhl8EeCKOMpCHXRNLw" x="329" y="150" height="270" width="20"/>
+            <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TohKAPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp8tYPWhEeG4Wag4JBRK3A _TqQPYPWhEeG4Wag4JBRK3A" incomingEdges="_Tp7fQPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
+              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
+              <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.5"/>
+              <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.17"/>
+              <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
+              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQAwkxl8EeCKOMpCHXRNLw" x="344" y="170" height="230" width="20"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_TohxEPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="163,219,218">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+            </ownedBorderedNodes>
+            <ownedStyle xmi:type="diagram:Square" uid="_Togi8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="181,228,225">
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+          </ownedBorderedNodes>
+          <ownedStyle xmi:type="diagram:Square" uid="_TofU0PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_To3IQPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_ToetwPWhEeG4Wag4JBRK3A" outgoingEdges="_TqTSsPWhEeG4Wag4JBRK3A" incomingEdges="_Tp0xkPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.1"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.21"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAwkRl8EeCKOMpCHXRNLw" x="314" y="130" height="310" width="20"/>
-            <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tof74PWhEeG4Wag4JBRK3A" outgoingEdges="_TqSEkPWhEeG4Wag4JBRK3A" incomingEdges="_Tp5DAPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
-              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
-              <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.3"/>
-              <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.19"/>
-              <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAwkhl8EeCKOMpCHXRNLw" x="329" y="150" height="270" width="20"/>
-              <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TohKAPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp8tYPWhEeG4Wag4JBRK3A _TqQPYPWhEeG4Wag4JBRK3A" incomingEdges="_Tp7fQPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-                <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
-                <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
-                <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.5"/>
-                <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.17"/>
-                <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-                <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQAwkxl8EeCKOMpCHXRNLw" x="344" y="170" height="230" width="20"/>
-                <ownedStyle xmi:type="diagram:Square" xmi:id="_TohxEPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                  <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TohxEfWhEeG4Wag4JBRK3A"/>
-                  <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                  <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TohxEvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                  <color xmi:type="viewpoint:RGBValues" xmi:id="_TohxFPWhEeG4Wag4JBRK3A" red="163" green="219" blue="218"/>
-                </ownedStyle>
-                <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-              </ownedBorderedNodes>
-              <ownedStyle xmi:type="diagram:Square" xmi:id="_Togi8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Togi8fWhEeG4Wag4JBRK3A"/>
-                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Togi8vWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                <color xmi:type="viewpoint:RGBValues" xmi:id="_Togi9PWhEeG4Wag4JBRK3A" red="181" green="228" blue="225"/>
-              </ownedStyle>
-              <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-            </ownedBorderedNodes>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TofU0PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TofU0fWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TofU0vWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TofU1PWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_To3IQPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_To3vUPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_To3vUfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_To3vUvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_To3vU_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TocRgfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Toc4kPWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Toc4kfWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_Toc4kvWhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_To3vUPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_ToDP8PWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ToDP8fWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ToDP8vWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_ToDP8_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TocRgfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ToD3APWhEeG4Wag4JBRK3A" name="c : C" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ToDP8PWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ToD3APWhEeG4Wag4JBRK3A" name="c : C" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URE-0vWhEeG4Wag4JBRK3A" x="696" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_To49cPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp7fQPWhEeG4Wag4JBRK3A" incomingEdges="_TqQPYPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URE-0vWhEeG4Wag4JBRK3A" x="696" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_To49cPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp7fQPWhEeG4Wag4JBRK3A" incomingEdges="_TqQPYPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_To6LkPWhEeG4Wag4JBRK3A" outgoingEdges="_TqC0APWhEeG4Wag4JBRK3A _Tqff8PWhEeG4Wag4JBRK3A" incomingEdges="_TqA-0PWhEeG4Wag4JBRK3A _TqccoPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.28"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.37"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQBXoBl8EeCKOMpCHXRNLw" x="746" y="550" height="150" width="20"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_To-dAPWhEeG4Wag4JBRK3A" outgoingEdges="_TqECIPWhEeG4Wag4JBRK3A _TqccoPWhEeG4Wag4JBRK3A" incomingEdges="_TqC0APWhEeG4Wag4JBRK3A _TqancPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
+            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
+            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.30"/>
+            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.35"/>
+            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
+            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQBXoRl8EeCKOMpCHXRNLw" x="761" y="580" height="90" width="20"/>
+            <ownedStyle xmi:type="diagram:Square" uid="_To_rIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="181,228,225">
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+          </ownedBorderedNodes>
+          <ownedStyle xmi:type="diagram:Square" uid="_To7ZsPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TpG_4PWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_To6LkPWhEeG4Wag4JBRK3A" outgoingEdges="_TqC0APWhEeG4Wag4JBRK3A _Tqff8PWhEeG4Wag4JBRK3A" incomingEdges="_TqA-0PWhEeG4Wag4JBRK3A _TqccoPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.28"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.37"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQBXoBl8EeCKOMpCHXRNLw" x="746" y="550" height="150" width="20"/>
-            <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_To-dAPWhEeG4Wag4JBRK3A" outgoingEdges="_TqECIPWhEeG4Wag4JBRK3A _TqccoPWhEeG4Wag4JBRK3A" incomingEdges="_TqC0APWhEeG4Wag4JBRK3A _TqancPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
-              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
-              <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.30"/>
-              <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.35"/>
-              <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQBXoRl8EeCKOMpCHXRNLw" x="761" y="580" height="90" width="20"/>
-              <ownedStyle xmi:type="diagram:Square" xmi:id="_To_rIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_To_rIfWhEeG4Wag4JBRK3A"/>
-                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_To_rIvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                <color xmi:type="viewpoint:RGBValues" xmi:id="_TpA5QPWhEeG4Wag4JBRK3A" red="181" green="228" blue="225"/>
-              </ownedStyle>
-              <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-            </ownedBorderedNodes>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_To7ZsPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_To7ZsfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_To7ZsvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_To9O4PWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TpG_4PWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TpI1EPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpI1EfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpI1EvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TpI1E_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_To5kgPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_To5kgfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_To5kgvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_To5kg_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TpI1EPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_ToD3AfWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ToD3AvWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ToD3A_WhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_ToD3BPWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_To5kgPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ToEeEPWhEeG4Wag4JBRK3A" name="d : C" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ToD3AfWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ToEeEPWhEeG4Wag4JBRK3A" name="d : C" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URFl4PWhEeG4Wag4JBRK3A" x="940" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TpKDMPWhEeG4Wag4JBRK3A" outgoingEdges="_TqAXwPWhEeG4Wag4JBRK3A" incomingEdges="_TqVH4PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URFl4PWhEeG4Wag4JBRK3A" x="940" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TpKDMPWhEeG4Wag4JBRK3A" outgoingEdges="_TqAXwPWhEeG4Wag4JBRK3A" incomingEdges="_TqVH4PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TpNtkPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp-ikPWhEeG4Wag4JBRK3A _TqGeYPWhEeG4Wag4JBRK3A _TqJhsPWhEeG4Wag4JBRK3A" incomingEdges="_Tp8tYPWhEeG4Wag4JBRK3A _TqNzIPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.7"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.16"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQBXohl8EeCKOMpCHXRNLw" x="990" y="190" height="190" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TpOUoPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TpPiwPWhEeG4Wag4JBRK3A" outgoingEdges="_TqVH4PWhEeG4Wag4JBRK3A" incomingEdges="_TqAXwPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.24"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.25"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQBXoxl8EeCKOMpCHXRNLw" x="990" y="470" height="50" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TpQw4PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TpXekPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TpNtkPWhEeG4Wag4JBRK3A" outgoingEdges="_Tp-ikPWhEeG4Wag4JBRK3A _TqGeYPWhEeG4Wag4JBRK3A _TqJhsPWhEeG4Wag4JBRK3A" incomingEdges="_Tp8tYPWhEeG4Wag4JBRK3A _TqNzIPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.7"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.16"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQBXohl8EeCKOMpCHXRNLw" x="990" y="190" height="190" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TpOUoPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpOUofWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpOUovWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TpO7sPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TpPiwPWhEeG4Wag4JBRK3A" outgoingEdges="_TqVH4PWhEeG4Wag4JBRK3A" incomingEdges="_TqAXwPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.24"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.25"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQBXoxl8EeCKOMpCHXRNLw" x="990" y="470" height="50" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TpQw4PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpQw4fWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpQw4vWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TpRX8PWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TpXekPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TpYssPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpYssfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpYssvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TpYss_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TpLRUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpLRUfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpLRUvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TpLRU_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TpYssPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_ToFFIPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ToFFIfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ToFFIvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_ToFFI_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TpLRUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ToFsMPWhEeG4Wag4JBRK3A" name="e : A" incomingEdges="_TqGeYPWhEeG4Wag4JBRK3A" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ToFFIPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ToFsMPWhEeG4Wag4JBRK3A" name="e : A" incomingEdges="_TqGeYPWhEeG4Wag4JBRK3A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URFl4fWhEeG4Wag4JBRK3A" x="1300" y="185" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tpah4PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URFl4fWhEeG4Wag4JBRK3A" x="1300" y="185" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tpah4PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TpcXEPWhEeG4Wag4JBRK3A" outgoingEdges="_TqNzIPWhEeG4Wag4JBRK3A" incomingEdges="_Tp-ikPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.11"/>
+          <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.12"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQBXpBl8EeCKOMpCHXRNLw" x="1350" y="265" height="50" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TpdlMPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tpjr0PWhEeG4Wag4JBRK3A" incomingEdges="_TqJhsPWhEeG4Wag4JBRK3A" width="5" height="5">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TpcXEPWhEeG4Wag4JBRK3A" outgoingEdges="_TqNzIPWhEeG4Wag4JBRK3A" incomingEdges="_Tp-ikPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.11"/>
-            <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.12"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQBXpBl8EeCKOMpCHXRNLw" x="1350" y="265" height="50" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TpdlMPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpdlMfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpdlMvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TpeMQPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tpjr0PWhEeG4Wag4JBRK3A" incomingEdges="_TqJhsPWhEeG4Wag4JBRK3A" width="5" height="5">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
-            <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_TpkS4PWhEeG4Wag4JBRK3A" showIcon="false" workspacePath="/org.eclipse.sirius.sample.interactions.design/description/eol.png">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpkS4fWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpkS4vWhEeG4Wag4JBRK3A"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TpbI8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TpbI8fWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TpbI8vWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TpbI8_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_TpkS4PWhEeG4Wag4JBRK3A" showIcon="false" workspacePath="/org.eclipse.sirius.sample.interactions.design/description/eol.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='EOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_ToGTQPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ToGTQfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ToGTQvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_ToGTQ_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TpbI8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_Tp0xkPWhEeG4Wag4JBRK3A" name="m1" sourceNode="_ToHhYPWhEeG4Wag4JBRK3A" targetNode="_ToetwPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.0"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.0"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.0"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.1"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQB-sBl8EeCKOMpCHXRNLw" x="0" y="130" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_MFoW8OUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_MFoW8uUCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSH0_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSIE_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_Tp5DAPWhEeG4Wag4JBRK3A" name="m3" sourceNode="_ToHhYPWhEeG4Wag4JBRK3A" targetNode="_Tof74PWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.1"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.1"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.2"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.3"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQB-shl8EeCKOMpCHXRNLw" x="0" y="150" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_MmBHMeUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_MmBHM-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrIk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrI0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_Tp7fQPWhEeG4Wag4JBRK3A" name="m5" sourceNode="_To49cPWhEeG4Wag4JBRK3A" targetNode="_TohKAPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.2"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.2"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.4"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.5"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQB-tBl8EeCKOMpCHXRNLw" x="0" y="170" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_NHgqseUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_NHgqs-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrJE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSEE_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_Tp8tYPWhEeG4Wag4JBRK3A" name="m7" sourceNode="_TohKAPWhEeG4Wag4JBRK3A" targetNode="_TpNtkPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.3"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.3"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.6"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.7"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQClwRl8EeCKOMpCHXRNLw" x="0" y="190" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_OFUWweUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_OFUWw-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrDk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrD0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_Tp-ikPWhEeG4Wag4JBRK3A" name="m10" sourceNode="_TpNtkPWhEeG4Wag4JBRK3A" targetNode="_TpcXEPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.5"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.5"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.10"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.11"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDM0Bl8EeCKOMpCHXRNLw" x="0" y="265" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_gYwR4eUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_gYwR4-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrDE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrDU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqAXwPWhEeG4Wag4JBRK3A" name="m14" sourceNode="_TpKDMPWhEeG4Wag4JBRK3A" targetNode="_TpPiwPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.11"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.11"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.23"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.24"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDz4Bl8EeCKOMpCHXRNLw" x="0" y="460" height="10" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_jycKgeUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_jycKg-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrCk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrC0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqA-0PWhEeG4Wag4JBRK3A" name="m12" sourceNode="_TocRgPWhEeG4Wag4JBRK3A" targetNode="_To6LkPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.13"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.13"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.27"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.28"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDM0hl8EeCKOMpCHXRNLw" x="0" y="550" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_jHAn4eUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_jHAn4-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrEE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrEU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqC0APWhEeG4Wag4JBRK3A" name="m16" sourceNode="_To6LkPWhEeG4Wag4JBRK3A" targetNode="_To-dAPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.14"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.14"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.29"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.30"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDz4hl8EeCKOMpCHXRNLw" x="0" y="570" height="10" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_klW1MeUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_klW1M-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrEk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrE0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqECIPWhEeG4Wag4JBRK3A" name="m18" sourceNode="_To-dAPWhEeG4Wag4JBRK3A" targetNode="_ToIvgPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.15"/>
-        <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.15"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.31"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.32"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQEa8Bl8EeCKOMpCHXRNLw" x="0" y="600" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_lWW0UeUCEd-BEJhxHErs5g" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_lWW0U-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrAk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrA0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqGeYPWhEeG4Wag4JBRK3A" name="m_create8" sourceNode="_TpNtkPWhEeG4Wag4JBRK3A" targetNode="_ToFsMPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.4"/>
-        <semanticElements xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.4"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.8"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.9"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQClwhl8EeCKOMpCHXRNLw" x="0" y="210" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_QFmMceUCEd-BEJhxHErs5g" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_QFmMc-UCEd-BEJhxHErs5g" red="138" green="226" blue="52"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrIE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrIU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:CreationMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqJhsPWhEeG4Wag4JBRK3A" name="m_destroy9" sourceNode="_TpNtkPWhEeG4Wag4JBRK3A" targetNode="_Tpjr0PWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.7"/>
-        <semanticElements xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.7"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.14"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.15"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQClwxl8EeCKOMpCHXRNLw" x="0" y="360" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_UK2xoeUCEd-BEJhxHErs5g" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_UK3YsOUCEd-BEJhxHErs5g" red="246" green="139" blue="139"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSE0_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSFE_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:DestructionMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqNzIPWhEeG4Wag4JBRK3A" sourceNode="_TpcXEPWhEeG4Wag4JBRK3A" targetNode="_TpNtkPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.6"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.6"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.12"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.13"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDM0Rl8EeCKOMpCHXRNLw" x="0" y="315" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_gY40weUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_gY40w-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrGk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrG0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqQPYPWhEeG4Wag4JBRK3A" sourceNode="_TohKAPWhEeG4Wag4JBRK3A" targetNode="_To49cPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.8"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.8"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.17"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.18"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQClwBl8EeCKOMpCHXRNLw" x="0" y="400" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_NHjuAeUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_NHjuA-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSGU_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSGk_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqSEkPWhEeG4Wag4JBRK3A" sourceNode="_Tof74PWhEeG4Wag4JBRK3A" targetNode="_ToHhYPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.9"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.9"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.19"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.20"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQB-sxl8EeCKOMpCHXRNLw" x="0" y="420" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_MmEKgeUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_MmEKg-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrCE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrCU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqTSsPWhEeG4Wag4JBRK3A" sourceNode="_ToetwPWhEeG4Wag4JBRK3A" targetNode="_ToHhYPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.10"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.10"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.21"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.22"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQB-sRl8EeCKOMpCHXRNLw" x="0" y="440" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_MFqMIeUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_MFqMI-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrFE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrFU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqVH4PWhEeG4Wag4JBRK3A" sourceNode="_TpPiwPWhEeG4Wag4JBRK3A" targetNode="_TpKDMPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.12"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.12"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.25"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.26"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDz4Rl8EeCKOMpCHXRNLw" x="0" y="520" height="10" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_jyfN0eUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_jyfN0-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSG0_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSHE_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqancPWhEeG4Wag4JBRK3A" sourceNode="_ToIvgPWhEeG4Wag4JBRK3A" targetNode="_To-dAPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.16"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.16"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.33"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.34"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQEa8Rl8EeCKOMpCHXRNLw" x="0" y="650" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_lWZ3oeUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_lWZ3o-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrHk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrH0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TqccoPWhEeG4Wag4JBRK3A" sourceNode="_To-dAPWhEeG4Wag4JBRK3A" targetNode="_To6LkPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.17"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.17"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.35"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.36"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDz4xl8EeCKOMpCHXRNLw" x="0" y="670" height="10" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_klZ4geUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_klZ4g-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrFk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrF0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_Tqff8PWhEeG4Wag4JBRK3A" sourceNode="_To6LkPWhEeG4Wag4JBRK3A" targetNode="_TocRgPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.18"/>
-        <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.18"/>
-        <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.37"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.38"/>
-        <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQDM0xl8EeCKOMpCHXRNLw" x="0" y="700" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_jHDrMeUCEd-BEJhxHErs5g" lineStyle="dot" size="0">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_jHDrM-UCEd-BEJhxHErs5g" red="114" green="159" blue="207"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrAE_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrAU_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
-      </ownedDiagramElements>
-      <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
-      <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_Fni5MeUCEd-BEJhxHErs5g"/>
-      <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
-      <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.2"/>
-    </ownedRepresentations>
-    <ownedRepresentations xmi:type="sequence:SequenceDDiagram" xmi:id="_3c2zYOc2Ed-ci9l1AsdpKw" name="Basic Interaction Use Diagram">
-      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_3dCZkOc2Ed-ci9l1AsdpKw" source="GMF_DIAGRAMS">
-        <data xmi:type="notation:Diagram" xmi:id="_3dCZkec2Ed-ci9l1AsdpKw" type="Sirius" element="_3c2zYOc2Ed-ci9l1AsdpKw" measurementUnit="Pixel">
-          <children xmi:type="notation:Node" xmi:id="_3fIrUOc2Ed-ci9l1AsdpKw" type="2001" element="_Tq9aAPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_3fTqcOc2Ed-ci9l1AsdpKw" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_3fTqcec2Ed-ci9l1AsdpKw" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_3jCT4Oc2Ed-ci9l1AsdpKw" type="3001" element="_Tq_2RPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_3jC68Oc2Ed-ci9l1AsdpKw" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_3jC68ec2Ed-ci9l1AsdpKw" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_3jUAsOc2Ed-ci9l1AsdpKw" type="3003" element="_TrAdUPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_3jUAsec2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jUAsuc2Ed-ci9l1AsdpKw"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_m3N98E5cEeCHObKOrZ_h3Q" type="3001" element="_TrEuwPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_m3OlAE5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_m3OlAU5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_m3PzIE5cEeCHObKOrZ_h3Q" type="3002" element="_TrF84PWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_m3PzIU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3PzIk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_m3N98U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3N98k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_3jCT4ec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jCT4uc2Ed-ci9l1AsdpKw" y="42" width="10" height="400"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_3jDiAOc2Ed-ci9l1AsdpKw" type="3003" element="_Tq-oIPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_3jDiAec2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jDiAuc2Ed-ci9l1AsdpKw"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_3fJSYOc2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3fJSYec2Ed-ci9l1AsdpKw" x="50" y="50" width="120" height="50"/>
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ToGTQPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Tp0xkPWhEeG4Wag4JBRK3A" name="m1" sourceNode="_ToHhYPWhEeG4Wag4JBRK3A" targetNode="_ToetwPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.0"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.0"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.0"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQB-sBl8EeCKOMpCHXRNLw" y="130" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_MFoW8OUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSH0_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Tp5DAPWhEeG4Wag4JBRK3A" name="m3" sourceNode="_ToHhYPWhEeG4Wag4JBRK3A" targetNode="_Tof74PWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.1"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.1"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.2"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.3"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQB-shl8EeCKOMpCHXRNLw" y="150" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_MmBHMeUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrIk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Tp7fQPWhEeG4Wag4JBRK3A" name="m5" sourceNode="_To49cPWhEeG4Wag4JBRK3A" targetNode="_TohKAPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.2"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.2"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.4"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.5"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQB-tBl8EeCKOMpCHXRNLw" y="170" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_NHgqseUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrJE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Tp8tYPWhEeG4Wag4JBRK3A" name="m7" sourceNode="_TohKAPWhEeG4Wag4JBRK3A" targetNode="_TpNtkPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.3"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.3"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.6"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.7"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQClwRl8EeCKOMpCHXRNLw" y="190" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_OFUWweUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrDk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Tp-ikPWhEeG4Wag4JBRK3A" name="m10" sourceNode="_TpNtkPWhEeG4Wag4JBRK3A" targetNode="_TpcXEPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.5"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.5"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.10"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.11"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDM0Bl8EeCKOMpCHXRNLw" y="265" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_gYwR4eUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrDE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqAXwPWhEeG4Wag4JBRK3A" name="m14" sourceNode="_TpKDMPWhEeG4Wag4JBRK3A" targetNode="_TpPiwPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.11"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.11"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.23"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.24"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDz4Bl8EeCKOMpCHXRNLw" y="460" height="10"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_jycKgeUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrCk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqA-0PWhEeG4Wag4JBRK3A" name="m12" sourceNode="_TocRgPWhEeG4Wag4JBRK3A" targetNode="_To6LkPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.13"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.13"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.27"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.28"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDM0hl8EeCKOMpCHXRNLw" y="550" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_jHAn4eUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrEE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqC0APWhEeG4Wag4JBRK3A" name="m16" sourceNode="_To6LkPWhEeG4Wag4JBRK3A" targetNode="_To-dAPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.14"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.14"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.29"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.30"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDz4hl8EeCKOMpCHXRNLw" y="570" height="10"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_klW1MeUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrEk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqECIPWhEeG4Wag4JBRK3A" name="m18" sourceNode="_To-dAPWhEeG4Wag4JBRK3A" targetNode="_ToIvgPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.15"/>
+      <semanticElements xmi:type="interactions:CallMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.15"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.31"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.32"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQEa8Bl8EeCKOMpCHXRNLw" y="600" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_lWW0UeUCEd-BEJhxHErs5g" size="2" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrAk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Call%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqGeYPWhEeG4Wag4JBRK3A" name="m_create8" sourceNode="_TpNtkPWhEeG4Wag4JBRK3A" targetNode="_ToFsMPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.4"/>
+      <semanticElements xmi:type="interactions:CreateParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.4"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.8"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.9"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQClwhl8EeCKOMpCHXRNLw" y="210" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_QFmMceUCEd-BEJhxHErs5g" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2" strokeColor="138,226,52">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrIE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:CreationMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Create%20Participant%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqJhsPWhEeG4Wag4JBRK3A" name="m_destroy9" sourceNode="_TpNtkPWhEeG4Wag4JBRK3A" targetNode="_Tpjr0PWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.7"/>
+      <semanticElements xmi:type="interactions:DestroyParticipantMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.7"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.14"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.15"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQClwxl8EeCKOMpCHXRNLw" y="360" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_UK2xoeUCEd-BEJhxHErs5g" lineStyle="dash" targetArrow="InputFillClosedArrow" size="2" strokeColor="246,139,139">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSE0_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:DestructionMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Destroy%20Participant%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqNzIPWhEeG4Wag4JBRK3A" sourceNode="_TpcXEPWhEeG4Wag4JBRK3A" targetNode="_TpNtkPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.6"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.6"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.12"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.13"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.4"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDM0Rl8EeCKOMpCHXRNLw" y="315" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_gY40weUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrGk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqQPYPWhEeG4Wag4JBRK3A" sourceNode="_TohKAPWhEeG4Wag4JBRK3A" targetNode="_To49cPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.8"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.8"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.17"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.18"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.2"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.2"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQClwBl8EeCKOMpCHXRNLw" y="400" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_NHjuAeUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSGU_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqSEkPWhEeG4Wag4JBRK3A" sourceNode="_Tof74PWhEeG4Wag4JBRK3A" targetNode="_ToHhYPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.9"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.9"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.19"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.20"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQB-sxl8EeCKOMpCHXRNLw" y="420" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_MmEKgeUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrCE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqTSsPWhEeG4Wag4JBRK3A" sourceNode="_ToetwPWhEeG4Wag4JBRK3A" targetNode="_ToHhYPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.10"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.10"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.21"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.22"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQB-sRl8EeCKOMpCHXRNLw" y="440" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_MFqMIeUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrFE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqVH4PWhEeG4Wag4JBRK3A" sourceNode="_TpPiwPWhEeG4Wag4JBRK3A" targetNode="_TpKDMPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.12"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.12"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.25"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.26"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.5"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDz4Rl8EeCKOMpCHXRNLw" y="520" height="10"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_jyfN0eUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSG0_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqancPWhEeG4Wag4JBRK3A" sourceNode="_ToIvgPWhEeG4Wag4JBRK3A" targetNode="_To-dAPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.16"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.16"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.33"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.34"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.8"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQEa8Rl8EeCKOMpCHXRNLw" y="650" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_lWZ3oeUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrHk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TqccoPWhEeG4Wag4JBRK3A" sourceNode="_To-dAPWhEeG4Wag4JBRK3A" targetNode="_To6LkPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.17"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.17"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.35"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.36"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.7"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDz4xl8EeCKOMpCHXRNLw" y="670" height="10"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_klZ4geUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrFk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Tqff8PWhEeG4Wag4JBRK3A" sourceNode="_To6LkPWhEeG4Wag4JBRK3A" targetNode="_TocRgPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.18"/>
+      <semanticElements xmi:type="interactions:ReturnMessage" href="fixture.interactions#//@ownedInteractions.2/@messages.18"/>
+      <semanticElements xmi:type="interactions:MixEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.37"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.2/@ends.38"/>
+      <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.2/@executions.6"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.2/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQDM0xl8EeCKOMpCHXRNLw" y="700" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_jHDrMeUCEd-BEJhxHErs5g" lineStyle="dot" size="0" strokeColor="114,159,207">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrAE_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ReturnMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Return%20Message']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_Fni5MeUCEd-BEJhxHErs5g"/>
+    <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
+    <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.2"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_3c2zYOc2Ed-ci9l1AsdpKw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_3dCZkOc2Ed-ci9l1AsdpKw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_3dCZkec2Ed-ci9l1AsdpKw" type="Sirius" element="_3c2zYOc2Ed-ci9l1AsdpKw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_3fIrUOc2Ed-ci9l1AsdpKw" type="2001" element="_Tq9aAPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_3fTqcOc2Ed-ci9l1AsdpKw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3fTqcec2Ed-ci9l1AsdpKw" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_3fU4kOc2Ed-ci9l1AsdpKw" type="2001" element="_Tq-oJPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_3fVfoOc2Ed-ci9l1AsdpKw" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_3fVfoec2Ed-ci9l1AsdpKw" y="5"/>
+          <children xmi:type="notation:Node" xmi:id="_3jCT4Oc2Ed-ci9l1AsdpKw" type="3001" element="_Tq_2RPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_3jC68Oc2Ed-ci9l1AsdpKw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3jC68ec2Ed-ci9l1AsdpKw" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_3jvegOc2Ed-ci9l1AsdpKw" type="3001" element="_TrGj8PWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_3jwFkOc2Ed-ci9l1AsdpKw" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_3jwFkec2Ed-ci9l1AsdpKw" y="5"/>
+            <children xmi:type="notation:Node" xmi:id="_3jUAsOc2Ed-ci9l1AsdpKw" type="3003" element="_TrAdUPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3jUAsec2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jUAsuc2Ed-ci9l1AsdpKw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_m3N98E5cEeCHObKOrZ_h3Q" type="3001" element="_TrEuwPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_m3OlAE5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_m3OlAU5cEeCHObKOrZ_h3Q" y="5"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_3jyh0Oc2Ed-ci9l1AsdpKw" type="3003" element="_TrT_UPWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_3jyh0ec2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jyh0uc2Ed-ci9l1AsdpKw"/>
+              <children xmi:type="notation:Node" xmi:id="_m3PzIE5cEeCHObKOrZ_h3Q" type="3002" element="_TrF84PWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_m3PzIU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3PzIk5cEeCHObKOrZ_h3Q"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_m3UEkE5cEeCHObKOrZ_h3Q" type="3001" element="_TrXpsPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_m3UroE5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_m3UroU5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_m3V5wE5cEeCHObKOrZ_h3Q" type="3002" element="_TrY30PWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_m3V5wU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3V5wk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_m3UEkU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3UEkk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_m3N98U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3N98k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3jCT4ec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jCT4uc2Ed-ci9l1AsdpKw" y="42" width="10" height="400"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3jDiAOc2Ed-ci9l1AsdpKw" type="3003" element="_Tq-oIPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3jDiAec2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jDiAuc2Ed-ci9l1AsdpKw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3fJSYOc2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3fJSYec2Ed-ci9l1AsdpKw" x="50" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3fU4kOc2Ed-ci9l1AsdpKw" type="2001" element="_Tq-oJPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_3fVfoOc2Ed-ci9l1AsdpKw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3fVfoec2Ed-ci9l1AsdpKw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3jvegOc2Ed-ci9l1AsdpKw" type="3001" element="_TrGj8PWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_3jwFkOc2Ed-ci9l1AsdpKw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3jwFkec2Ed-ci9l1AsdpKw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3jyh0Oc2Ed-ci9l1AsdpKw" type="3003" element="_TrT_UPWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3jyh0ec2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jyh0uc2Ed-ci9l1AsdpKw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_m3UEkE5cEeCHObKOrZ_h3Q" type="3001" element="_TrXpsPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_m3UroE5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_m3UroU5cEeCHObKOrZ_h3Q" y="5"/>
               </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_3jvegec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jveguc2Ed-ci9l1AsdpKw" y="42" width="10" height="400"/>
+              <children xmi:type="notation:Node" xmi:id="_m3V5wE5cEeCHObKOrZ_h3Q" type="3002" element="_TrY30PWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_m3V5wU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3V5wk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_m3UEkU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3UEkk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_3jwFkuc2Ed-ci9l1AsdpKw" type="3003" element="_Tq_2QPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_3jwFk-c2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jwFlOc2Ed-ci9l1AsdpKw"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_3fU4kec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3fU4kuc2Ed-ci9l1AsdpKw" x="220" y="50" width="120" height="50"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3jvegec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jveguc2Ed-ci9l1AsdpKw" y="42" width="10" height="400"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_3shVIOc4Ed-lJtTyYMySKQ" type="2002" element="_TraF8PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_3sjxYOc4Ed-lJtTyYMySKQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_3sk_gOc4Ed-lJtTyYMySKQ" type="7001">
-              <styles xmi:type="notation:SortingStyle" xmi:id="_3sk_gec4Ed-lJtTyYMySKQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_3sk_guc4Ed-lJtTyYMySKQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_3shVIec4Ed-lJtTyYMySKQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3shVIuc4Ed-lJtTyYMySKQ" x="50" y="130" width="120" height="50"/>
+          <children xmi:type="notation:Node" xmi:id="_3jwFkuc2Ed-ci9l1AsdpKw" type="3003" element="_Tq_2QPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3jwFk-c2Ed-ci9l1AsdpKw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jwFlOc2Ed-ci9l1AsdpKw"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_2xaC0OdbEd-EjZA2qI8iFQ" type="2002" element="_TrjP4PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_2xap4OdbEd-EjZA2qI8iFQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_2xap4edbEd-EjZA2qI8iFQ" type="7001">
-              <styles xmi:type="notation:SortingStyle" xmi:id="_2xap4udbEd-EjZA2qI8iFQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_2xap4-dbEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_2xaC0edbEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2xaC0udbEd-EjZA2qI8iFQ" x="220" y="200" width="120" height="50"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3fU4kec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3fU4kuc2Ed-ci9l1AsdpKw" x="220" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3shVIOc4Ed-lJtTyYMySKQ" type="2002" element="_TraF8PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_3sjxYOc4Ed-lJtTyYMySKQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_3sk_gOc4Ed-lJtTyYMySKQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_3sk_gec4Ed-lJtTyYMySKQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_3sk_guc4Ed-lJtTyYMySKQ"/>
           </children>
-          <styles xmi:type="notation:DiagramStyle" xmi:id="_3dCZkuc2Ed-ci9l1AsdpKw"/>
-        </data>
-      </ownedAnnotationEntries>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_Tq9aAPWhEeG4Wag4JBRK3A" name="p1 : A" width="12" height="5" resizeKind="NSEW">
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3shVIec4Ed-lJtTyYMySKQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3shVIuc4Ed-lJtTyYMySKQ" x="50" y="130" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_2xaC0OdbEd-EjZA2qI8iFQ" type="2002" element="_TrjP4PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_2xap4OdbEd-EjZA2qI8iFQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_2xap4edbEd-EjZA2qI8iFQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_2xap4udbEd-EjZA2qI8iFQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_2xap4-dbEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_2xaC0edbEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2xaC0udbEd-EjZA2qI8iFQ" x="220" y="200" width="120" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_3dCZkuc2Ed-ci9l1AsdpKw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_9iqrgLm3Ee-UXMFld_STMg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_9iqrgbm3Ee-UXMFld_STMg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_Tq9aAPWhEeG4Wag4JBRK3A" name="p1 : A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URGM8PWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tq_2RPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URGM8PWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tq_2RPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TrEuwPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TrEuwPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.0"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TrF84PWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TrF84fWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TrF84vWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TrF84_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TrAdUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TrAdUfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TrAdUvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TrAdU_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TrF84PWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_Tq-oIPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tq-oIfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tq-oIvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_Tq-oI_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TrAdUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_Tq-oJPWhEeG4Wag4JBRK3A" name="p2 : B" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_Tq-oIPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_Tq-oJPWhEeG4Wag4JBRK3A" name="p2 : B" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URGM8fWhEeG4Wag4JBRK3A" x="220" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TrGj8PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URGM8fWhEeG4Wag4JBRK3A" x="220" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TrGj8PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TrXpsPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TrXpsPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.3/@participants.1"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TrY30PWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TrY30fWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TrY30vWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TrY30_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TrT_UPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TrT_UfWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TrT_UvWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TrT_U_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TrY30PWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_Tq_2QPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tq_2QfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tq_2QvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_Tq_2Q_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TrT_UPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_TraF8PWhEeG4Wag4JBRK3A" name="ref1">
-        <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.0"/>
-        <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.0"/>
-        <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQEa8hl8EeCKOMpCHXRNLw" x="50" y="130" height="50" width="120"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_TrciMPWhEeG4Wag4JBRK3A" labelAlignment="LEFT">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TrciMfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TrciMvWhEeG4Wag4JBRK3A"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TrciM_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TrciNPWhEeG4Wag4JBRK3A" red="209" green="209" blue="209"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_TrjP4PWhEeG4Wag4JBRK3A" name="ref2">
-        <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.1"/>
-        <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.1"/>
-        <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQEa8xl8EeCKOMpCHXRNLw" x="220" y="200" height="50" width="120"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_TrjP4fWhEeG4Wag4JBRK3A" labelAlignment="LEFT">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TrjP4vWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TrjP4_WhEeG4Wag4JBRK3A"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TrjP5PWhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TrjP5fWhEeG4Wag4JBRK3A" red="209" green="209" blue="209"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
-      </ownedDiagramElements>
-      <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
-      <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_3c2zYec2Ed-ci9l1AsdpKw"/>
-      <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
-      <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.3"/>
-    </ownedRepresentations>
-    <ownedRepresentations xmi:type="sequence:SequenceDDiagram" xmi:id="_48qywOdWEd-EjZA2qI8iFQ" name="Complex with CF">
-      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_49FpgOdWEd-EjZA2qI8iFQ" source="GMF_DIAGRAMS">
-        <data xmi:type="notation:Diagram" xmi:id="_49FpgedWEd-EjZA2qI8iFQ" type="Sirius" element="_48qywOdWEd-EjZA2qI8iFQ" measurementUnit="Pixel">
-          <children xmi:type="notation:Node" xmi:id="_4-q94OdWEd-EjZA2qI8iFQ" type="2001" element="_TsKT4PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_4-vPUOdWEd-EjZA2qI8iFQ" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_4-vPUedWEd-EjZA2qI8iFQ" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_5AHIUOdWEd-EjZA2qI8iFQ" type="3001" element="_TsMwIPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_5AHvYOdWEd-EjZA2qI8iFQ" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_5AHvYedWEd-EjZA2qI8iFQ" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_5ALZwOdWEd-EjZA2qI8iFQ" type="3003" element="_TsMwIfWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_5ALZwedWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ALZwudWEd-EjZA2qI8iFQ"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_H1twAOdqEd-1-6lw65J6ig" type="3001" element="_TsN-QPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_H1twA-dqEd-1-6lw65J6ig" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_H1twBOdqEd-1-6lw65J6ig" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_H1u-IOdqEd-1-6lw65J6ig" type="3003" element="_TsOlUPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_H1u-IedqEd-1-6lw65J6ig" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H1u-IudqEd-1-6lw65J6ig"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_M7hMMOdqEd-1-6lw65J6ig" type="3001" element="_TsUE4PWhEeG4Wag4JBRK3A">
-                  <children xmi:type="notation:Node" xmi:id="_M7hMM-dqEd-1-6lw65J6ig" type="5001">
-                    <layoutConstraint xmi:type="notation:Location" xmi:id="_M7hzQOdqEd-1-6lw65J6ig" y="5"/>
-                  </children>
-                  <children xmi:type="notation:Node" xmi:id="_M7iaUOdqEd-1-6lw65J6ig" type="3003" element="_TsWhIPWhEeG4Wag4JBRK3A">
-                    <styles xmi:type="notation:ShapeStyle" xmi:id="_M7iaUedqEd-1-6lw65J6ig" fontName="Segoe UI"/>
-                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M7iaUudqEd-1-6lw65J6ig"/>
-                  </children>
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_M7hMMedqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M7hMMudqEd-1-6lw65J6ig" x="12" y="70" width="20" height="50"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_H1twAedqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H1twAudqEd-1-6lw65J6ig" x="2" y="280" width="20" height="300"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_WHIdYOf9Ed-ytMWANgVcQw" type="3001" element="_TsQagfWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_WHj7MOf9Ed-ytMWANgVcQw" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_WHj7Mef9Ed-ytMWANgVcQw" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_WIK_MOf9Ed-ytMWANgVcQw" type="3003" element="_TsRooPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_WIK_Mef9Ed-ytMWANgVcQw" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WIK_Muf9Ed-ytMWANgVcQw"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_WHIdYef9Ed-ytMWANgVcQw" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WHIdYuf9Ed-ytMWANgVcQw" x="2" y="633" width="20" height="30"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_nyALME5cEeCHObKOrZ_h3Q" type="3001" element="_TscAsPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_nyALM05cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nyALNE5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_nyCAYE5cEeCHObKOrZ_h3Q" type="3002" element="_TscnwPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_nyCAYU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyCAYk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_nyALMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyALMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_5AHIUedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AHIUudWEd-EjZA2qI8iFQ" y="42" width="10" height="773"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_5AIWcOdWEd-EjZA2qI8iFQ" type="3003" element="_TsK68PWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_5AIWcedWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AIWcudWEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_4-q94edWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-q94udWEd-EjZA2qI8iFQ" x="60" y="50" width="120" height="50"/>
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_Tq_2QPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TraF8PWhEeG4Wag4JBRK3A" name="ref1">
+      <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.0"/>
+      <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.0"/>
+      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQEa8hl8EeCKOMpCHXRNLw" x="50" y="130" height="50" width="120"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TrciMPWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TrjP4PWhEeG4Wag4JBRK3A" name="ref2">
+      <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.1"/>
+      <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.1"/>
+      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQEa8xl8EeCKOMpCHXRNLw" x="220" y="200" height="50" width="120"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TrjP4fWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_3c2zYec2Ed-ci9l1AsdpKw"/>
+    <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
+    <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.3"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_48qywOdWEd-EjZA2qI8iFQ">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_49FpgOdWEd-EjZA2qI8iFQ" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_49FpgedWEd-EjZA2qI8iFQ" type="Sirius" element="_48qywOdWEd-EjZA2qI8iFQ" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_4-q94OdWEd-EjZA2qI8iFQ" type="2001" element="_TsKT4PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_4-vPUOdWEd-EjZA2qI8iFQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_4-vPUedWEd-EjZA2qI8iFQ" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_4-wdcOdWEd-EjZA2qI8iFQ" type="2001" element="_TsLiAPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_4-wdc-dWEd-EjZA2qI8iFQ" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_4-wddOdWEd-EjZA2qI8iFQ" y="5"/>
+          <children xmi:type="notation:Node" xmi:id="_5AHIUOdWEd-EjZA2qI8iFQ" type="3001" element="_TsMwIPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_5AHvYOdWEd-EjZA2qI8iFQ" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5AHvYedWEd-EjZA2qI8iFQ" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_5AaDQOdWEd-EjZA2qI8iFQ" type="3001" element="_Tsd14PWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_5AaDQ-dWEd-EjZA2qI8iFQ" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_5AaDROdWEd-EjZA2qI8iFQ" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_5AbRYOdWEd-EjZA2qI8iFQ" type="3003" element="_Tsec8PWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_5AbRYedWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AbRYudWEd-EjZA2qI8iFQ"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_9ERmsOdpEd-1-6lw65J6ig" type="3001" element="_TsgSIPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_9Ej6kOdpEd-1-6lw65J6ig" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_9Ej6kedpEd-1-6lw65J6ig" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_9GLrMOdpEd-1-6lw65J6ig" type="3003" element="_TshgQPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_9GLrMedpEd-1-6lw65J6ig" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9GLrMudpEd-1-6lw65J6ig"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_9ERmsedpEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9ERmsudpEd-1-6lw65J6ig" x="2" y="30" width="20" height="90"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="__4roAOdpEd-1-6lw65J6ig" type="3001" element="_TsoN8PWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="__4roA-dpEd-1-6lw65J6ig" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="__4roBOdpEd-1-6lw65J6ig" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="__4tdMOdpEd-1-6lw65J6ig" type="3003" element="_TsqDIPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="__4tdMedpEd-1-6lw65J6ig" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="__4tdMudpEd-1-6lw65J6ig"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="__4roAedpEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="__4roAudpEd-1-6lw65J6ig" x="2" y="190" width="20" height="50"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_YzFQEOdqEd-1-6lw65J6ig" type="3001" element="_TsqqMPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_YzF3IedqEd-1-6lw65J6ig" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_YzF3IudqEd-1-6lw65J6ig" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_YzHFQOdqEd-1-6lw65J6ig" type="3003" element="_TsqqMfWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_YzHFQedqEd-1-6lw65J6ig" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YzHFQudqEd-1-6lw65J6ig"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_YzFQEedqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YzF3IOdqEd-1-6lw65J6ig" x="2" y="490" width="20" height="50"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_nyGR0E5cEeCHObKOrZ_h3Q" type="3001" element="_TsuUkPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_nyGR005cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nyGR1E5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_nyIHAE5cEeCHObKOrZ_h3Q" type="3002" element="_Tsu7oPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_nyIHAU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyIHAk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_nyGR0U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyGR0k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_5AaDQedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AaDQudWEd-EjZA2qI8iFQ" y="42" width="10" height="773"/>
+            <children xmi:type="notation:Node" xmi:id="_5ALZwOdWEd-EjZA2qI8iFQ" type="3003" element="_TsMwIfWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_5ALZwedWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ALZwudWEd-EjZA2qI8iFQ"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_5AaDRedWEd-EjZA2qI8iFQ" type="3003" element="_TsMJEPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_5AaDRudWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AaDR-dWEd-EjZA2qI8iFQ"/>
+            <children xmi:type="notation:Node" xmi:id="_H1twAOdqEd-1-6lw65J6ig" type="3001" element="_TsN-QPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_H1twA-dqEd-1-6lw65J6ig" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_H1twBOdqEd-1-6lw65J6ig" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_H1u-IOdqEd-1-6lw65J6ig" type="3003" element="_TsOlUPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_H1u-IedqEd-1-6lw65J6ig" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H1u-IudqEd-1-6lw65J6ig"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_M7hMMOdqEd-1-6lw65J6ig" type="3001" element="_TsUE4PWhEeG4Wag4JBRK3A">
+                <children xmi:type="notation:Node" xmi:id="_M7hMM-dqEd-1-6lw65J6ig" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_M7hzQOdqEd-1-6lw65J6ig" y="5"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_M7iaUOdqEd-1-6lw65J6ig" type="3003" element="_TsWhIPWhEeG4Wag4JBRK3A">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_M7iaUedqEd-1-6lw65J6ig" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M7iaUudqEd-1-6lw65J6ig"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_M7hMMedqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M7hMMudqEd-1-6lw65J6ig" x="12" y="70" width="20" height="50"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_H1twAedqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H1twAudqEd-1-6lw65J6ig" x="2" y="280" width="20" height="300"/>
             </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_4-wdcedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-wdcudWEd-EjZA2qI8iFQ" x="250" y="50" width="120" height="50"/>
+            <children xmi:type="notation:Node" xmi:id="_WHIdYOf9Ed-ytMWANgVcQw" type="3001" element="_TsQagfWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_WHj7MOf9Ed-ytMWANgVcQw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_WHj7Mef9Ed-ytMWANgVcQw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_WIK_MOf9Ed-ytMWANgVcQw" type="3003" element="_TsRooPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_WIK_Mef9Ed-ytMWANgVcQw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WIK_Muf9Ed-ytMWANgVcQw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_WHIdYef9Ed-ytMWANgVcQw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WHIdYuf9Ed-ytMWANgVcQw" x="2" y="633" width="20" height="30"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nyALME5cEeCHObKOrZ_h3Q" type="3001" element="_TscAsPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_nyALM05cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_nyALNE5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_nyCAYE5cEeCHObKOrZ_h3Q" type="3002" element="_TscnwPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_nyCAYU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyCAYk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nyALMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyALMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_5AHIUedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AHIUudWEd-EjZA2qI8iFQ" y="42" width="10" height="773"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_4-xEgOdWEd-EjZA2qI8iFQ" type="2002" element="_TsxX4PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_4-xrkOdWEd-EjZA2qI8iFQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_4-ySoOdWEd-EjZA2qI8iFQ" type="7001">
-              <styles xmi:type="notation:SortingStyle" xmi:id="_4-ySoedWEd-EjZA2qI8iFQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_4-ySoudWEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_4-xEgedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-xEgudWEd-EjZA2qI8iFQ" x="60" y="150" width="310" height="50"/>
+          <children xmi:type="notation:Node" xmi:id="_5AIWcOdWEd-EjZA2qI8iFQ" type="3003" element="_TsK68PWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_5AIWcedWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AIWcudWEd-EjZA2qI8iFQ"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_4-ySo-dWEd-EjZA2qI8iFQ" type="2002" element="_Tsz0IPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_4-y5sOdWEd-EjZA2qI8iFQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_4-y5sedWEd-EjZA2qI8iFQ" type="7001">
-              <styles xmi:type="notation:SortingStyle" xmi:id="_4-y5sudWEd-EjZA2qI8iFQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_4-y5s-dWEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_4-ySpOdWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-ySpedWEd-EjZA2qI8iFQ" x="60" y="520" width="310" height="50"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4-q94edWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-q94udWEd-EjZA2qI8iFQ" x="60" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4-wdcOdWEd-EjZA2qI8iFQ" type="2001" element="_TsLiAPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_4-wdc-dWEd-EjZA2qI8iFQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_4-wddOdWEd-EjZA2qI8iFQ" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_4-y5tOdWEd-EjZA2qI8iFQ" type="2002" element="_Ts2QYPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_4-zgwOdWEd-EjZA2qI8iFQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_4-zgwedWEd-EjZA2qI8iFQ" type="7001">
-              <children xmi:type="notation:Node" xmi:id="_4-3LIOdWEd-EjZA2qI8iFQ" type="3008" element="_Ts56wPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_4-4ZQOdWEd-EjZA2qI8iFQ" type="5005"/>
-                <children xmi:type="notation:Node" xmi:id="_4-5AUOdWEd-EjZA2qI8iFQ" type="7002">
-                  <styles xmi:type="notation:SortingStyle" xmi:id="_4-5AUedWEd-EjZA2qI8iFQ"/>
-                  <styles xmi:type="notation:FilteringStyle" xmi:id="_4-5AUudWEd-EjZA2qI8iFQ"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_4-3LIedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-3LIudWEd-EjZA2qI8iFQ" y="30" width="120" height="90"/>
+          <children xmi:type="notation:Node" xmi:id="_5AaDQOdWEd-EjZA2qI8iFQ" type="3001" element="_Tsd14PWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_5AaDQ-dWEd-EjZA2qI8iFQ" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_5AaDROdWEd-EjZA2qI8iFQ" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_5AbRYOdWEd-EjZA2qI8iFQ" type="3003" element="_Tsec8PWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_5AbRYedWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AbRYudWEd-EjZA2qI8iFQ"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_9ERmsOdpEd-1-6lw65J6ig" type="3001" element="_TsgSIPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_9Ej6kOdpEd-1-6lw65J6ig" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_9Ej6kedpEd-1-6lw65J6ig" y="5"/>
               </children>
-              <styles xmi:type="notation:SortingStyle" xmi:id="_4-zgwudWEd-EjZA2qI8iFQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_4-zgw-dWEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_4-y5tedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-y5tudWEd-EjZA2qI8iFQ" x="60" y="240" width="120" height="120"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_4-zgxOdWEd-EjZA2qI8iFQ" type="2002" element="_Ts3egfWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_4-0H0OdWEd-EjZA2qI8iFQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_4-0H0edWEd-EjZA2qI8iFQ" type="7001">
-              <children xmi:type="notation:Node" xmi:id="_4-61gOdWEd-EjZA2qI8iFQ" type="3008" element="_Ts7I4PWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_4-7ckOdWEd-EjZA2qI8iFQ" type="5005"/>
-                <children xmi:type="notation:Node" xmi:id="_4-7ckedWEd-EjZA2qI8iFQ" type="7002">
-                  <styles xmi:type="notation:SortingStyle" xmi:id="_4-7ckudWEd-EjZA2qI8iFQ"/>
-                  <styles xmi:type="notation:FilteringStyle" xmi:id="_4-7ck-dWEd-EjZA2qI8iFQ"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_4-61gedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-61gudWEd-EjZA2qI8iFQ" y="30" width="330" height="230"/>
+              <children xmi:type="notation:Node" xmi:id="_9GLrMOdpEd-1-6lw65J6ig" type="3003" element="_TshgQPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_9GLrMedpEd-1-6lw65J6ig" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9GLrMudpEd-1-6lw65J6ig"/>
               </children>
-              <styles xmi:type="notation:SortingStyle" xmi:id="_4-0H0udWEd-EjZA2qI8iFQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_4-0H0-dWEd-EjZA2qI8iFQ"/>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_9ERmsedpEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9ERmsudpEd-1-6lw65J6ig" x="2" y="30" width="20" height="90"/>
             </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_4-zgxedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-zgxudWEd-EjZA2qI8iFQ" x="50" y="400" width="330" height="260"/>
+            <children xmi:type="notation:Node" xmi:id="__4roAOdpEd-1-6lw65J6ig" type="3001" element="_TsoN8PWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="__4roA-dpEd-1-6lw65J6ig" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="__4roBOdpEd-1-6lw65J6ig" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="__4tdMOdpEd-1-6lw65J6ig" type="3003" element="_TsqDIPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="__4tdMedpEd-1-6lw65J6ig" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="__4tdMudpEd-1-6lw65J6ig"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="__4roAedpEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="__4roAudpEd-1-6lw65J6ig" x="2" y="190" width="20" height="50"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_YzFQEOdqEd-1-6lw65J6ig" type="3001" element="_TsqqMPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_YzF3IedqEd-1-6lw65J6ig" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_YzF3IudqEd-1-6lw65J6ig" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_YzHFQOdqEd-1-6lw65J6ig" type="3003" element="_TsqqMfWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_YzHFQedqEd-1-6lw65J6ig" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YzHFQudqEd-1-6lw65J6ig"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_YzFQEedqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YzF3IOdqEd-1-6lw65J6ig" x="2" y="490" width="20" height="50"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nyGR0E5cEeCHObKOrZ_h3Q" type="3001" element="_TsuUkPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_nyGR005cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_nyGR1E5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_nyIHAE5cEeCHObKOrZ_h3Q" type="3002" element="_Tsu7oPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_nyIHAU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyIHAk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nyGR0U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyGR0k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_5AaDQedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AaDQudWEd-EjZA2qI8iFQ" y="42" width="10" height="773"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_GGPMoOf9Ed-ytMWANgVcQw" type="2002" element="_Ts0bMPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_GGSP8Of9Ed-ytMWANgVcQw" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_GGS3AOf9Ed-ytMWANgVcQw" type="7001">
-              <styles xmi:type="notation:SortingStyle" xmi:id="_GGS3Aef9Ed-ytMWANgVcQw"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_GGS3Auf9Ed-ytMWANgVcQw"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_GGPzsOf9Ed-ytMWANgVcQw" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GGPzsef9Ed-ytMWANgVcQw" x="250" y="704" width="120" height="84"/>
+          <children xmi:type="notation:Node" xmi:id="_5AaDRedWEd-EjZA2qI8iFQ" type="3003" element="_TsMJEPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_5AaDRudWEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AaDR-dWEd-EjZA2qI8iFQ"/>
           </children>
-          <styles xmi:type="notation:DiagramStyle" xmi:id="_49FpgudWEd-EjZA2qI8iFQ"/>
-          <edges xmi:type="notation:Edge" xmi:id="_ab8rUOdqEd-1-6lw65J6ig" type="4001" element="_TtES0PWhEeG4Wag4JBRK3A" source="_5AHIUOdWEd-EjZA2qI8iFQ" target="_5AHIUOdWEd-EjZA2qI8iFQ">
-            <children xmi:type="notation:Node" xmi:id="_acCx8OdqEd-1-6lw65J6ig" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_acCx8edqEd-1-6lw65J6ig" x="-1" y="-61"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4-wdcedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-wdcudWEd-EjZA2qI8iFQ" x="250" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4-xEgOdWEd-EjZA2qI8iFQ" type="2002" element="_TsxX4PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_4-xrkOdWEd-EjZA2qI8iFQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4-ySoOdWEd-EjZA2qI8iFQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4-ySoedWEd-EjZA2qI8iFQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4-ySoudWEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4-xEgedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-xEgudWEd-EjZA2qI8iFQ" x="60" y="150" width="310" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4-ySo-dWEd-EjZA2qI8iFQ" type="2002" element="_Tsz0IPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_4-y5sOdWEd-EjZA2qI8iFQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4-y5sedWEd-EjZA2qI8iFQ" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4-y5sudWEd-EjZA2qI8iFQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4-y5s-dWEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4-ySpOdWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-ySpedWEd-EjZA2qI8iFQ" x="60" y="520" width="310" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4-y5tOdWEd-EjZA2qI8iFQ" type="2002" element="_Ts2QYPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_4-zgwOdWEd-EjZA2qI8iFQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4-zgwedWEd-EjZA2qI8iFQ" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_4-3LIOdWEd-EjZA2qI8iFQ" type="3008" element="_Ts56wPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_4-4ZQOdWEd-EjZA2qI8iFQ" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_4-5AUOdWEd-EjZA2qI8iFQ" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_4-5AUedWEd-EjZA2qI8iFQ"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_4-5AUudWEd-EjZA2qI8iFQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_4-3LIedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-3LIudWEd-EjZA2qI8iFQ" y="30" width="120" height="90"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVSeAFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVSeAVGCEeC1w6iasj3fZA" y="10"/>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4-zgwudWEd-EjZA2qI8iFQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4-zgw-dWEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4-y5tedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-y5tudWEd-EjZA2qI8iFQ" x="60" y="240" width="120" height="120"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4-zgxOdWEd-EjZA2qI8iFQ" type="2002" element="_Ts3egfWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_4-0H0OdWEd-EjZA2qI8iFQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4-0H0edWEd-EjZA2qI8iFQ" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_4-61gOdWEd-EjZA2qI8iFQ" type="3008" element="_Ts7I4PWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_4-7ckOdWEd-EjZA2qI8iFQ" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_4-7ckedWEd-EjZA2qI8iFQ" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_4-7ckudWEd-EjZA2qI8iFQ"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_4-7ck-dWEd-EjZA2qI8iFQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_4-61gedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-61gudWEd-EjZA2qI8iFQ" y="30" width="330" height="230"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_OVSeAlGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVSeA1GCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_ab8rUedqEd-1-6lw65J6ig"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_ab8rUudqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ab8rU-dqEd-1-6lw65J6ig" points="[0, -30, 0, -51]$[0, -20, 0, -41]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_acDZAOdqEd-1-6lw65J6ig" id="(0.5,0.31111112)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_acDZAedqEd-1-6lw65J6ig" id="(0.5,0.33809525)"/>
-          </edges>
-          <edges xmi:type="notation:Edge" xmi:id="_bhZmUOgAEd-ytMWANgVcQw" type="4001" element="_TtGIAPWhEeG4Wag4JBRK3A" source="_5AHIUOdWEd-EjZA2qI8iFQ" target="_5AaDQOdWEd-EjZA2qI8iFQ">
-            <children xmi:type="notation:Node" xmi:id="_bhZmVOgAEd-ytMWANgVcQw" type="6001">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bhZmVegAEd-ytMWANgVcQw" y="-10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVSeBFGCEeC1w6iasj3fZA" type="6002">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVSeBVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_OVTFEFGCEeC1w6iasj3fZA" type="6003">
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVTFEVGCEeC1w6iasj3fZA" y="10"/>
-            </children>
-            <styles xmi:type="notation:ConnectorStyle" xmi:id="_bhZmUegAEd-ytMWANgVcQw"/>
-            <styles xmi:type="notation:FontStyle" xmi:id="_bhZmUugAEd-ytMWANgVcQw" fontName="Segoe UI" fontHeight="8"/>
-            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bhZmU-gAEd-ytMWANgVcQw" points="[0, -2, -170, -2]$[170, -2, 0, -2]"/>
-            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bhZmVugAEd-ytMWANgVcQw" id="(0.5,0.9377432)"/>
-            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bhZmV-gAEd-ytMWANgVcQw" id="(0.5,0.9377432)"/>
-          </edges>
-        </data>
-      </ownedAnnotationEntries>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TsKT4PWhEeG4Wag4JBRK3A" name="p1 : A" width="12" height="5" resizeKind="NSEW">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4-0H0udWEd-EjZA2qI8iFQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4-0H0-dWEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4-zgxedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4-zgxudWEd-EjZA2qI8iFQ" x="50" y="400" width="330" height="260"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_GGPMoOf9Ed-ytMWANgVcQw" type="2002" element="_Ts0bMPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_GGSP8Of9Ed-ytMWANgVcQw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_GGS3AOf9Ed-ytMWANgVcQw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_GGS3Aef9Ed-ytMWANgVcQw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_GGS3Auf9Ed-ytMWANgVcQw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_GGPzsOf9Ed-ytMWANgVcQw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GGPzsef9Ed-ytMWANgVcQw" x="250" y="704" width="120" height="84"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_49FpgudWEd-EjZA2qI8iFQ"/>
+        <edges xmi:type="notation:Edge" xmi:id="_ab8rUOdqEd-1-6lw65J6ig" type="4001" element="_TtES0PWhEeG4Wag4JBRK3A" source="_5AHIUOdWEd-EjZA2qI8iFQ" target="_5AHIUOdWEd-EjZA2qI8iFQ">
+          <children xmi:type="notation:Node" xmi:id="_acCx8OdqEd-1-6lw65J6ig" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_acCx8edqEd-1-6lw65J6ig" x="-1" y="-61"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVSeAFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVSeAVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVSeAlGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVSeA1GCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ab8rUedqEd-1-6lw65J6ig"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ab8rUudqEd-1-6lw65J6ig" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ab8rU-dqEd-1-6lw65J6ig" points="[0, -30, 0, -51]$[0, -20, 0, -41]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_acDZAOdqEd-1-6lw65J6ig" id="(0.5,0.31111112)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_acDZAedqEd-1-6lw65J6ig" id="(0.5,0.33809525)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_bhZmUOgAEd-ytMWANgVcQw" type="4001" element="_TtGIAPWhEeG4Wag4JBRK3A" source="_5AHIUOdWEd-EjZA2qI8iFQ" target="_5AaDQOdWEd-EjZA2qI8iFQ">
+          <children xmi:type="notation:Node" xmi:id="_bhZmVOgAEd-ytMWANgVcQw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bhZmVegAEd-ytMWANgVcQw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVSeBFGCEeC1w6iasj3fZA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVSeBVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_OVTFEFGCEeC1w6iasj3fZA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OVTFEVGCEeC1w6iasj3fZA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_bhZmUegAEd-ytMWANgVcQw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_bhZmUugAEd-ytMWANgVcQw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bhZmU-gAEd-ytMWANgVcQw" points="[0, -2, -170, -2]$[170, -2, 0, -2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bhZmVugAEd-ytMWANgVcQw" id="(0.5,0.9377432)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bhZmV-gAEd-ytMWANgVcQw" id="(0.5,0.9377432)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_9iqrgrm3Ee-UXMFld_STMg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_9iqrg7m3Ee-UXMFld_STMg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TsKT4PWhEeG4Wag4JBRK3A" name="p1 : A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URICIPWhEeG4Wag4JBRK3A" x="60" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsMwIPWhEeG4Wag4JBRK3A" outgoingEdges="_TtES0PWhEeG4Wag4JBRK3A _TtGIAPWhEeG4Wag4JBRK3A" incomingEdges="_TtES0PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URICIPWhEeG4Wag4JBRK3A" x="60" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsMwIPWhEeG4Wag4JBRK3A" outgoingEdges="_TtES0PWhEeG4Wag4JBRK3A _TtGIAPWhEeG4Wag4JBRK3A" incomingEdges="_TtES0PWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsN-QPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.2"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.2"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.11"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.21"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFCABl8EeCKOMpCHXRNLw" x="110" y="380" height="300" width="20"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsUE4PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.3"/>
+            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.3"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.14"/>
+            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.15"/>
+            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
+            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFCARl8EeCKOMpCHXRNLw" x="125" y="450" height="50" width="20"/>
+            <ownedStyle xmi:type="diagram:Square" uid="_TsWhIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="181,228,225">
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+          </ownedBorderedNodes>
+          <ownedStyle xmi:type="diagram:Square" uid="_TsOlUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsQagfWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.5"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.5"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.23"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.24"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFCAhl8EeCKOMpCHXRNLw" x="110" y="733" height="30" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TsRooPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TscAsPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsN-QPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.2"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.2"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.11"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.21"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFCABl8EeCKOMpCHXRNLw" x="110" y="380" height="300" width="20"/>
-            <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsUE4PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-              <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.3"/>
-              <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.3"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.14"/>
-              <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.15"/>
-              <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-              <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFCARl8EeCKOMpCHXRNLw" x="125" y="450" height="50" width="20"/>
-              <ownedStyle xmi:type="diagram:Square" xmi:id="_TsWhIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-                <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsWhIfWhEeG4Wag4JBRK3A"/>
-                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-                <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsWhIvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-                <color xmi:type="viewpoint:RGBValues" xmi:id="_TsYWUPWhEeG4Wag4JBRK3A" red="181" green="228" blue="225"/>
-              </ownedStyle>
-              <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-            </ownedBorderedNodes>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TsOlUPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsOlUfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsPMYPWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TsQagPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsQagfWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.5"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.5"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.23"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.24"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFCAhl8EeCKOMpCHXRNLw" x="110" y="733" height="30" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TsRooPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsRoofWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsRoovWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TsTd0PWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TscAsPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TscnwPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TscnwfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TscnwvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tscnw_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TsMwIfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsMwIvWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsMwI_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TsMwJPWhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TscnwPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TsK68PWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsK68fWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsK68vWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TsK68_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TsMwIfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TsLiAPWhEeG4Wag4JBRK3A" name="p2 : B" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TsK68PWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TsLiAPWhEeG4Wag4JBRK3A" name="p2 : B" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URICIfWhEeG4Wag4JBRK3A" x="250" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Tsd14PWhEeG4Wag4JBRK3A" incomingEdges="_TtGIAPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URICIfWhEeG4Wag4JBRK3A" x="250" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Tsd14PWhEeG4Wag4JBRK3A" incomingEdges="_TtGIAPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsgSIPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.0"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.0"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.0"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.3"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpEBl8EeCKOMpCHXRNLw" x="300" y="130" height="90" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TshgQPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsoN8PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.1"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.1"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.6"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.9"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpERl8EeCKOMpCHXRNLw" x="300" y="290" height="50" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TsqDIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsqqMPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
+          <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.4"/>
+          <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.4"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.18"/>
+          <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.19"/>
+          <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
+          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpEhl8EeCKOMpCHXRNLw" x="300" y="590" height="50" width="20"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_TsqqMfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" width="2" height="5" color="199,237,232">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TsuUkPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsgSIPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.0"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.0"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.0"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.3"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFpEBl8EeCKOMpCHXRNLw" x="300" y="130" height="90" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TshgQPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TshgQfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TshgQvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TslKoPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsoN8PWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.1"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.1"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.6"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.9"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFpERl8EeCKOMpCHXRNLw" x="300" y="290" height="50" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TsqDIPWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsqDIfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsqDIvWhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TsqDJPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsqqMPWhEeG4Wag4JBRK3A" width="2" height="5" resizeKind="NORTH_SOUTH">
-            <target xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.4"/>
-            <semanticElements xmi:type="interactions:Execution" href="fixture.interactions#//@ownedInteractions.5/@executions.4"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.18"/>
-            <semanticElements xmi:type="interactions:ExecutionEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.19"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-            <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFpEhl8EeCKOMpCHXRNLw" x="300" y="590" height="50" width="20"/>
-            <ownedStyle xmi:type="diagram:Square" xmi:id="_TsqqMfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" width="2" height="5">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsqqMvWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsqqM_WhEeG4Wag4JBRK3A" red="39" green="76" blue="114"/>
-              <color xmi:type="viewpoint:RGBValues" xmi:id="_TsrRQPWhEeG4Wag4JBRK3A" red="199" green="237" blue="232"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='Execution']"/>
-          </ownedBorderedNodes>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TsuUkPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_Tsu7oPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsu7ofWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsu7ovWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsu7o_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_Tsec8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsec8fWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsec8vWhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_Tsec8_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_Tsu7oPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TsMJEPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TsMJEfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TsMJEvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TsMJE_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_Tsec8PWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_TsxX4PWhEeG4Wag4JBRK3A" name="ref1">
-        <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.0"/>
-        <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.0"/>
-        <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFpExl8EeCKOMpCHXRNLw" x="60" y="150" height="50" width="310"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Tsx-8PWhEeG4Wag4JBRK3A" labelAlignment="LEFT">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsx-8fWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsx-8vWhEeG4Wag4JBRK3A"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsx-8_WhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsx-9PWhEeG4Wag4JBRK3A" red="209" green="209" blue="209"/>
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TsMJEPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TsxX4PWhEeG4Wag4JBRK3A" name="ref1">
+      <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.0"/>
+      <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.0"/>
+      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpExl8EeCKOMpCHXRNLw" x="60" y="150" height="50" width="310"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Tsx-8PWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Tsz0IPWhEeG4Wag4JBRK3A" name="ref2">
+      <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.1"/>
+      <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.1"/>
+      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpFBl8EeCKOMpCHXRNLw" x="60" y="520" height="50" width="310"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Tsz0IfWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ts0bMPWhEeG4Wag4JBRK3A" name="ref.3">
+      <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.2"/>
+      <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.2"/>
+      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.5"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQGQIxl8EeCKOMpCHXRNLw" x="250" y="704" height="84" width="120"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ts0bMfWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ts2QYPWhEeG4Wag4JBRK3A" name="opt1">
+      <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0"/>
+      <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpFRl8EeCKOMpCHXRNLw" x="60" y="240" height="120" width="120"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ts2QYfWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundColor="166,227,187" foregroundColor="166,227,187">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ts56wPWhEeG4Wag4JBRK3A" name="[op1]">
+        <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0/@ownedOperands.0"/>
+        <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0/@ownedOperands.0"/>
+        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQGQIBl8EeCKOMpCHXRNLw" x="60" y="270" height="90" width="120"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ts6h0PWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundStyle="GradientTopToBottom" backgroundColor="160,222,214" foregroundColor="160,222,214">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
+        <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_Tsz0IPWhEeG4Wag4JBRK3A" name="ref2">
-        <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.1"/>
-        <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.1"/>
-        <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFpFBl8EeCKOMpCHXRNLw" x="60" y="520" height="50" width="310"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Tsz0IfWhEeG4Wag4JBRK3A" labelAlignment="LEFT">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsz0IvWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsz0I_WhEeG4Wag4JBRK3A"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsz0JPWhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tsz0JfWhEeG4Wag4JBRK3A" red="209" green="209" blue="209"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ts3egfWhEeG4Wag4JBRK3A" name="opt2">
+      <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1"/>
+      <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQGQIRl8EeCKOMpCHXRNLw" x="50" y="400" height="260" width="330"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ts4FkPWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundColor="166,227,187" foregroundColor="166,227,187">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ts7I4PWhEeG4Wag4JBRK3A" name="[op2]">
+        <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1/@ownedOperands.0"/>
+        <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1/@ownedOperands.0"/>
+        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQGQIhl8EeCKOMpCHXRNLw" x="50" y="430" height="230" width="330"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ts7I4fWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundStyle="GradientTopToBottom" backgroundColor="160,222,214" foregroundColor="160,222,214">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
+        <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_Ts0bMPWhEeG4Wag4JBRK3A" name="ref.3">
-        <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.2"/>
-        <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.2"/>
-        <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.5"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQGQIxl8EeCKOMpCHXRNLw" x="250" y="704" height="84" width="120"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Ts0bMfWhEeG4Wag4JBRK3A" labelAlignment="LEFT">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts0bMvWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts0bM_WhEeG4Wag4JBRK3A"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts0bNPWhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts0bNfWhEeG4Wag4JBRK3A" red="209" green="209" blue="209"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:InteractionUseMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_Ts2QYPWhEeG4Wag4JBRK3A" name="opt1">
-        <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0"/>
-        <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQFpFRl8EeCKOMpCHXRNLw" x="60" y="240" height="120" width="120"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Ts2QYfWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts2QYvWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts2QY_WhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts23cPWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts3egPWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
-        <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_Ts56wPWhEeG4Wag4JBRK3A" name="[op1]">
-          <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0/@ownedOperands.0"/>
-          <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.0/@ownedOperands.0"/>
-          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQGQIBl8EeCKOMpCHXRNLw" x="60" y="270" height="90" width="120"/>
-          <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Ts6h0PWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts6h0fWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts6h0vWhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts6h0_WhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts6h1PWhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
-        </ownedDiagramElements>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_Ts3egfWhEeG4Wag4JBRK3A" name="opt2">
-        <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1"/>
-        <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQGQIRl8EeCKOMpCHXRNLw" x="50" y="400" height="260" width="330"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Ts4FkPWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts4FkfWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts4FkvWhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts4soPWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts5TsPWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
-        <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_Ts7I4PWhEeG4Wag4JBRK3A" name="[op2]">
-          <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1/@ownedOperands.0"/>
-          <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.5/@combinedFragments.1/@ownedOperands.0"/>
-          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQGQIhl8EeCKOMpCHXRNLw" x="50" y="430" height="230" width="330"/>
-          <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Ts7I4fWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts7I4vWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts7I4_WhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts7I5PWhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Ts7I5fWhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
-        </ownedDiagramElements>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TtES0PWhEeG4Wag4JBRK3A" name="m1" sourceNode="_TsMwIPWhEeG4Wag4JBRK3A" targetNode="_TsMwIPWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.0"/>
-        <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.0"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.7"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.8"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQGQJBl8EeCKOMpCHXRNLw" x="0" y="310" height="10" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_aZ7SEedqEd-1-6lw65J6ig" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_aZ75IOdqEd-1-6lw65J6ig" red="77" green="137" blue="20"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLcrBk_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLcrB0_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_TtGIAPWhEeG4Wag4JBRK3A" name="m2" sourceNode="_TsMwIPWhEeG4Wag4JBRK3A" targetNode="_Tsd14PWhEeG4Wag4JBRK3A">
-        <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.1"/>
-        <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.1"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.26"/>
-        <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.27"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
-        <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQG3MBl8EeCKOMpCHXRNLw" x="0" y="823" height="0" width="0"/>
-        <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_bhFdQegAEd-ytMWANgVcQw" size="2">
-          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
-          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_bhFdQ-gAEd-ytMWANgVcQw" red="77" green="137" blue="20"/>
-          <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_KLdSHU_mEeCYI5ZMnXmjRA" showIcon="false">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KLdSHk_mEeCYI5ZMnXmjRA"/>
-          </centerLabelStyle>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
-      </ownedDiagramElements>
-      <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
-      <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_48qywedWEd-EjZA2qI8iFQ"/>
-      <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
-      <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.5"/>
-    </ownedRepresentations>
-    <ownedRepresentations xmi:type="sequence:SequenceDDiagram" xmi:id="_W42gYOdcEd-EjZA2qI8iFQ" name="Basic Combined Fragment Diagram">
-      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_W42gZOdcEd-EjZA2qI8iFQ" source="GMF_DIAGRAMS">
-        <data xmi:type="notation:Diagram" xmi:id="_W42gZedcEd-EjZA2qI8iFQ" type="Sirius" element="_W42gYOdcEd-EjZA2qI8iFQ" measurementUnit="Pixel">
-          <children xmi:type="notation:Node" xmi:id="_W5ZS8OdcEd-EjZA2qI8iFQ" type="2001" element="_TtTjYPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_W5Z6AOdcEd-EjZA2qI8iFQ" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_W5Z6AedcEd-EjZA2qI8iFQ" y="5"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_W6LWEOdcEd-EjZA2qI8iFQ" type="3001" element="_TtaREPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_W6LWE-dcEd-EjZA2qI8iFQ" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_W6LWFOdcEd-EjZA2qI8iFQ" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_W6NLQOdcEd-EjZA2qI8iFQ" type="3003" element="_TtaREfWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_W6NLQedcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6NLQudcEd-EjZA2qI8iFQ"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_me_rME5cEeCHObKOrZ_h3Q" type="3001" element="_TtbfMPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_me_rM05cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_me_rNE5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_mfBgYE5cEeCHObKOrZ_h3Q" type="3002" element="_TtcGQPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_mfBgYU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfBgYk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_me_rMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_me_rMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_W6LWEedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6LWEudcEd-EjZA2qI8iFQ" y="42" width="10" height="400"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_W6L9IOdcEd-EjZA2qI8iFQ" type="3003" element="_TtX00PWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_W6L9IedcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6L9IudcEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_W5ZS8edcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5ZS8udcEd-EjZA2qI8iFQ" x="50" y="50" width="120" height="50"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TtES0PWhEeG4Wag4JBRK3A" name="m1" sourceNode="_TsMwIPWhEeG4Wag4JBRK3A" targetNode="_TsMwIPWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.0"/>
+      <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.0"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.7"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.8"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQGQJBl8EeCKOMpCHXRNLw" y="310" height="10"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_aZ7SEedqEd-1-6lw65J6ig" size="2" strokeColor="77,137,20">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLcrBk_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TtGIAPWhEeG4Wag4JBRK3A" name="m2" sourceNode="_TsMwIPWhEeG4Wag4JBRK3A" targetNode="_Tsd14PWhEeG4Wag4JBRK3A">
+      <target xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.1"/>
+      <semanticElements xmi:type="interactions:FeatureAccessMessage" href="fixture.interactions#//@ownedInteractions.5/@messages.1"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.26"/>
+      <semanticElements xmi:type="interactions:MessageEnd" href="fixture.interactions#//@ownedInteractions.5/@ends.27"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.5/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQG3MBl8EeCKOMpCHXRNLw" y="823" height="0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_bhFdQegAEd-ytMWANgVcQw" size="2" strokeColor="77,137,20">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KLdSHU_mEeCYI5ZMnXmjRA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:BasicMessageMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@edgeMappings[name='Feature%20Access%20Message']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_48qywedWEd-EjZA2qI8iFQ"/>
+    <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
+    <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.5"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_W42gYOdcEd-EjZA2qI8iFQ">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_W42gZOdcEd-EjZA2qI8iFQ" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_W42gZedcEd-EjZA2qI8iFQ" type="Sirius" element="_W42gYOdcEd-EjZA2qI8iFQ" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_W5ZS8OdcEd-EjZA2qI8iFQ" type="2001" element="_TtTjYPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_W5Z6AOdcEd-EjZA2qI8iFQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_W5Z6AedcEd-EjZA2qI8iFQ" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_W5Z6AudcEd-EjZA2qI8iFQ" type="2001" element="_TtZC8PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_W5Z6BedcEd-EjZA2qI8iFQ" type="5002">
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_W5Z6BudcEd-EjZA2qI8iFQ" y="5"/>
+          <children xmi:type="notation:Node" xmi:id="_W6LWEOdcEd-EjZA2qI8iFQ" type="3001" element="_TtaREPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_W6LWE-dcEd-EjZA2qI8iFQ" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_W6LWFOdcEd-EjZA2qI8iFQ" y="5"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_W6SDwOdcEd-EjZA2qI8iFQ" type="3001" element="_TtctUPWhEeG4Wag4JBRK3A">
-              <children xmi:type="notation:Node" xmi:id="_W6Sq0OdcEd-EjZA2qI8iFQ" type="5001">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_W6Sq0edcEd-EjZA2qI8iFQ" y="5"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_W6T48OdcEd-EjZA2qI8iFQ" type="3003" element="_TtctUfWhEeG4Wag4JBRK3A">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_W6T48edcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6T48udcEd-EjZA2qI8iFQ"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_mfFKwE5cEeCHObKOrZ_h3Q" type="3001" element="_Ttd7cPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_mfFx0E5cEeCHObKOrZ_h3Q" type="5001">
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_mfFx0U5cEeCHObKOrZ_h3Q" y="5"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_mfHnAE5cEeCHObKOrZ_h3Q" type="3002" element="_TteigPWhEeG4Wag4JBRK3A">
-                  <styles xmi:type="notation:ShapeStyle" xmi:id="_mfHnAU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
-                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfHnAk5cEeCHObKOrZ_h3Q"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_mfFKwU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfFKwk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_W6SDwedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6SDwudcEd-EjZA2qI8iFQ" y="42" width="10" height="400"/>
+            <children xmi:type="notation:Node" xmi:id="_W6NLQOdcEd-EjZA2qI8iFQ" type="3003" element="_TtaREfWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_W6NLQedcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6NLQudcEd-EjZA2qI8iFQ"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_W6Sq0udcEd-EjZA2qI8iFQ" type="3003" element="_TtZqAPWhEeG4Wag4JBRK3A">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_W6Sq0-dcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6Sq1OdcEd-EjZA2qI8iFQ"/>
+            <children xmi:type="notation:Node" xmi:id="_me_rME5cEeCHObKOrZ_h3Q" type="3001" element="_TtbfMPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_me_rM05cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_me_rNE5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_mfBgYE5cEeCHObKOrZ_h3Q" type="3002" element="_TtcGQPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_mfBgYU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfBgYk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_me_rMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_me_rMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
             </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_W5Z6A-dcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5Z6BOdcEd-EjZA2qI8iFQ" x="220" y="50" width="120" height="50"/>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_W6LWEedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6LWEudcEd-EjZA2qI8iFQ" y="42" width="10" height="400"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_W5ahEOdcEd-EjZA2qI8iFQ" type="2002" element="_TtgXsPWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_W5ahE-dcEd-EjZA2qI8iFQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_W5ahFOdcEd-EjZA2qI8iFQ" type="7001">
-              <children xmi:type="notation:Node" xmi:id="_W5cWQOdcEd-EjZA2qI8iFQ" type="3008" element="_TtkCEPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_W5cWQ-dcEd-EjZA2qI8iFQ" type="5005"/>
-                <children xmi:type="notation:Node" xmi:id="_W5cWROdcEd-EjZA2qI8iFQ" type="7002">
-                  <styles xmi:type="notation:SortingStyle" xmi:id="_W5cWRedcEd-EjZA2qI8iFQ"/>
-                  <styles xmi:type="notation:FilteringStyle" xmi:id="_W5cWRudcEd-EjZA2qI8iFQ"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_W5cWQedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5cWQudcEd-EjZA2qI8iFQ" y="30" width="120" height="60"/>
-              </children>
-              <styles xmi:type="notation:SortingStyle" xmi:id="_W5ahFedcEd-EjZA2qI8iFQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_W5ahFudcEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_W5ahEedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5ahEudcEd-EjZA2qI8iFQ" x="50" y="130" width="120" height="90"/>
+          <children xmi:type="notation:Node" xmi:id="_W6L9IOdcEd-EjZA2qI8iFQ" type="3003" element="_TtX00PWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_W6L9IedcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6L9IudcEd-EjZA2qI8iFQ"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_W5ahF-dcEd-EjZA2qI8iFQ" type="2002" element="_Ttiz8PWhEeG4Wag4JBRK3A">
-            <children xmi:type="notation:Node" xmi:id="_W5bIIOdcEd-EjZA2qI8iFQ" type="5006"/>
-            <children xmi:type="notation:Node" xmi:id="_W5bIIedcEd-EjZA2qI8iFQ" type="7001">
-              <children xmi:type="notation:Node" xmi:id="_W5c9UOdcEd-EjZA2qI8iFQ" type="3008" element="_TtkpIPWhEeG4Wag4JBRK3A">
-                <children xmi:type="notation:Node" xmi:id="_W5dkYOdcEd-EjZA2qI8iFQ" type="5005"/>
-                <children xmi:type="notation:Node" xmi:id="_W5dkYedcEd-EjZA2qI8iFQ" type="7002">
-                  <styles xmi:type="notation:SortingStyle" xmi:id="_W5dkYudcEd-EjZA2qI8iFQ"/>
-                  <styles xmi:type="notation:FilteringStyle" xmi:id="_W5dkY-dcEd-EjZA2qI8iFQ"/>
-                </children>
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_W5c9UedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5c9UudcEd-EjZA2qI8iFQ" y="30" width="120" height="60"/>
-              </children>
-              <styles xmi:type="notation:SortingStyle" xmi:id="_W5bIIudcEd-EjZA2qI8iFQ"/>
-              <styles xmi:type="notation:FilteringStyle" xmi:id="_W5bII-dcEd-EjZA2qI8iFQ"/>
-            </children>
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_W5ahGOdcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5ahGedcEd-EjZA2qI8iFQ" x="220" y="240" width="120" height="90"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_W5ZS8edcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5ZS8udcEd-EjZA2qI8iFQ" x="50" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_W5Z6AudcEd-EjZA2qI8iFQ" type="2001" element="_TtZC8PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_W5Z6BedcEd-EjZA2qI8iFQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_W5Z6BudcEd-EjZA2qI8iFQ" y="5"/>
           </children>
-          <styles xmi:type="notation:DiagramStyle" xmi:id="_W42gZudcEd-EjZA2qI8iFQ"/>
-        </data>
-      </ownedAnnotationEntries>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TtTjYPWhEeG4Wag4JBRK3A" name="p1 : A" width="12" height="5" resizeKind="NSEW">
+          <children xmi:type="notation:Node" xmi:id="_W6SDwOdcEd-EjZA2qI8iFQ" type="3001" element="_TtctUPWhEeG4Wag4JBRK3A">
+            <children xmi:type="notation:Node" xmi:id="_W6Sq0OdcEd-EjZA2qI8iFQ" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_W6Sq0edcEd-EjZA2qI8iFQ" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_W6T48OdcEd-EjZA2qI8iFQ" type="3003" element="_TtctUfWhEeG4Wag4JBRK3A">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_W6T48edcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6T48udcEd-EjZA2qI8iFQ"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_mfFKwE5cEeCHObKOrZ_h3Q" type="3001" element="_Ttd7cPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_mfFx0E5cEeCHObKOrZ_h3Q" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_mfFx0U5cEeCHObKOrZ_h3Q" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_mfHnAE5cEeCHObKOrZ_h3Q" type="3002" element="_TteigPWhEeG4Wag4JBRK3A">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_mfHnAU5cEeCHObKOrZ_h3Q" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfHnAk5cEeCHObKOrZ_h3Q"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_mfFKwU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfFKwk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_W6SDwedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6SDwudcEd-EjZA2qI8iFQ" y="42" width="10" height="400"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_W6Sq0udcEd-EjZA2qI8iFQ" type="3003" element="_TtZqAPWhEeG4Wag4JBRK3A">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_W6Sq0-dcEd-EjZA2qI8iFQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6Sq1OdcEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_W5Z6A-dcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="12" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5Z6BOdcEd-EjZA2qI8iFQ" x="220" y="50" width="120" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_W5ahEOdcEd-EjZA2qI8iFQ" type="2002" element="_TtgXsPWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_W5ahE-dcEd-EjZA2qI8iFQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_W5ahFOdcEd-EjZA2qI8iFQ" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_W5cWQOdcEd-EjZA2qI8iFQ" type="3008" element="_TtkCEPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_W5cWQ-dcEd-EjZA2qI8iFQ" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_W5cWROdcEd-EjZA2qI8iFQ" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_W5cWRedcEd-EjZA2qI8iFQ"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_W5cWRudcEd-EjZA2qI8iFQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_W5cWQedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5cWQudcEd-EjZA2qI8iFQ" y="30" width="120" height="60"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_W5ahFedcEd-EjZA2qI8iFQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_W5ahFudcEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_W5ahEedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5ahEudcEd-EjZA2qI8iFQ" x="50" y="130" width="120" height="90"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_W5ahF-dcEd-EjZA2qI8iFQ" type="2002" element="_Ttiz8PWhEeG4Wag4JBRK3A">
+          <children xmi:type="notation:Node" xmi:id="_W5bIIOdcEd-EjZA2qI8iFQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_W5bIIedcEd-EjZA2qI8iFQ" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_W5c9UOdcEd-EjZA2qI8iFQ" type="3008" element="_TtkpIPWhEeG4Wag4JBRK3A">
+              <children xmi:type="notation:Node" xmi:id="_W5dkYOdcEd-EjZA2qI8iFQ" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_W5dkYedcEd-EjZA2qI8iFQ" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_W5dkYudcEd-EjZA2qI8iFQ"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_W5dkY-dcEd-EjZA2qI8iFQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_W5c9UedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5c9UudcEd-EjZA2qI8iFQ" y="30" width="120" height="60"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_W5bIIudcEd-EjZA2qI8iFQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_W5bII-dcEd-EjZA2qI8iFQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_W5ahGOdcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5ahGedcEd-EjZA2qI8iFQ" x="220" y="240" width="120" height="90"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_W42gZudcEd-EjZA2qI8iFQ"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_9iqrhLm3Ee-UXMFld_STMg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_9iqrhbm3Ee-UXMFld_STMg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TtTjYPWhEeG4Wag4JBRK3A" name="p1 : A" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URIpMPWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TtaREPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URIpMPWhEeG4Wag4JBRK3A" x="50" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TtaREPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TtbfMPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TtbfMPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.0"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TtcGQPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtcGQfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtcGQvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtcGQ_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TtaREfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtaREvWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtaRE_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TtaRFPWhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TtcGQPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TtX00PWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtX00fWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtX00vWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TtX00_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TtaREfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_TtZC8PWhEeG4Wag4JBRK3A" name="p2 : B" width="12" height="5" resizeKind="NSEW">
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TtX00PWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TtZC8PWhEeG4Wag4JBRK3A" name="p2 : B" width="12" height="5" resizeKind="NSEW">
+      <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
+      <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_URIpMfWhEeG4Wag4JBRK3A" x="220" y="50" height="50" width="120"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TtctUPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
         <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
         <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_URIpMfWhEeG4Wag4JBRK3A" x="220" y="50" height="50" width="120"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_TtctUPWhEeG4Wag4JBRK3A" width="1" height="40" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Ttd7cPWhEeG4Wag4JBRK3A" width="1" height="1">
           <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
           <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
-          <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Ttd7cPWhEeG4Wag4JBRK3A" width="1" height="1">
-            <target xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
-            <semanticElements xmi:type="interactions:Participant" href="fixture.interactions#//@ownedInteractions.4/@participants.1"/>
-            <ownedStyle xmi:type="diagram:Dot" xmi:id="_TteigPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
-              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TteigfWhEeG4Wag4JBRK3A"/>
-              <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
-              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TteigvWhEeG4Wag4JBRK3A"/>
-              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Tteig_WhEeG4Wag4JBRK3A" red="136" green="136" blue="136"/>
-            </ownedStyle>
-            <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
-          </ownedBorderedNodes>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_TtctUfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" width="1" height="40">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtctUvWhEeG4Wag4JBRK3A"/>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtctU_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
-            <color xmi:type="viewpoint:RGBValues" xmi:id="_TtctVPWhEeG4Wag4JBRK3A" red="255" green="255" blue="255"/>
+          <ownedStyle xmi:type="diagram:Dot" uid="_TteigPWhEeG4Wag4JBRK3A" strokeSizeComputationExpression="1">
+            <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+          <actualMapping xmi:type="description_1:EndOfLifeMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@borderedNodeMappings[name='redimEOL']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" xmi:id="_TtZqAPWhEeG4Wag4JBRK3A" labelSize="12" labelFormat="bold" showIcon="false" labelPosition="node" width="12" height="5">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtZqAfWhEeG4Wag4JBRK3A"/>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtZqAvWhEeG4Wag4JBRK3A"/>
-          <color xmi:type="viewpoint:RGBValues" xmi:id="_TtZqA_WhEeG4Wag4JBRK3A" red="114" green="159" blue="207"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_TtctUfWhEeG4Wag4JBRK3A" showIcon="false" borderSize="3" borderSizeComputationExpression="3" borderColor="114,159,207" width="1" height="40" color="255,255,255">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
-      </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_TtgXsPWhEeG4Wag4JBRK3A" name="opt1">
-        <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0"/>
-        <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQG3MRl8EeCKOMpCHXRNLw" x="50" y="130" height="90" width="120"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_TtgXsfWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtgXsvWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtgXs_WhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtiM4PWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtiM4fWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
+        <actualMapping xmi:type="description_1:ExecutionMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@borderedNodeMappings[name='Lifeline']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_TtZqAPWhEeG4Wag4JBRK3A" labelSize="12" showIcon="false" labelPosition="node" width="12" height="5" color="114,159,207">
+        <labelFormat>bold</labelFormat>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:InstanceRoleMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@nodeMappings[name='Participant']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TtgXsPWhEeG4Wag4JBRK3A" name="opt1">
+      <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0"/>
+      <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQG3MRl8EeCKOMpCHXRNLw" x="50" y="130" height="90" width="120"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TtgXsfWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundColor="166,227,187" foregroundColor="166,227,187">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TtkCEPWhEeG4Wag4JBRK3A" name="[op1]">
+        <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0/@ownedOperands.0"/>
+        <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0/@ownedOperands.0"/>
+        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQG3Mhl8EeCKOMpCHXRNLw" x="50" y="160" height="60" width="120"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TtkCEfWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundStyle="GradientTopToBottom" backgroundColor="160,222,214" foregroundColor="160,222,214">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
-        <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_TtkCEPWhEeG4Wag4JBRK3A" name="[op1]">
-          <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0/@ownedOperands.0"/>
-          <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.0/@ownedOperands.0"/>
-          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQG3Mhl8EeCKOMpCHXRNLw" x="50" y="160" height="60" width="120"/>
-          <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_TtkCEfWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkCEvWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkCE_WhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkCFPWhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkCFfWhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
-        </ownedDiagramElements>
+        <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_Ttiz8PWhEeG4Wag4JBRK3A" name="opt2">
-        <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1"/>
-        <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1"/>
-        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQG3Mxl8EeCKOMpCHXRNLw" x="220" y="240" height="90" width="120"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Ttiz8fWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
-          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Ttiz8vWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
-          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_Ttiz8_WhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtjbAPWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
-          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtjbAfWhEeG4Wag4JBRK3A" red="166" green="227" blue="187"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ttiz8PWhEeG4Wag4JBRK3A" name="opt2">
+      <target xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1"/>
+      <semanticElements xmi:type="interactions:CombinedFragment" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQG3Mxl8EeCKOMpCHXRNLw" x="220" y="240" height="90" width="120"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ttiz8fWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundColor="166,227,187" foregroundColor="166,227,187">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TtkpIPWhEeG4Wag4JBRK3A" name="[op2]">
+        <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1/@ownedOperands.0"/>
+        <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1/@ownedOperands.0"/>
+        <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQG3NBl8EeCKOMpCHXRNLw" x="220" y="270" height="60" width="120"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TtkpIfWhEeG4Wag4JBRK3A" showIcon="false" labelColor="11,16,140" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="22,147,165" backgroundStyle="GradientTopToBottom" backgroundColor="160,222,214" foregroundColor="160,222,214">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:CombinedFragmentMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']"/>
-        <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_TtkpIPWhEeG4Wag4JBRK3A" name="[op2]">
-          <target xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1/@ownedOperands.0"/>
-          <semanticElements xmi:type="interactions:Operand" href="fixture.interactions#//@ownedInteractions.4/@combinedFragments.1/@ownedOperands.0"/>
-          <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" xmi:id="_MQG3NBl8EeCKOMpCHXRNLw" x="220" y="270" height="60" width="120"/>
-          <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_TtkpIfWhEeG4Wag4JBRK3A" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="GradientTopToBottom">
-            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkpIvWhEeG4Wag4JBRK3A" red="11" green="16" blue="140"/>
-            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']/@style"/>
-            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkpI_WhEeG4Wag4JBRK3A" red="22" green="147" blue="165"/>
-            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkpJPWhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_TtkpJfWhEeG4Wag4JBRK3A" red="160" green="222" blue="214"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
-        </ownedDiagramElements>
+        <actualMapping xmi:type="description_1:OperandMapping" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Combined%20Fragment']/@subContainerMappings[name='Operand']"/>
       </ownedDiagramElements>
-      <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
-      <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_W42gYedcEd-EjZA2qI8iFQ"/>
-      <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
-      <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
-    </ownedRepresentations>
-    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']"/>
-  </ownedViews>
-</viewpoint:DAnalysis>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_W42gYedcEd-EjZA2qI8iFQ"/>
+    <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer"/>
+    <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
+  </sequence:SequenceDDiagram>
+</xmi:XMI>

--- a/plugins/org.eclipse.sirius.tests.swtbot/data/unit/sequence/navigation/fixture.aird
+++ b/plugins/org.eclipse.sirius.tests.swtbot/data/unit/sequence/navigation/fixture.aird
@@ -5,27 +5,27 @@
     <semanticResources>types.ecore</semanticResources>
     <ownedViews xmi:type="viewpoint:DView" uid="_9W1N8N2zEd-ZhcM4sDvRBQ">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ig6hLm3Ee-UXMFld_STMg" name="Basic Messages Diagram" repPath="#_-pfIoN2zEd-ZhcM4sDvRBQ" changeId="1734138523195">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ig6hLm3Ee-UXMFld_STMg" name="Basic Messages Diagram" repPath="#_-pfIoN2zEd-ZhcM4sDvRBQ" changeId="1734139269208">
         <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
         <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.0"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ioPRLm3Ee-UXMFld_STMg" name="Basic Executions Diagram" repPath="#_OHyPgN6tEd-_dMn5_cB9Xw" changeId="1734138523195">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ioPRLm3Ee-UXMFld_STMg" name="Basic Executions Diagram" repPath="#_OHyPgN6tEd-_dMn5_cB9Xw" changeId="1734139267545">
         <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
         <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.1"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ioPSbm3Ee-UXMFld_STMg" name="Complex" repPath="#_Fni5MOUCEd-BEJhxHErs5g" changeId="1734138523195">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9ioPSbm3Ee-UXMFld_STMg" name="Complex" repPath="#_Fni5MOUCEd-BEJhxHErs5g" changeId="1734139270405">
         <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
         <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.2"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2VLm3Ee-UXMFld_STMg" name="Basic Interaction Use Diagram" repPath="#_3c2zYOc2Ed-ci9l1AsdpKw" changeId="1734138523195">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2VLm3Ee-UXMFld_STMg" name="Basic Interaction Use Diagram" repPath="#_3c2zYOc2Ed-ci9l1AsdpKw" changeId="1734139268342">
         <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
         <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.3"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2Wbm3Ee-UXMFld_STMg" name="Complex with CF" repPath="#_48qywOdWEd-EjZA2qI8iFQ" changeId="1734138523195">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2Wbm3Ee-UXMFld_STMg" name="Complex with CF" repPath="#_48qywOdWEd-EjZA2qI8iFQ" changeId="1734139271242">
         <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
         <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.5"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2Xrm3Ee-UXMFld_STMg" name="Basic Combined Fragment Diagram" repPath="#_W42gYOdcEd-EjZA2qI8iFQ" changeId="1734138523195">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_9io2Xrm3Ee-UXMFld_STMg" name="Basic Combined Fragment Diagram" repPath="#_W42gYOdcEd-EjZA2qI8iFQ" changeId="1734139265891">
         <description xmi:type="description_1:SequenceDiagramDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']"/>
         <target xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
       </ownedRepresentationDescriptors>
@@ -55,7 +55,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIsIck5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_nIqTQU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIqTQk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIqTQk5cEeCHObKOrZ_h3Q" x="2" y="510" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_-8Rhwd2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8Rhwt2zEd-ZhcM4sDvRBQ" y="42" width="10" height="510"/>
@@ -88,7 +88,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIxA8k5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_nIvy0U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIvy0k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nIvy0k5cEeCHObKOrZ_h3Q" x="2" y="510" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_-9Bvsd2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9Bvst2zEd-ZhcM4sDvRBQ" y="42" width="10" height="510"/>
@@ -121,7 +121,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nI2ggk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_nI0rUU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nI0rUk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nI0rUk5cEeCHObKOrZ_h3Q" x="2" y="510" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_-9RnUN2zEd-ZhcM4sDvRBQ" fontName="Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-9RnUd2zEd-ZhcM4sDvRBQ" x="52" y="42" width="10" height="510"/>
@@ -557,7 +557,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msJWYk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_msHhMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msHhMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msHhMk5cEeCHObKOrZ_h3Q" x="2" y="548" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_OI638d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OI638t6tEd-_dMn5_cB9Xw" y="42" width="10" height="548"/>
@@ -667,7 +667,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msQEEk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_msOO4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msOO4k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_msOO4k5cEeCHObKOrZ_h3Q" x="2" y="548" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_OJEB4d6tEd-_dMn5_cB9Xw" fontName="DejaVu Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJEB4t6tEd-_dMn5_cB9Xw" y="42" width="10" height="548"/>
@@ -909,7 +909,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdYX4k5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_bdRqMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdRqMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdRqMk5cEeCHObKOrZ_h3Q" x="2" y="650" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_GwPmoeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GwPmouUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
@@ -975,7 +975,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdklIk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_bdiI4U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdiI4k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdiI4k5cEeCHObKOrZ_h3Q" x="2" y="650" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_H8BdQeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_H8BdQuUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
@@ -1030,7 +1030,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdsg8k5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_bdqEsU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdqEsk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdqEsk5cEeCHObKOrZ_h3Q" x="2" y="650" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_IzTDgeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IzTDguUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
@@ -1085,7 +1085,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bd0cwk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_bdyAgU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdyAgk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bdyAgk5cEeCHObKOrZ_h3Q" x="2" y="650" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_KCI1MeUCEd-BEJhxHErs5g" fontName="DejaVu Sans" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KCI1MuUCEd-BEJhxHErs5g" y="42" width="10" height="650"/>
@@ -1981,7 +1981,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3PzIk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_m3N98U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3N98k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3N98k5cEeCHObKOrZ_h3Q" x="2" y="400" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_3jCT4ec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jCT4uc2Ed-ci9l1AsdpKw" y="42" width="10" height="400"/>
@@ -2014,7 +2014,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3V5wk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_m3UEkU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3UEkk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m3UEkk5cEeCHObKOrZ_h3Q" x="2" y="400" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_3jvegec2Ed-ci9l1AsdpKw" fontName="Segoe UI" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jveguc2Ed-ci9l1AsdpKw" y="42" width="10" height="400"/>
@@ -2105,7 +2105,6 @@
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TraF8PWhEeG4Wag4JBRK3A" name="ref1">
       <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.0"/>
       <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.0"/>
-      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
       <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQEa8hl8EeCKOMpCHXRNLw" x="50" y="130" height="50" width="120"/>
       <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TrciMPWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
@@ -2115,7 +2114,6 @@
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TrjP4PWhEeG4Wag4JBRK3A" name="ref2">
       <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.1"/>
       <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.3/@interactionUses.1"/>
-      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
       <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQEa8xl8EeCKOMpCHXRNLw" x="220" y="200" height="50" width="120"/>
       <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TrjP4fWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
@@ -2184,7 +2182,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyCAYk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_nyALMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyALMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyALMk5cEeCHObKOrZ_h3Q" x="2" y="773" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_5AHIUedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AHIUudWEd-EjZA2qI8iFQ" y="42" width="10" height="773"/>
@@ -2250,7 +2248,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyIHAk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_nyGR0U5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyGR0k5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyGR0k5cEeCHObKOrZ_h3Q" x="2" y="773" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_5AaDQedWEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5AaDQudWEd-EjZA2qI8iFQ" y="42" width="10" height="773"/>
@@ -2490,7 +2488,6 @@
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TsxX4PWhEeG4Wag4JBRK3A" name="ref1">
       <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.0"/>
       <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.0"/>
-      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
       <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpExl8EeCKOMpCHXRNLw" x="60" y="150" height="50" width="310"/>
       <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Tsx-8PWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
@@ -2500,7 +2497,6 @@
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Tsz0IPWhEeG4Wag4JBRK3A" name="ref2">
       <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.1"/>
       <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.1"/>
-      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.4"/>
       <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQFpFBl8EeCKOMpCHXRNLw" x="60" y="520" height="50" width="310"/>
       <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Tsz0IfWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
@@ -2510,7 +2506,6 @@
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ts0bMPWhEeG4Wag4JBRK3A" name="ref.3">
       <target xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.2"/>
       <semanticElements xmi:type="interactions:InteractionUse" href="fixture.interactions#//@ownedInteractions.5/@interactionUses.2"/>
-      <semanticElements xmi:type="interactions:Interaction" href="fixture.interactions#//@ownedInteractions.5"/>
       <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_MQGQIxl8EeCKOMpCHXRNLw" x="250" y="704" height="84" width="120"/>
       <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ts0bMfWhEeG4Wag4JBRK3A" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.sirius.sample.interactions.design/description/interaction.odesign#//@ownedViewpoints[name='Interactions']/@ownedRepresentations[name='Sequence%20Diagram%20on%20Interaction']/@defaultLayer/@containerMappings[name='Interaction%20Use']/@style"/>
@@ -2609,7 +2604,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfBgYk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_me_rMU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_me_rMk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_me_rMk5cEeCHObKOrZ_h3Q" x="2" y="400" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_W6LWEedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6LWEudcEd-EjZA2qI8iFQ" y="42" width="10" height="400"/>
@@ -2642,7 +2637,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfHnAk5cEeCHObKOrZ_h3Q"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_mfFKwU5cEeCHObKOrZ_h3Q" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfFKwk5cEeCHObKOrZ_h3Q" x="2" width="10" height="10"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mfFKwk5cEeCHObKOrZ_h3Q" x="2" y="400" width="10" height="10"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_W6SDwedcEd-EjZA2qI8iFQ" fontName="Segoe UI" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W6SDwudcEd-EjZA2qI8iFQ" y="42" width="10" height="400"/>


### PR DESCRIPTION
This PR rework the layout computation for InteractionContainer and handle additional cases
- When a group of execution is present on the right lifeline, the depth of excution and their width is taken into account to compute the InteractionContainer width 
![image](https://github.com/user-attachments/assets/7898bb9d-ebad-415b-b774-2caf935abeeb)

- The vertical layout of InteractionContainer has also been reworked to be based on the currently computed "future range" of lifelines and add the current margin:
![image](https://github.com/user-attachments/assets/134ab4de-834a-457c-9895-6d60504ab30e)

----
Edit : this last part has been removed from this PR
- The InteractionContainer is not always placed at (0,0) but follows the moves of the first left InstanceRole:
![image](https://github.com/user-attachments/assets/fcfc249c-5302-432d-9da9-701dd2443c2b)
This makes the reset Origin works in standard way, the arrange all too. It also gve the possibility to the user to easily select the diagram background to get the "diagram" tabbar

