### PR TITLE
[536] Fix Execution resize/move operations 

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/tool/internal/edit/validator/ISEComplexMoveValidator.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/tool/internal/edit/validator/ISEComplexMoveValidator.java
@@ -467,6 +467,13 @@ public class ISEComplexMoveValidator extends AbstractSequenceInteractionValidato
         toIgnore.addAll(endReflexiveMessageToResize);
 
         boolean canChildOccupy = movedElements.contains(insertionParent) || insertionParent.canChildOccupy(ise, futureExtRange, toIgnore, lifelines);
+
+        if (insertionParent.getLifeline().some() //
+                && insertionParent.getLifeline().get().getCreationMessage().some() //
+                && (insertionParent.getLifeline().get().getDestructionMessage().some())) {
+            canChildOccupy = canChildOccupy || movedElements.contains(insertionParent.getLifeline().get().getCreationMessage().get())
+                    && movedElements.contains(insertionParent.getLifeline().get().getDestructionMessage().get());
+        }
         if (!canChildOccupy) {
             if (topLevel && !expansionZone.isEmpty()) {
                 expansionZone = globalMovedRange;

--- a/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/tool/internal/validation/description/constraints/UniqueInteractionContainerMappingConstraints.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/tool/internal/validation/description/constraints/UniqueInteractionContainerMappingConstraints.java
@@ -51,7 +51,10 @@ public class UniqueInteractionContainerMappingConstraints extends AbstractModelC
         Collection<Layer> layersToInspect = new LinkedHashSet<>();
 
         if (eObj instanceof SequenceDiagramDescription sequenceDiagramDescription) {
-            layersToInspect.add(sequenceDiagramDescription.getDefaultLayer());
+            Layer defaultLayer = sequenceDiagramDescription.getDefaultLayer();
+            if (defaultLayer != null) {
+                layersToInspect.add(defaultLayer);
+            }
             layersToInspect.addAll(sequenceDiagramDescription.getAdditionalLayers());
         } else if (eObj instanceof Layer layer) {
             layersToInspect.add(layer);

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/AbstractDefaultModelSequenceTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/AbstractDefaultModelSequenceTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,18 @@
  *******************************************************************************/
 package org.eclipse.sirius.tests.swtbot.sequence;
 
+import java.util.List;
+
+import org.eclipse.sirius.diagram.sequence.ui.tool.internal.edit.part.ObservationPointEditPart;
 import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.ext.base.Options;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.OperationDoneCondition;
+import org.eclipse.sirius.tests.swtbot.support.api.view.SiriusOutlineView;
+import org.eclipse.sirius.tests.swtbot.support.utils.SWTBotUtils;
 import org.eclipse.sirius.tests.unit.diagram.sequence.InteractionsConstants;
+import org.eclipse.swtbot.eclipse.gef.finder.matchers.IsInstanceOf;
+import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
+import org.eclipse.swtbot.swt.finder.waits.ICondition;
 
 /**
  * Abstract test class for simple sequence diagrams.
@@ -41,14 +50,17 @@ public abstract class AbstractDefaultModelSequenceTests extends AbstractSequence
         return PATH;
     }
 
+    @Override
     protected String getSemanticModel() {
         return MODEL;
     }
 
+    @Override
     protected String getTypesSemanticModel() {
         return TYPES_FILE;
     }
 
+    @Override
     protected String getSessionModel() {
         return SESSION_FILE;
     }
@@ -67,5 +79,17 @@ public abstract class AbstractDefaultModelSequenceTests extends AbstractSequence
     @Override
     protected Option<String> getDRepresentationName() {
         return Options.newSome(REPRESENTATION_NAME);
+    }
+
+    protected void changeDurationLayerActivation() {
+        ICondition done = new OperationDoneCondition();
+        final SiriusOutlineView outlineView = designerViews.openOutlineView();
+        outlineView.layers().activateLayer("Duration Constraints");
+        bot.waitUntil(done);
+        SWTBotUtils.waitAllUiEvents();
+    }
+
+    protected List<SWTBotGefEditPart> getObservationPoints() {
+        return editor.mainEditPart().descendants(IsInstanceOf.instanceOf(ObservationPointEditPart.class));
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/AbstractSequenceDiagramTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/AbstractSequenceDiagramTestCase.java
@@ -467,6 +467,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
         ICondition done = new CheckToolIsActivated(editor, toolName);
         editor.activateTool(toolName);
         bot.waitUntil(done);
+
         editor.click(sourceX, sourceY);
         editor.click(targetX, targetY);
     }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/AbstractSequenceDiagramTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/AbstractSequenceDiagramTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -90,8 +90,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
 /**
- * Abstract base class for SWTbot tests on Sequence Diagram, with helper
- * methods.
+ * Abstract base class for SWTbot tests on Sequence Diagram, with helper methods.
  * 
  * @author pcdavid
  */
@@ -121,7 +120,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     protected static final String LIFELINE_D = "d : D";
 
     protected static final String LIFELINE_E = "e : E";
-    
+
     protected static final String LIFELINE_1 = "newParticipant1 : ";
 
     protected static final String NEW_LIFELINE = "newParticipant4 : ";
@@ -324,19 +323,16 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     protected abstract String getRepresentationId();
 
     /**
-     * Get the full name of the representation id displayed in the category
-     * subtree of the model content view.
+     * Get the full name of the representation id displayed in the category subtree of the model content view.
      * 
-     * @return the full name of the representation id displayed in the category
-     *         subtree of the model content view
+     * @return the full name of the representation id displayed in the category subtree of the model content view
      */
     protected String getRepresentationIdNameFromCategoryView() {
         return REPRESENTATION_DESCRIPTION_NAME + " " + getRepresentationId();
     }
 
     /**
-     * Get the representation (diagram.DDiagram) name as defined in the .aird
-     * model.
+     * Get the representation (diagram.DDiagram) name as defined in the .aird model.
      * 
      * @return the representation name as defined in the .aird model
      */
@@ -454,8 +450,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a message of type toolName from (sourceX, sourceY) to (targetX,
-     * targetY)
+     * Create a message of type toolName from (sourceX, sourceY) to (targetX, targetY)
      * 
      * @param toolName
      *            id of the tool
@@ -477,8 +472,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a message of type toolName from (sourceX, sourceY) to (targetX,
-     * targetY)
+     * Create a message of type toolName from (sourceX, sourceY) to (targetX, targetY)
      * 
      * @param toolName
      *            id of the tool
@@ -492,8 +486,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a new InteractionUse where its top left corner is start is its
-     * bottom right corner is finish
+     * Create a new InteractionUse where its top left corner is start is its bottom right corner is finish
      * 
      * @param start
      *            {@link Point} of the first click
@@ -554,8 +547,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a new InteractionUse where its top left corner is start is its
-     * bottom right corner is finish
+     * Create a new InteractionUse where its top left corner is start is its bottom right corner is finish
      * 
      * @param start
      *            {@link Point} of the first click
@@ -595,8 +587,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a new CombinedFragment where its top left corner is start is its
-     * bottom right corner is finish
+     * Create a new CombinedFragment where its top left corner is start is its bottom right corner is finish
      * 
      * @param start
      *            {@link Point} of the first click
@@ -618,8 +609,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a new CombinedFragment where its top left corner is start is its
-     * bottom right corner is finish
+     * Create a new CombinedFragment where its top left corner is start is its bottom right corner is finish
      * 
      * @param start
      *            {@link Point} of the first click
@@ -669,8 +659,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a new CombinedFragment's Operand where its top left corner is
-     * start is its bottom right corner is finish
+     * Create a new CombinedFragment's Operand where its top left corner is start is its bottom right corner is finish
      * 
      * @param start
      *            {@link Point} of the first click
@@ -693,8 +682,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a new CombinedFragment's Operand where its top left corner is
-     * start is its bottom right corner is finish
+     * Create a new CombinedFragment's Operand where its top left corner is start is its bottom right corner is finish
      * 
      * @param start
      *            {@link Point} of the first click
@@ -815,8 +803,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Create a new {@link InstanceRoleEditPart}'s figure named name and drop it
-     * to the specified location
+     * Create a new {@link InstanceRoleEditPart}'s figure named name and drop it to the specified location
      * 
      * @param name
      *            name of the newly created InstanceRole
@@ -1146,8 +1133,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Get the {@link SequenceDiagram} associated to the current editor. Asserts
-     * checks thaht it is not null.
+     * Get the {@link SequenceDiagram} associated to the current editor. Asserts checks thaht it is not null.
      * 
      * @return the {@link SequenceDiagram} associated to the current editor.
      */
@@ -1484,8 +1470,8 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
     }
 
     /**
-     * Returns the bounds of the first edit part with requested name, relative
-     * to screen or logical regarding the screen parameter.
+     * Returns the bounds of the first edit part with requested name, relative to screen or logical regarding the screen
+     * parameter.
      * 
      * @param name
      *            name of the edit part.
@@ -1591,7 +1577,7 @@ public abstract class AbstractSequenceDiagramTestCase extends AbstractSiriusSwtB
         filterTable.click(0, 0);
         bot.waitUntil(done);
     }
-    
+
     @Override
     protected void manualRefresh() {
         // Do nothing, sequence diagrams only work in auto-refresh mode anyway.

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/ObservationPointTests.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/ObservationPointTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -47,8 +47,6 @@ import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentat
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckSelectedCondition;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.CheckToolIsActivated;
 import org.eclipse.sirius.tests.swtbot.support.api.condition.OperationDoneCondition;
-import org.eclipse.sirius.tests.swtbot.support.api.view.SiriusOutlineView;
-import org.eclipse.sirius.tests.swtbot.support.utils.SWTBotUtils;
 import org.eclipse.sirius.ui.business.api.dialect.DialectEditor;
 import org.eclipse.sirius.viewpoint.DRepresentationElement;
 import org.eclipse.swtbot.eclipse.gef.finder.matchers.IsInstanceOf;
@@ -66,9 +64,8 @@ import com.google.common.collect.Lists;
 /**
  * This class tests the ObservationPoint concept of Sequence dagrams.
  * 
- * An observation point is a node with an ObservationPointMapping and a semantic
- * target which belongs to the semantic global ordering. On the interaction
- * sample, it is displayed when the "Constraint" layer is active. It allows to
+ * An observation point is a node with an ObservationPointMapping and a semantic target which belongs to the semantic
+ * global ordering. On the interaction sample, it is displayed when the "Constraint" layer is active. It allows to
  * create/display constraints as edges with a bracket style.
  * 
  * @author mporhel
@@ -76,6 +73,7 @@ import com.google.common.collect.Lists;
 public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
 
     private final Predicate<DDiagramElement> isVisible = new Predicate<DDiagramElement>() {
+        @Override
         public boolean apply(DDiagramElement input) {
             return input.isVisible();
         }
@@ -86,18 +84,16 @@ public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
     private final Predicate<DDiagramElement> isNonVisibleObsPoint = Predicates.and(ObservationPoint.viewpointElementPredicate(), Predicates.not(isVisible));
 
     /**
-     * Test the activation of the observation layer. It should trigger the
-     * creation of observation points. They should be placed by the sequence
-     * layout.
+     * Test the activation of the observation layer. It should trigger the creation of observation points. They should
+     * be placed by the sequence layout.
      */
     public void test_ObservationPointLayer_Activation() {
         doTest_ObservationPoint_Layer_Activation(ZoomLevel.ZOOM_100.getAmount());
     }
 
     /**
-     * Test the activation of the observation layer. It should trigger the
-     * creation of observation points. They should be placed by the sequence
-     * layout.
+     * Test the activation of the observation layer. It should trigger the creation of observation points. They should
+     * be placed by the sequence layout.
      */
     public void test_ObservationPointLayer_Activation_Zoom50() {
         try {
@@ -142,8 +138,8 @@ public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
         bot.waitUntil(done);
 
         // Validates the position of the execution
-        Rectangle execA0ScreenBounds = assertExecutionHasValidScreenBounds(LIFELINE_A, 0, new Rectangle(0, yScreenExecA0, LayoutConstants.DEFAULT_EXECUTION_WIDTH,
-                (int) (LayoutConstants.DEFAULT_EXECUTION_HEIGHT * zoom)), false);
+        Rectangle execA0ScreenBounds = assertExecutionHasValidScreenBounds(LIFELINE_A, 0,
+                new Rectangle(0, yScreenExecA0, LayoutConstants.DEFAULT_EXECUTION_WIDTH, (int) (LayoutConstants.DEFAULT_EXECUTION_HEIGHT * zoom)), false);
 
         // Creation of an execution
         int yExecA1 = execA0ScreenBounds.getCenter().y;
@@ -174,9 +170,8 @@ public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
     }
 
     /**
-     * Test the creation of events once when the observation layer is active.
-     * Each creation should trigger the creation of observation points. They
-     * should be placed by the sequence layout.
+     * Test the creation of events once when the observation layer is active. Each creation should trigger the creation
+     * of observation points. They should be placed by the sequence layout.
      */
     public void test_Creation_With_Activated_Layer() {
         // Activate Observation layer
@@ -207,7 +202,7 @@ public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
         // try to move the first observation point.
         SWTBotGefEditPart observationPoint = getObservationPoints().get(0);
         Rectangle beforeDrag = getBounds((IGraphicalEditPart) observationPoint.part());
-        ICondition selected = new CheckSelectedCondition(editor, (IGraphicalEditPart) observationPoint.part());
+        ICondition selected = new CheckSelectedCondition(editor, observationPoint.part());
         editor.drag(observationPoint, new Point(getLifelineScreenX(LIFELINE_B), 250));
         bot.waitUntil(selected);
 
@@ -566,19 +561,17 @@ public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
      * Try to change the observation layer status.
      * 
      * @param activationExpected
-     *            true if the method should activate the observation layer,
-     *            false otherwise
+     *            true if the method should activate the observation layer, false otherwise
      * @param expectedObservationPoints
-     *            the number of expected observation points, if true, they
-     *            should be visible, if false they should exists on the
-     *            viewpoint side, but the should be no edit part.
+     *            the number of expected observation points, if true, they should be visible, if false they should
+     *            exists on the viewpoint side, but the should be no edit part.
      * 
      */
     private void changeAndCheckObservationLayerActivation(boolean activationExpected, int expectedObservationPoints) {
         DDiagram diagram = (DDiagram) ((DialectEditor) editor.getReference().getEditor(false)).getRepresentation();
         int prevActivatedLayers = diagram.getActivatedLayers().size();
 
-        changeLostMessagesLayerActivation();
+        changeDurationLayerActivation();
 
         // Check activation/deactivation
         int postActivatedLayers = diagram.getActivatedLayers().size();
@@ -597,20 +590,9 @@ public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
         }
     }
 
-    private void changeLostMessagesLayerActivation() {
-        ICondition done = new OperationDoneCondition();
-        final SiriusOutlineView outlineView = designerViews.openOutlineView();
-        outlineView.layers().activateLayer("Duration Constraints");
-        bot.waitUntil(done);
-        SWTBotUtils.waitAllUiEvents();
-    }
-
-    private List<SWTBotGefEditPart> getObservationPoints() {
-        return editor.mainEditPart().descendants(IsInstanceOf.instanceOf(ObservationPointEditPart.class));
-    }
-
     private List<ObservationPointEditPart> getSortedObservationParts() {
         Function<SWTBotGefEditPart, EditPart> getPart = new Function<SWTBotGefEditPart, EditPart>() {
+            @Override
             public EditPart apply(SWTBotGefEditPart input) {
                 return input.part();
             }
@@ -623,6 +605,7 @@ public class ObservationPointTests extends AbstractDefaultModelSequenceTests {
             /**
              * {@inheritDoc}
              */
+            @Override
             public int compare(ObservationPointEditPart o1, ObservationPointEditPart o2) {
                 int y1 = o1.getFigure().getBounds().y;
                 int y2 = o2.getFigure().getBounds().y;

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/SequenceExecutionBasicAndReturnMessageObervationPointDisplayedTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/SequenceExecutionBasicAndReturnMessageObervationPointDisplayedTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.tests.swtbot.sequence;
+
+import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.ui.business.api.dialect.DialectEditor;
+
+/**
+ * Test class for creation message management
+ * 
+ * @author smonnier
+ */
+public class SequenceExecutionBasicAndReturnMessageObervationPointDisplayedTest extends SequenceExecutionBasicAndReturnMessageTest {
+
+    @Override
+    protected void onSetUpAfterOpeningDesignerPerspective() throws Exception {
+        super.onSetUpAfterOpeningDesignerPerspective();
+
+        DDiagram diagram = (DDiagram) ((DialectEditor) editor.getReference().getEditor(false)).getRepresentation();
+        int prevActivatedLayers = diagram.getActivatedLayers().size();
+
+        changeDurationLayerActivation();
+
+        // Check activation/deactivation
+        int postActivatedLayers = diagram.getActivatedLayers().size();
+        int delta = postActivatedLayers - prevActivatedLayers;
+        assertTrue("Observation layer was not activated.", delta == 1);
+    }
+}

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/SequenceExecutionBasicAndReturnMessageTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/SequenceExecutionBasicAndReturnMessageTest.java
@@ -417,6 +417,68 @@ public class SequenceExecutionBasicAndReturnMessageTest extends AbstractDefaultM
 
         validateOrdering();
 
+        // Create two sync call to test redirect of basic message while resizing executions
+        // Sync call are needed to resize executions via their messages as observation points will prevent SWT Bot to be
+        // able to resize the execution from its edit part.
+        Point m1Right = getSequenceMessageLastBendpointScreenPosition(FIRST_MESSAGE);
+        Point syncCall1ExecStart = m1.getTranslated(0, -80);
+        Point syncCall2ExecStart = new Point(getLifelineScreenX(LIFELINE_A), returnMessageNewPosition + 20);
+
+        createSyncCall(m1Right.getTranslated(0, -80), syncCall1ExecStart);
+        createSyncCall(new Point(getLifelineScreenX(LIFELINE_B), returnMessageNewPosition + 20), syncCall2ExecStart);
+
+        Rectangle sync1Bounds = getExecutionScreenBounds(LIFELINE_A, 0);
+        sync1Bounds.y = syncCall1ExecStart.y;
+        sync1Bounds.height = 50;
+        Rectangle sync2Bounds = getExecutionScreenBounds(LIFELINE_A, 3);
+        sync2Bounds.y = syncCall2ExecStart.y;
+        sync2Bounds.height = 50;
+
+        // Check stability
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 2, sync1Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 0, e1Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 1, e2Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 3, sync2Bounds);
+
+        assertMessageVerticalPosition(FIRST_MESSAGE, m1.y);
+        assertMessageVerticalPosition(THIRD_MESSAGE, m3.y);
+        assertMessageVerticalPosition(FOURTH_MESSAGE, m4.y);
+        assertMessageVerticalPosition(secondReturnMessage, return2yClic);
+        assertMessageVerticalPosition(thirdReturnMessage, return3yClic);
+        assertMessageVerticalPosition(firstReturnMessage, returnMessageNewPosition);
+
+        validateOrdering();
+
+        done = new OperationDoneCondition();
+        editor.drag(syncCall1ExecStart.getTranslated(50, 50), syncCall2ExecStart.getTranslated(50, 60));
+        bot.waitUntil(done);
+        done = new OperationDoneCondition();
+        editor.drag(syncCall2ExecStart.getTranslated(50, 0), syncCall1ExecStart.getTranslated(50, 10));
+        bot.waitUntil(done);
+        done = new OperationDoneCondition();
+
+        sync1Bounds.setBottom(sync2Bounds.bottom() + 10);
+        sync2Bounds.shrinkTop(sync1Bounds.y + 10 - sync2Bounds.y);
+
+        sync2Bounds.setX(sync1Bounds.right() - 5);
+        e1Bounds.setX(sync2Bounds.right() - 5);
+        e2Bounds.setX(e1Bounds.right() - 5);
+
+        // Check stability
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 0, sync1Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 1, sync2Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 2, e1Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 3, e2Bounds);
+
+        assertMessageVerticalPosition(FIRST_MESSAGE, m1.y);
+        assertMessageVerticalPosition(THIRD_MESSAGE, m3.y);
+        assertMessageVerticalPosition(FOURTH_MESSAGE, m4.y);
+        assertMessageVerticalPosition(secondReturnMessage, return2yClic);
+        assertMessageVerticalPosition(thirdReturnMessage, return3yClic);
+        assertMessageVerticalPosition(firstReturnMessage, returnMessageNewPosition);
+
+        validateOrdering();
+
     }
 
     /**

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/SequenceExecutionBasicAndReturnMessageTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/sequence/SequenceExecutionBasicAndReturnMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,9 @@ import org.eclipse.sirius.diagram.sequence.business.internal.layout.LayoutConsta
 import org.eclipse.sirius.diagram.sequence.ui.tool.internal.edit.part.SequenceMessageEditPart;
 import org.eclipse.sirius.tests.swtbot.sequence.condition.CheckNotEmptySelection;
 import org.eclipse.sirius.tests.swtbot.sequence.condition.CheckReturnMessageNumber;
+import org.eclipse.sirius.tests.swtbot.support.api.condition.OperationDoneCondition;
 import org.eclipse.sirius.tests.unit.diagram.sequence.InteractionsConstants;
+import org.eclipse.swtbot.swt.finder.waits.ICondition;
 
 /**
  * Test class for creation message management
@@ -142,7 +144,7 @@ public class SequenceExecutionBasicAndReturnMessageTest extends AbstractDefaultM
         return2yClic = execA1.y + LayoutConstants.MIN_INTER_SEQUENCE_EVENTS_VERTICAL_GAP;
         createMessage(InteractionsConstants.RETURN_TOOL_ID, execA1.x, return2yClic, lifelineBPosition, 300);
         bot.waitUntil(checker);
-        editor.click(execA1.x + 25, return2yClic);
+        editor.click(execA1.x + 35, return2yClic);
         bot.waitUntil(new CheckNotEmptySelection(editor, SequenceMessageEditPart.class));
         secondReturnMessage = getSelectedMessage();
         editor.click(0, 0);
@@ -161,7 +163,7 @@ public class SequenceExecutionBasicAndReturnMessageTest extends AbstractDefaultM
         return3yClic = execA1.y + LayoutConstants.MIN_INTER_SEQUENCE_EVENTS_VERTICAL_GAP * 2;
         createMessage(InteractionsConstants.RETURN_TOOL_ID, lifelineBPosition, return3yClic, execA1.x, return3yClic);
         bot.waitUntil(checker);
-        editor.click(execA1.x + 25, return3yClic);
+        editor.click(execA1.x + 35, return3yClic);
         bot.waitUntil(new CheckNotEmptySelection(editor, SequenceMessageEditPart.class));
         thirdReturnMessage = getSelectedMessage();
         editor.click(0, 0);
@@ -179,6 +181,7 @@ public class SequenceExecutionBasicAndReturnMessageTest extends AbstractDefaultM
         assertMessageVerticalPosition(thirdReturnMessage, return3yClic);
 
         validateOrdering(16);
+
     }
 
     /**
@@ -367,6 +370,53 @@ public class SequenceExecutionBasicAndReturnMessageTest extends AbstractDefaultM
         assertMessageVerticalPosition(firstReturnMessage, return1yClic);
 
         validateOrdering();
+
+        ICondition done = new OperationDoneCondition();
+        editor.drag(e1Bounds.getLocation(), e1Bounds.getLocation().getTranslated(0, -20));
+        bot.waitUntil(done);
+        done = new OperationDoneCondition();
+        editor.drag(e1Bounds.getLocation().getTranslated(0, -20), e1Bounds.getLocation().getTranslated(0, +20));
+        bot.waitUntil(done);
+        done = new OperationDoneCondition();
+        editor.drag(e1Bounds.getLocation().getTranslated(0, +20), e1Bounds.getLocation());
+        bot.waitUntil(done);
+
+        m1.y = m1.y + 20;
+        int returnMessageNewPosition = return1yClic - 20;
+
+        // Check stability
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 0, e1Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 1, e2Bounds);
+
+        assertMessageVerticalPosition(FIRST_MESSAGE, m1.y);
+        assertMessageVerticalPosition(THIRD_MESSAGE, m3.y);
+        assertMessageVerticalPosition(FOURTH_MESSAGE, m4.y);
+        assertMessageVerticalPosition(secondReturnMessage, return2yClic);
+        assertMessageVerticalPosition(thirdReturnMessage, return3yClic);
+        assertMessageVerticalPosition(firstReturnMessage, returnMessageNewPosition);
+
+        validateOrdering();
+
+        // Move m1 / return to previous positions
+        editor.drag(m1.getTranslated(50, 0), m1.getTranslated(0, -20));
+        m1.y = m1.y - 20;
+
+        editor.drag(new Point(m1.x, returnMessageNewPosition).getTranslated(100, 0), new Point(m1.x, return1yClic));
+        returnMessageNewPosition = return1yClic;
+
+        // Check stability
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 0, e1Bounds);
+        assertExecutionHasValidScreenBounds(LIFELINE_A, 1, e2Bounds);
+
+        assertMessageVerticalPosition(FIRST_MESSAGE, m1.y);
+        assertMessageVerticalPosition(THIRD_MESSAGE, m3.y);
+        assertMessageVerticalPosition(FOURTH_MESSAGE, m4.y);
+        assertMessageVerticalPosition(secondReturnMessage, return2yClic);
+        assertMessageVerticalPosition(thirdReturnMessage, return3yClic);
+        assertMessageVerticalPosition(firstReturnMessage, returnMessageNewPosition);
+
+        validateOrdering();
+
     }
 
     /**

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/SequenceSwtBotTestSuite.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/SequenceSwtBotTestSuite.java
@@ -67,6 +67,7 @@ import org.eclipse.sirius.tests.swtbot.sequence.SequenceDestroyMessageMoveTest;
 import org.eclipse.sirius.tests.swtbot.sequence.SequenceDestroyMessageTest;
 import org.eclipse.sirius.tests.swtbot.sequence.SequenceDiagramDirtyTests;
 import org.eclipse.sirius.tests.swtbot.sequence.SequenceDiagramNoSnapTest;
+import org.eclipse.sirius.tests.swtbot.sequence.SequenceExecutionBasicAndReturnMessageObervationPointDisplayedTest;
 import org.eclipse.sirius.tests.swtbot.sequence.SequenceExecutionBasicAndReturnMessageTest;
 import org.eclipse.sirius.tests.swtbot.sequence.SequenceExecutionMessageToSelfReparentTest;
 import org.eclipse.sirius.tests.swtbot.sequence.SequenceExecutionMessageToSelfTest;
@@ -178,6 +179,7 @@ public class SequenceSwtBotTestSuite extends TestCase {
             addGerritPart(suite);
 
             suite.addTestSuite(SequenceBasicMessageTest.class);
+            suite.addTestSuite(SequenceExecutionBasicAndReturnMessageObervationPointDisplayedTest.class);
             suite.addTestSuite(SequenceMessageToSelfTest.class);
             suite.addTestSuite(ExecutionLinkedMessageReconnectionTests.class);
             suite.addTestSuite(SequenceReturnMessageTest.class);


### PR DESCRIPTION
Final moved range was not updated after each query update. This used to cause wrong identification of message to reconnect and incorrect vertical layout (no conservation of unmoved message positions) after some execution moves with the target final range engloing unmoved simple messages.