### PR TITLE
[fix] Fix compilation error when using Eclipse 2025-03

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/layout/vertical/SequenceVerticalLayout.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence/src/org/eclipse/sirius/diagram/sequence/business/internal/layout/vertical/SequenceVerticalLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2010, 2025 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -779,10 +779,10 @@ public class SequenceVerticalLayout extends AbstractSequenceOrderingLayout<ISequ
         Range range = new Range(0, InteractionContainer.DEFAULT_HEIGHT);
         for (Entry<ISequenceEvent, Range> entry : lifelinesRanges.entrySet()) {
             ISequenceEvent key = entry.getKey();
-            if (key instanceof Lifeline lifeline && lifeline.getInstanceRole() instanceof InstanceRole instanceRole) {
+            if (key instanceof Lifeline lifeline && lifeline.getInstanceRole() != null) {
                 Range lifelineComputedRange = entry.getValue();
                 // Gather instance role bounds
-                Rectangle irBounds = instanceRole.getBounds();
+                Rectangle irBounds = lifeline.getInstanceRole().getBounds();
                 // Check that the lifeline is within bounds of the interaction container, resize it otherwise
 
                 Option<EndOfLife> endOfLife = lifeline.getEndOfLife();


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3478

This pattern was wrongly allowed before, but with ecj from 2025-03
it (correctly) causes a compilation error.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
