### PR TITLE
[test] Add ArrangeAll*Test as unreliable

### DIFF
--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2025 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -309,8 +309,11 @@ public class AllTestSuite extends TestCase {
         suite.addTestSuite(CompartmentsTest.class);
         suite.addTestSuite(CompartmentsWithComponentTest.class);
 
-        suite.addTestSuite(ArrangeAllTest.class);
-        suite.addTestSuite(ArrangeAllWithSnapToGridTest.class);
+        if (!TestsUtil.shouldSkipUnreliableTests()) {
+            // These tests fail regularly on CI server caused by "pango error"
+            suite.addTestSuite(ArrangeAllTest.class);
+            suite.addTestSuite(ArrangeAllWithSnapToGridTest.class);
+        }
         suite.addTest(new JUnit4TestAdapter(DragAndDropWithSnapToGridTest.class));
         suite.addTestSuite(EdgeStabilityOnBendpointsAlignmentTest.class);
         suite.addTestSuite(EdgeStabilityOnDragAndDropTest.class);

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllUnreliableTestSuite.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/suite/AllUnreliableTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo.
+ * Copyright (c) 2021, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ package org.eclipse.sirius.tests.swtbot.suite;
 
 import org.eclipse.sirius.tests.support.api.TestsUtil;
 import org.eclipse.sirius.tests.swtbot.Activator;
+import org.eclipse.sirius.tests.swtbot.ArrangeAllTest;
+import org.eclipse.sirius.tests.swtbot.ArrangeAllWithSnapToGridTest;
 import org.eclipse.sirius.tests.swtbot.DeleteHookTests;
 import org.eclipse.sirius.tests.swtbot.DiagramCreationDescriptionTest;
 import org.eclipse.sirius.tests.swtbot.DndWorkspaceToAirdEditorTest;
@@ -131,6 +133,9 @@ public class AllUnreliableTestSuite extends TestCase {
                 suite.addTestSuite(TableUIRefreshTests.class);
                 suite.addTestSuite(ViewpointSpecificationProjectCreationTest.class);
                 suite.addTestSuite(VSMFieldTest.class);
+                // These tests fail regularly on CI server caused by "pango error"
+                suite.addTestSuite(ArrangeAllTest.class);
+                suite.addTestSuite(ArrangeAllWithSnapToGridTest.class);
             }
         }
         return suite;


### PR DESCRIPTION
On CI server, the SwtBot suite regularly fails on ArrangeAllTest or ArrangeAllWithSnapToGridTest due to "Pango Error". In this condition, there was no result for the corresponding job.
The goal of this commit is to allow to exclude these tests to have the result for the other tests.