### PR TITLE
[521] Adjust Size on grid when active

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2025 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,9 +13,7 @@
 package org.eclipse.sirius.diagram.ui.internal.refresh;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -26,9 +24,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -48,31 +43,23 @@ import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.Size;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.sirius.diagram.AbstractDNode;
-import org.eclipse.sirius.diagram.DDiagram;
-import org.eclipse.sirius.diagram.DDiagramElement;
-import org.eclipse.sirius.diagram.DNode;
 import org.eclipse.sirius.diagram.DNodeContainer;
 import org.eclipse.sirius.diagram.DNodeList;
-import org.eclipse.sirius.diagram.ResizeKind;
-import org.eclipse.sirius.diagram.business.api.query.DDiagramElementQuery;
 import org.eclipse.sirius.diagram.business.api.refresh.CanonicalSynchronizer;
 import org.eclipse.sirius.diagram.model.business.internal.query.DDiagramElementContainerExperimentalQuery;
 import org.eclipse.sirius.diagram.model.business.internal.query.DNodeContainerExperimentalQuery;
 import org.eclipse.sirius.diagram.ui.business.api.query.ViewQuery;
 import org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager;
-import org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery;
 import org.eclipse.sirius.diagram.ui.business.internal.view.LayoutData;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainer2EditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DNodeContainerEditPart;
 import org.eclipse.sirius.diagram.ui.internal.providers.SiriusViewProvider;
-import org.eclipse.sirius.diagram.ui.internal.refresh.borderednode.CanonicalDBorderItemLocator;
 import org.eclipse.sirius.diagram.ui.internal.view.factories.AbstractContainerViewFactory;
 import org.eclipse.sirius.diagram.ui.internal.view.factories.ViewSizeHint;
 import org.eclipse.sirius.diagram.ui.part.SiriusDiagramUpdater;
 import org.eclipse.sirius.diagram.ui.part.SiriusNodeDescriptor;
 import org.eclipse.sirius.diagram.ui.part.SiriusVisualIDRegistry;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
-import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.IBorderItemOffsets;
 import org.eclipse.sirius.ext.base.Option;
 
 import com.google.common.collect.Iterables;
@@ -96,6 +83,11 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
 
     private final static boolean STANDARD_LAYOUT_FOR_CREATED_REGION_CONTENT = Boolean.getBoolean("org.eclipse.sirius.diagram.ui.internal.region.content.canonical.layout.standard"); //$NON-NLS-1$
 
+    // Default size is already provided by 
+    // AbstractDNodeViewFactory#updateLayoutConstraint(View, IAdaptable).
+    // There is no need to compute default size here.
+    private final static Dimension NO_CHANGE_SIZE = new Dimension(-1, -1);
+    
     /**
      * Say if we should store created views to layout in SiriusLayoutDataManager.
      */
@@ -332,8 +324,12 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
         return null;
     }
 
+    @SuppressWarnings("cast")
     private List<View> getViewChildren(final View current) {
-        return new ArrayList<>(current.getChildren());
+        // API Legacy adaptation: 
+        // children is the (hand-made) aggregation of transientChildren and persistedChildren.
+        // List only used for reading.
+        return (List<View>) current.getChildren();
     }
 
     /**
@@ -460,11 +456,11 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
     private LayoutDataResult updateLocationAndSize(View createdView) {
         LayoutDataResult updateLocationAndSize;
         EObject element = createdView.getElement();
-        if (isBorderedNode(element) || new ViewQuery(createdView).isForNameEditPartOnBorder()) {
+        if (NodePositionHelper.isBorderedNode(element) || new ViewQuery(createdView).isForNameEditPartOnBorder()) {
             updateLocationAndSize = updateAbstractDNode_ownedBorderedNodes_Bounds(createdView);
-        } else if (isTopLevelNode(element)) {
+        } else if (NodePositionHelper.isTopLevelNode(element)) {
             updateLocationAndSize = updateDDiagramChildBounds(createdView);
-        } else if (isChildNodeButNotBorderedNodeOfContainer(element)) {
+        } else if (NodePositionHelper.isInsideNodeContainer(element)) {
             updateLocationAndSize = updateDNodeContainerChildButNotBorderedNodeBounds(createdView);
         } else {
             updateLocationAndSize = new LayoutDataResult(true, false, false, false, false);
@@ -474,8 +470,8 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
 
     private LayoutDataResult updateDDiagramChildBounds(View createdView) {
         Dimension size = null;
-        Point location = null;
 
+        Point location = null;
         boolean normalLayout = true;
         boolean centerLayout = false;
         boolean borderLayout = false;
@@ -483,63 +479,34 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
         boolean isLayoutReference = false;
 
         EObject element = createdView.getElement();
-        org.eclipse.sirius.diagram.business.api.query.DNodeQuery dNodeQuery = null;
-        if (element instanceof DNode) {
-            DNode dNode = (DNode) element;
-            dNodeQuery = new org.eclipse.sirius.diagram.business.api.query.DNodeQuery(dNode);
-        }
-        if (element instanceof DDiagramElement) {
-            if (element instanceof AbstractDNode) {
-                AbstractDNode abstractDNode = (AbstractDNode) element;
-                LayoutData layoutData = SiriusLayoutDataManager.INSTANCE.getData(abstractDNode);
-                if (layoutData == null) {
-                    layoutData = SiriusLayoutDataManager.INSTANCE.getData(abstractDNode, true);
-                }
-                if (layoutData != null && layoutData.getSize() != null) {
-                    if (dNodeQuery == null || (dNodeQuery != null && dNodeQuery.allowsHorizontalResize() && dNodeQuery.allowsVerticalResize())) {
-                        size = layoutData.getSize();
-                    } else if (dNodeQuery != null && dNodeQuery.allowsHorizontalResize()) {
-                        size = new Dimension(layoutData.getSize().width, getDefaultSize((AbstractDNode) element).height);
-                    } else if (dNodeQuery != null && dNodeQuery.allowsVerticalResize()) {
-                        size = new Dimension(getDefaultSize((AbstractDNode) element).width, layoutData.getSize().height);
-                    }
-                }
-                if (layoutData != null && layoutData.getLocation() != null) {
-                    location = layoutData.getLocation();
-                    isLayoutReference = true;
-                }
 
-                // If the AbstractDNode has BorderNodes, it should be marked as to layout its BorderNodes.
-                if (!abstractDNode.getOwnedBorderedNodes().isEmpty()) { // if (has border nodes)
-                    borderLayout = true;
-                }
+        AbstractDNode abstractDNode = null;
+        if (element instanceof AbstractDNode) {
+            abstractDNode = (AbstractDNode) element;
+
+            LayoutData layoutData = SiriusLayoutDataManager.INSTANCE.getData(abstractDNode);
+            if (layoutData == null) {
+                layoutData = SiriusLayoutDataManager.INSTANCE.getData(abstractDNode, true);
             }
+            if (layoutData != null) {
+                size = layoutData.getSize();
+                location = layoutData.getLocation();
+                isLayoutReference = location != null;
+            }
+
+            // If the AbstractDNode has BorderNodes, it should be marked as to layout its BorderNodes.
+            borderLayout = !abstractDNode.getOwnedBorderedNodes().isEmpty();
+
         } else {
             size = ViewSizeHint.getInstance().consumeSize();
         }
-        if (size == null) {
-            size = getDefaultSize((AbstractDNode) element);
-        }
-        if (createdView instanceof Node && ((Node) createdView).getLayoutConstraint() instanceof Bounds) {
-            Bounds bounds = (Bounds) ((Node) createdView).getLayoutConstraint();
-            if (location == null) {
-                normalLayout = false;
-                centerLayout = true;
-                isAlreadyLayouted = true;
-            } else {
-                bounds.setX(location.x);
-                bounds.setY(location.y);
-                normalLayout = false;
-                isAlreadyLayouted = true;
-            }
-            if (size != null) {
-                if (size.width != -1) {
-                    bounds.setWidth(size.width);
-                }
-                if (size.height != -1) {
-                    bounds.setHeight(size.height);
-                }
-            }
+
+        if (createdView instanceof Node createdNode && createdNode.getLayoutConstraint() instanceof Bounds) {
+            normalLayout = false;
+            isAlreadyLayouted = true;
+            centerLayout = location == null;
+
+            updateBoundsConstraint(createdNode, location, size);
         }
 
         return new LayoutDataResult(normalLayout, centerLayout, borderLayout, isAlreadyLayouted, isLayoutReference);
@@ -548,7 +515,7 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
     private LayoutDataResult updateAbstractDNode_ownedBorderedNodes_Bounds(View createdView) {
         Node createdNode = (Node) createdView;
         AbstractDNode portNode = (AbstractDNode) createdView.getElement();
-        Node parentNode = (Node) createdView.eContainer();
+
         LayoutData layoutData = SiriusLayoutDataManager.INSTANCE.getData(portNode);
 
         boolean laidOut = false;
@@ -558,137 +525,36 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
             // In creation mode we must calculate the best position for the new
             // port
             layoutData = SiriusLayoutDataManager.INSTANCE.getData(portNode, true);
-            Rectangle tempBounds;
+            Dimension size = null;
+            Point contextLocation = null;
+            boolean forNamePart = new ViewQuery(createdView).isForNameEditPart();
             if (layoutData != null) {
                 laidOut = true;
-                // We get the layoutData from the manager with the parent of the
-                // node
-                final Point location = layoutData.getLocation() != null ? layoutData.getLocation() : new Point(0, 0);
-                Dimension size = null;
-                if (layoutData.getSize() != null) {
-                    size = layoutData.getSize();
-                } else {
-                    size = getDefaultSize(portNode);
-                }
-                tempBounds = new Rectangle(location, size);
-            } else {
-                Dimension size = ViewSizeHint.getInstance().consumeSize();
-                Point location = null;
-
-                if (size == null) {
-                    if (new ViewQuery(createdView).isForNameEditPart()) {
-                        Optional<Rectangle> optionalRect = GMFHelper.getAbsoluteBounds(createdView);
-                        if (optionalRect.isPresent()) {
-                            size = optionalRect.get().getSize();
-                        }
-                    }
-                    if (size == null) {
-                        size = getDefaultSize(portNode);
-                    }
-                }
-                if (location == null) {
-                    location = new Point(0, 0);
-                }
-                tempBounds = new Rectangle(location, size);
-            }
-
-            CanonicalDBorderItemLocator locator = new CanonicalDBorderItemLocator(parentNode, PositionConstants.NSEW, isSnapToGrid(), getGridSpacing());
-            if (new ViewQuery(createdView).isForNameEditPart()) {
-                locator.setBorderItemOffset(IBorderItemOffsets.NO_OFFSET);
-            } else {
-                if (new DDiagramElementQuery(portNode).isIndirectlyCollapsed()) {
-                    locator.setBorderItemOffset(IBorderItemOffsets.COLLAPSE_FILTER_OFFSET);
-                } else {
-                    locator.setBorderItemOffset(IBorderItemOffsets.DEFAULT_OFFSET);
-                }
-            }
-
-            final IFigure dummyFigure = new Figure();
-            final Rectangle constraint = tempBounds.getCopy();
-            locator.setConstraint(constraint);
-            dummyFigure.setVisible(true);
-            final Rectangle rect = new Rectangle(constraint);
-            Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parentNode, true, false);
-            rect.translate(parentAbsoluteLocation.x, parentAbsoluteLocation.y);
-            dummyFigure.setBounds(rect);
-            final Point realLocation = locator.getValidLocation(rect, createdNode, new ArrayList<Node>(Arrays.asList(createdNode)));
-            final Dimension d = realLocation.getDifference(parentAbsoluteLocation);
-            final Point location = new Point(d.width, d.height);
-            realLocation.setLocation(location);
-
-            locator.relocate(createdNode);
-
-            LayoutConstraint createdNodeLayoutConstraint = createdNode.getLayoutConstraint();
-            if (createdNodeLayoutConstraint instanceof Location) {
-                laidOut = true;
-                Location createdNodeBounds = (Location) createdNodeLayoutConstraint;
-                createdNodeBounds.setX(location.x);
-                createdNodeBounds.setY(location.y);
-            }
-            if (createdNodeLayoutConstraint instanceof Size) {
-                Size createdNodeBounds = (Size) createdNodeLayoutConstraint;
-                ResizeKind resizeKind = ResizeKind.NSEW_LITERAL;
-                if (portNode instanceof DNode) {
-                    resizeKind = ((DNode) portNode).getResizeKind();
-                }
-                if (constraint.width != -1 && canResizeWidth(resizeKind)) {
-                    createdNodeBounds.setWidth(constraint.width);
-                }
-                if (constraint.height != -1 && canResizeHeight(resizeKind)) {
-                    createdNodeBounds.setHeight(constraint.height);
-                }
-            }
-        } else {
-            laidOut = true;
-            // We get the layoutData from the manager directly with the node
-            // (drag'n'drop) but this location should be adapt to be correct
-            // according to CanonicalDBorderItemLocator.
-            final Point location = layoutData.getLocation() != null ? layoutData.getLocation() : new Point(0, 0);
-
-            Dimension size = null;
-            if (layoutData.getSize() != null) {
+                // We get the layoutData from the manager with the parent of the node
+                contextLocation = layoutData.getLocation();
                 size = layoutData.getSize();
             } else {
-                size = getDefaultSize(portNode);
-            }
-
-            // Compute the best location according to other existing bordered
-            // nodes.
-            CanonicalDBorderItemLocator locator = new CanonicalDBorderItemLocator(parentNode, PositionConstants.NSEW);
-            if (portNode != null) {
-                if (new DDiagramElementQuery(portNode).isIndirectlyCollapsed()) {
-                    locator.setBorderItemOffset(IBorderItemOffsets.COLLAPSE_FILTER_OFFSET);
-                } else {
-                    locator.setBorderItemOffset(IBorderItemOffsets.DEFAULT_OFFSET);
+                size = ViewSizeHint.getInstance().consumeSize();
+                if (size == null && forNamePart) {
+                    Optional<Rectangle> optionalRect = GMFHelper.getAbsoluteBounds(createdView);
+                    if (optionalRect.isPresent()) {
+                        size = optionalRect.get().getSize();
+                    }
                 }
-            } else {
-                locator.setBorderItemOffset(IBorderItemOffsets.DEFAULT_OFFSET);
             }
 
-            // CanonicalDBorderItemLocator works with absolute GMF parent
-            // location so we need to translate BorderedNode absolute location.
-            final org.eclipse.draw2d.geometry.Point parentAbsoluteLocation = GMFHelper.getAbsoluteBounds(parentNode, false, false, false, false).getTopLeft();
-            final Point realLocation = locator.getValidLocation(new Rectangle(location.getTranslated(parentAbsoluteLocation), size), createdNode, Collections.singleton(createdNode));
+            final Point location = new NodePositionHelper(isSnapToGrid(), getGridSpacing()).getOnBorderPositionFromParent(createdNode, contextLocation, size);
 
-            // Compute the new relative position to the parent
-            realLocation.translate(parentAbsoluteLocation.negate());
+            laidOut = laidOut || createdNode.getLayoutConstraint() instanceof Location;
+            updateBoundsConstraint(createdNode, location, size != null ? size : NO_CHANGE_SIZE);
 
-            Node node = (Node) createdView;
-            Bounds bounds = (Bounds) node.getLayoutConstraint();
-            bounds.setX(realLocation.x);
-            bounds.setY(realLocation.y);
-            if (size.width != -1) {
-                bounds.setWidth(size.width);
-            }
-            if (size.height != -1) {
-                bounds.setHeight(size.height);
-            }
-        }
-        if (laidOut) {
-            return new LayoutDataResult(false, false, false, true, false);
         } else {
-            return new LayoutDataResult(true, false, false, false, false);
+            laidOut = true;
+            final Point location = new NodePositionHelper(isSnapToGrid(), getGridSpacing()).getOnBorderPositionFromLayoutData(createdNode, layoutData);
+
+            updateBoundsConstraint(createdNode, location, layoutData.getSize());
         }
+        return new LayoutDataResult(!laidOut, false, false, laidOut, false);
     }
 
     private LayoutDataResult updateDNodeContainerChildButNotBorderedNodeBounds(View createdView) {
@@ -701,11 +567,10 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
         boolean isAlreadylayouted = false;
         boolean isLayoutReference = false;
 
-        if (element instanceof AbstractDNode && parent instanceof DNodeContainer) {
+        if (element instanceof AbstractDNode abstractDNode && parent instanceof DNodeContainer nodeContainer) {
             Dimension size = null;
             Point location = null;
 
-            AbstractDNode abstractDNode = (AbstractDNode) element;
             LayoutData layoutData = SiriusLayoutDataManager.INSTANCE.getData(abstractDNode);
             if (layoutData == null) {
                 layoutData = SiriusLayoutDataManager.INSTANCE.getData(abstractDNode, true);
@@ -718,81 +583,64 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
                 isLayoutReference = true;
             }
 
-            if (size == null) {
-                size = getDefaultSize(abstractDNode);
-            }
-            if (location == null) {
-                boolean isInRegionContainer = new DNodeContainerExperimentalQuery((DNodeContainer) parent).isRegionContainer();
-                boolean skip = false;
-                if (STANDARD_LAYOUT_FOR_CREATED_REGION_CONTENT && new DDiagramElementContainerExperimentalQuery((DNodeContainer) parent).isRegion()) {
-                    // Get CompartmentView edit part
-                    EObject dnodeContainer2_3008 = createdView.eContainer();
-                    dnodeContainer2_3008 = dnodeContainer2_3008 != null ? dnodeContainer2_3008.eContainer() : null;
-
-                    skip = dnodeContainer2_3008 != null && (dnodeContainer2_3008.eAdapters().contains(SiriusLayoutDataManager.INSTANCE.getCenterAdapterMarker())
-                            || dnodeContainer2_3008.eAdapters().contains(SiriusLayoutDataManager.INSTANCE.getAdapterMarker()));
-                }
-                if (!skip && !isInRegionContainer) {
-                    normalLayout = false;
-                    centerLayout = true;
-                    isAlreadylayouted = true;
-                }
+            if (location == null && !isInForcedLayout(createdView, nodeContainer)) {
+                normalLayout = false;
+                centerLayout = true;
+                isAlreadylayouted = true;
             }
             // If the DNodeContainer has BorderNodes, it should be marked as to layout its BorderNodes.
             if (!abstractDNode.getOwnedBorderedNodes().isEmpty()) { // if (has border nodes)
                 borderLayout = true;
             }
 
-            if (createdView instanceof Node) {
-                Node createdNode = (Node) createdView;
-                updateBoundsConstraint(createdNode, size, location, abstractDNode);
+            if (createdView instanceof Node createdNode) {
+                updateBoundsConstraint(createdNode, location, size);
             }
         }
         return new LayoutDataResult(normalLayout, centerLayout, borderLayout, isAlreadylayouted, isLayoutReference);
     }
 
-    protected void updateLocationConstraint(Bounds bounds, Point location) {
+    private boolean isInForcedLayout(View createdView, DNodeContainer nodeContainer) {
+        boolean skip = false;
+        if (STANDARD_LAYOUT_FOR_CREATED_REGION_CONTENT && new DDiagramElementContainerExperimentalQuery(nodeContainer).isRegion()) {
+            // Get CompartmentView edit part
+            EObject dnodeContainer2_3008 = createdView.eContainer();
+            dnodeContainer2_3008 = dnodeContainer2_3008 != null ? dnodeContainer2_3008.eContainer() : null;
+
+            skip = dnodeContainer2_3008 != null && (dnodeContainer2_3008.eAdapters().contains(SiriusLayoutDataManager.INSTANCE.getCenterAdapterMarker())
+                    || dnodeContainer2_3008.eAdapters().contains(SiriusLayoutDataManager.INSTANCE.getAdapterMarker()));
+        }
+        return skip || new DNodeContainerExperimentalQuery(nodeContainer).isRegionContainer();
+    }
+
+    protected void updateLocationConstraint(Location constraint, Point location) {
         if (location != null) {
-            bounds.setX(location.x);
-            bounds.setY(location.y);
+            constraint.setX(location.x);
+            constraint.setY(location.y);
         }
     }
 
-    protected void updateSizeConstraint(Bounds bounds, Dimension size, EObject abstractDNode) {
-        ResizeKind resizeKind = ResizeKind.NSEW_LITERAL;
-        if (abstractDNode instanceof DNode dNode) {
-            resizeKind = dNode.getResizeKind();
+    protected void updateSizeConstraint(Node createdNode, Size constraint, Dimension size) {
+        Dimension safeSize = size != null ? size : NO_CHANGE_SIZE;
+
+        Dimension defaultSize = new NodePositionHelper(isSnapToGrid(), getGridSpacing()).getAdjustedDimension(createdNode, constraint);
+
+        if (NodePositionHelper.canResizeWidth(createdNode)) { // Horizontal
+            constraint.setWidth(safeSize.width != -1 ? safeSize.width : defaultSize.width);
         }
-        if (size != null) {
-            if (size.width != -1 && canResizeWidth(resizeKind)) {
-                bounds.setWidth(size.width);
-            }
-            if (size.height != -1 && canResizeHeight(resizeKind)) {
-                bounds.setHeight(size.height);
-            }
+        if (NodePositionHelper.canResizeHeight(createdNode)) { // Vertical
+            constraint.setHeight(safeSize.height != -1 ? safeSize.height : defaultSize.height);
         }
     }
 
-    private void updateBoundsConstraint(Node createdNode, Dimension size, Point location, AbstractDNode abstractDNode) {
-        Bounds bounds = (Bounds) createdNode.getLayoutConstraint();
-        updateLocationConstraint(bounds, location);
-        updateSizeConstraint(bounds, size, abstractDNode);
-    }
-
-    private boolean canResizeHeight(ResizeKind resizeKind) {
-        return resizeKind.getValue() == ResizeKind.NORTH_SOUTH || resizeKind.getValue() == ResizeKind.NSEW;
-    }
-
-    private boolean canResizeWidth(ResizeKind resizeKind) {
-        return resizeKind.getValue() == ResizeKind.EAST_WEST || resizeKind.getValue() == ResizeKind.NSEW;
-    }
-
-    private Dimension getDefaultSize(AbstractDNode abstractDNode) {
-        Dimension defaultSize = new Dimension(-1, -1);
-        if (abstractDNode instanceof DNode viewNode && !new org.eclipse.sirius.diagram.business.api.query.DNodeQuery(viewNode).isAutoSize()) {
-            defaultSize = new DNodeQuery(viewNode).getDefaultDimension();
+    private void updateBoundsConstraint(Node createdNode, Point location, Dimension size) {
+        LayoutConstraint constraint = createdNode.getLayoutConstraint();
+        if (constraint instanceof Location locationConstraint) {
+            updateLocationConstraint(locationConstraint, location);
         }
-        return defaultSize;
+        if (constraint instanceof Size sizeConstraint) {
+            updateSizeConstraint(createdNode, sizeConstraint, size);
+        }
     }
 
     /**
@@ -804,61 +652,6 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
      */
     protected CreateViewRequest getCreateViewRequest(final List<? extends ViewDescriptor> descriptors) {
         return new CreateViewRequest(descriptors);
-    }
-
-    /**
-     * Check if element is a borderedNode.
-     * 
-     * @param element
-     *            the element to check
-     * @return true if the element is a bordered node, false otherwise
-     */
-    protected boolean isBorderedNode(EObject element) {
-        boolean result = false;
-        if (element instanceof DNode) {
-            EObject parent = element.eContainer();
-            if (parent instanceof AbstractDNode) {
-                AbstractDNode parentDNode = (AbstractDNode) parent;
-                result = parentDNode.getOwnedBorderedNodes().contains(element);
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Check if element is a direct child of {@link DDiagram}.
-     * 
-     * @param element
-     *            the element to check
-     * 
-     * @return true if the element is a direct child of {@link DDiagram}, false otherwise
-     */
-    protected boolean isTopLevelNode(EObject element) {
-        boolean isTopLevelNode = false;
-        EObject container = element.eContainer();
-        if (container instanceof DDiagram) {
-            DDiagram dDiagram = (DDiagram) container;
-            isTopLevelNode = dDiagram.getOwnedDiagramElements().contains(element);
-        }
-        return isTopLevelNode;
-    }
-
-    /**
-     * Check if element is a child of {@link DNodeContainer} but not a bordered node.
-     * 
-     * @param element
-     *            the element to check
-     * 
-     * @return true if the element is a child of {@link DNodeContainer} but not a bordered node, false otherwise
-     */
-    private boolean isChildNodeButNotBorderedNodeOfContainer(EObject element) {
-        boolean isChildNodeButNotBorderedNodeOfContainer = false;
-        EObject container = element.eContainer();
-        if (container instanceof DNodeContainer) {
-            DNodeContainer dNodeContainer = (DNodeContainer) container;
-            isChildNodeButNotBorderedNodeOfContainer = dNodeContainer.getOwnedDiagramElements().contains(element);
-        }
-        return isChildNodeButNotBorderedNodeOfContainer;
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/NodePositionHelper.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/NodePositionHelper.java
@@ -1,0 +1,355 @@
+/*******************************************************************************
+ * Copyright (c) 2025 THALES GLOBAL SERVICES and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.internal.refresh;
+
+import java.util.Collections;
+
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.gmf.runtime.notation.Size;
+import org.eclipse.sirius.diagram.AbstractDNode;
+import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.diagram.DNode;
+import org.eclipse.sirius.diagram.DNodeContainer;
+import org.eclipse.sirius.diagram.ResizeKind;
+import org.eclipse.sirius.diagram.business.api.query.DDiagramElementQuery;
+import org.eclipse.sirius.diagram.ui.business.api.query.ViewQuery;
+import org.eclipse.sirius.diagram.ui.business.internal.query.DNodeQuery;
+import org.eclipse.sirius.diagram.ui.business.internal.view.LayoutData;
+import org.eclipse.sirius.diagram.ui.internal.refresh.borderednode.CanonicalDBorderItemLocator;
+import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.IBorderItemOffsets;
+
+/**
+ * Helper class to compute node location during diagram synchronization.
+ * 
+ * @author <a href="mailto:nicolas.perans@obeo.fr">Nicolas Peransin</a>
+ */
+public class NodePositionHelper {
+
+    /**
+     * True if the snap to grid is considered as activated. In this case, the returned location, by
+     * {@link #getValidLocation(Rectangle, Node, Collection<Node>)}, is snapped to the grid (if possible).
+     */
+    private final boolean snapToGrid;
+
+    /**
+     * The grid step, expected to be strictly positive. Only used when {@code snapToGrid} is true.
+     */
+    private final int gridSpacing;
+
+    /**
+     * Default constructor.
+     * 
+     * @param snapToGrid
+     *            flag of current diagram regarding element alignment.
+     * @param gridSpacing
+     *            space of grid point of current diagram .
+     */
+    public NodePositionHelper(boolean snapToGrid, int gridSpacing) {
+        this.snapToGrid = snapToGrid;
+        this.gridSpacing = gridSpacing;
+    }
+
+    /**
+     * Computes the position of border node using location and size from parent interaction.
+     * 
+     * @param node
+     *            GMF border node
+     * @param contextLocation
+     *            user-selected location
+     * @param size
+     *            user-provided size (maybe null)
+     * @return location of border
+     */
+    public Point getOnBorderPositionFromParent(Node node, Point contextLocation, Dimension size) {
+        AbstractDNode port = (AbstractDNode) node.getElement();
+        Node parent = (Node) node.eContainer();
+
+        CanonicalDBorderItemLocator locator = new CanonicalDBorderItemLocator(parent, PositionConstants.NSEW, snapToGrid, gridSpacing);
+        Dimension borderOffsets = IBorderItemOffsets.DEFAULT_OFFSET;
+        if (new ViewQuery(node).isForNameEditPart()) {
+            borderOffsets = IBorderItemOffsets.NO_OFFSET;
+        } else if (new DDiagramElementQuery(port).isIndirectlyCollapsed()) {
+            borderOffsets = IBorderItemOffsets.COLLAPSE_FILTER_OFFSET;
+        }
+        locator.setBorderItemOffset(borderOffsets);
+
+        Rectangle constraint = new Rectangle(
+                // Safe location
+                contextLocation != null ? contextLocation : new Point(0, 0),
+                // Dimension is required for Border Item Locator
+                size != null ? size : getBorderDefaultSize(port));
+        locator.setConstraint(constraint);
+        final Rectangle dummyBounds = new Rectangle(constraint);
+        Point parentAbsoluteLocation = GMFHelper.getAbsoluteLocation(parent, true, false);
+        dummyBounds.translate(parentAbsoluteLocation);
+
+        final Point realLocation = locator.getValidLocation(dummyBounds, node, Collections.singleton(node));
+        final Dimension d = realLocation.getDifference(parentAbsoluteLocation);
+        final Point location = new Point(d.width, d.height);
+        realLocation.setLocation(location);
+
+        locator.relocate(node);
+        return location;
+    }
+
+    /**
+     * Computes the position of border node using location and size from parent interaction.
+     * 
+     * @param node
+     *            GMF border node
+     * @param contextLocation
+     *            user-selected location
+     * @param size
+     *            user-provided size (maybe null)
+     * @return location of border
+     */
+    public Point getOnBorderPositionFromLayoutData(Node node, LayoutData layoutData) {
+        AbstractDNode port = (AbstractDNode) node.getElement();
+        Node parent = (Node) node.eContainer();
+
+        // We get the layoutData from the manager directly with the node
+        // (drag'n'drop) but this location should be adapt to be correct
+        // according to CanonicalDBorderItemLocator.
+        final Point location = layoutData.getLocation() != null ? layoutData.getLocation() : new Point(0, 0);
+
+        Dimension size = layoutData.getSize();
+
+        // Compute the best location according to other existing bordered nodes.
+        CanonicalDBorderItemLocator locator = new CanonicalDBorderItemLocator(parent, PositionConstants.NSEW);
+        Dimension borderOffsets = IBorderItemOffsets.DEFAULT_OFFSET;
+        if (port != null && new DDiagramElementQuery(port).isIndirectlyCollapsed()) {
+            borderOffsets = IBorderItemOffsets.COLLAPSE_FILTER_OFFSET;
+        }
+        locator.setBorderItemOffset(borderOffsets);
+
+        // CanonicalDBorderItemLocator works with absolute GMF parent
+        // location so we need to translate BorderedNode absolute location.
+        final Point parentAbsoluteLocation = GMFHelper.getAbsoluteBounds(parent, false, false, false, false).getTopLeft();
+        final Point realLocation = locator.getValidLocation(new Rectangle(location.getTranslated(parentAbsoluteLocation), size), node, Collections.singleton(node));
+
+        // Compute the new relative position to the parent
+        realLocation.translate(parentAbsoluteLocation.negate());
+
+        return realLocation;
+    }
+
+    private Dimension getBorderDefaultSize(AbstractDNode abstractDNode) {
+        Dimension defaultSize = new Dimension(-1, -1);
+        if (abstractDNode instanceof DNode viewNode && !new org.eclipse.sirius.diagram.business.api.query.DNodeQuery(viewNode).isAutoSize()) {
+            defaultSize = new DNodeQuery(viewNode).getDefaultDimension();
+        }
+        return defaultSize;
+    }
+
+    /**
+     * Returns the dimension of a node corrected by the grid.
+     * <p>
+     * When grid is enable, user expects the node corner to be matching a grid point.
+     * </p>
+     * <p>
+     * If no size or no grid is provided, the result matches the input {@code size}.
+     * </p>
+     * <p>
+     * The fact a node cannot be resized is no treated in the computation of dimension.
+     * </p>
+     * 
+     * @param node
+     *            GMF element
+     * @param size
+     *            actual size to adjust
+     * @return adjusted dimension
+     */
+    public Dimension getAdjustedDimension(Node node, Size size) {
+        Dimension result = new Dimension(size.getWidth(), size.getHeight());
+
+        if (snapToGrid && gridSpacing > 0) {
+            // When snap to grid, node origin is located on grid.
+            int enlargedAxis = PositionConstants.HORIZONTAL | PositionConstants.VERTICAL;
+
+            if (isBorderedNode(node.getElement())) {
+                enlargedAxis = PositionConstants.NONE;
+                if (node.getLayoutConstraint() instanceof Bounds nodeBounds // this node
+                        && node.eContainer() instanceof Node parent // and parent
+                        && parent.getLayoutConstraint() instanceof Bounds parentBounds) {
+                    // For Border node, only enlarge the attached dimension.
+                    // As there is a small shift inside the component,
+                    // adjusting the other dimension is useless:
+                    // when moving the element, the size would not match the grid.
+                    int borderSide = getPortSide(nodeBounds, parentBounds);
+                    switch (borderSide) {
+                    case PositionConstants.NORTH:
+                    case PositionConstants.SOUTH:
+                        enlargedAxis = PositionConstants.HORIZONTAL;
+                        break;
+                    case PositionConstants.EAST:
+                    case PositionConstants.WEST:
+                        enlargedAxis = PositionConstants.VERTICAL;
+                        break;
+                    }
+                }
+            }
+            if ((enlargedAxis & PositionConstants.HORIZONTAL) != 0) {
+                result.width = extendToGrid(result.width);
+            }
+            if ((enlargedAxis & PositionConstants.VERTICAL) != 0) {
+                result.height = extendToGrid(result.height);
+            }
+        }
+        return result;
+    }
+
+    private int extendToGrid(int value) {
+        if (value == -1) {
+            // no value
+            return -1;
+        }
+
+        int shift = value % gridSpacing;
+        int enlarge = 0;
+        if (shift != 0) {
+            enlarge = gridSpacing - shift;
+        }
+        return value + enlarge;
+    }
+
+    /**
+     * Evaluates if element is a borderedNode.
+     * 
+     * @param element
+     *            the element to check
+     * @return true if the element is a bordered node, false otherwise
+     */
+    public static boolean isBorderedNode(EObject element) {
+        return element instanceof DNode // only node
+                && element.eContainer() instanceof AbstractDNode parentDNode // in border reference
+                && parentDNode.getOwnedBorderedNodes().contains(element);
+    }
+
+    /**
+     * Evaluates if element is a direct child of {@link DDiagram}.
+     * 
+     * @param element
+     *            the element to check
+     * @return true if the element is a direct child of {@link DDiagram}, false otherwise
+     */
+    public static boolean isTopLevelNode(EObject element) {
+        return element.eContainer() instanceof DDiagram dDiagram // only for diagram
+                && dDiagram.getOwnedDiagramElements().contains(element);
+    }
+
+    /**
+     * Evaluates if element is a child of {@link DNodeContainer} but not a bordered node.
+     * 
+     * @param element
+     *            the element to check
+     * 
+     * @return true if the element is a child of {@link DNodeContainer} but not a bordered node, false otherwise
+     */
+    public static boolean isInsideNodeContainer(EObject element) {
+        return element.eContainer() instanceof DNodeContainer dNodeContainer // only in container
+                && dNodeContainer.getOwnedDiagramElements().contains(element);
+    }
+
+    private static ResizeKind getNodeResizeKind(Node createdNode) {
+        if (createdNode.getElement() instanceof DNode dNode) {
+            return dNode.getResizeKind();
+        }
+        return ResizeKind.NSEW_LITERAL;
+    }
+
+    /**
+     * Evaluates if width of a node can changed.
+     * 
+     * @param node
+     *            GMF element
+     * @return true if width can modified
+     */
+    public static boolean canResizeWidth(Node node) {
+        ResizeKind kind = getNodeResizeKind(node);
+        return kind == ResizeKind.EAST_WEST_LITERAL || kind == ResizeKind.NSEW_LITERAL;
+    }
+
+    /**
+     * Evaluates if height of a node can changed.
+     * 
+     * @param node
+     *            GMF element
+     * @return true if height can modified
+     */
+    public static boolean canResizeHeight(Node node) {
+        ResizeKind kind = getNodeResizeKind(node);
+        return kind == ResizeKind.NORTH_SOUTH_LITERAL || kind == ResizeKind.NSEW_LITERAL;
+    }
+
+    /**
+     * Returns the side of a border node from its container using {@link PositionConstants}.
+     * 
+     * @param borderNode
+     *            bounds of border node
+     * @param container
+     *            bounds of container node
+     * @return side
+     */
+    private static int getPortSide(Bounds borderNode, Bounds container) {
+        // Warning: legacy implementation has suspicious results.
+        // CanonicalDBorderItemLocator.findClosestSideOfParent(borderNode, container);
+        if (container.getWidth() == 0) { // no dimension, 0-division risk
+            return PositionConstants.WEST;
+        }
+
+        Point center = new Rectangle(borderNode.getX(), borderNode.getY(), borderNode.getWidth(), borderNode.getHeight()).getCenter();
+        // Diagonal SW to NE
+        boolean aboveNwse = isAboveLine(center, container.getHeight(), container.getWidth(), 0);
+        // Diagonal NW to SE
+        boolean aboveSwne = isAboveLine(center, -container.getHeight(), container.getWidth(), container.getHeight());
+        if (aboveSwne) {
+            return aboveNwse ? PositionConstants.NORTH : PositionConstants.WEST;
+        } else {
+            return aboveNwse ? PositionConstants.EAST : PositionConstants.SOUTH;
+        }
+    }
+
+    /**
+     * Returns if a point is above a line.
+     * <p>
+     * Referential is screen-based (Y-axis increases toward the South, X-Axis increases toward East).
+     * </p>
+     * <p>
+     * Line is defined with formula:
+     * 
+     * <pre>
+     * y = (a / r) * x + b
+     * </pre>
+     * </p>
+     * 
+     * @param point
+     *            location to test
+     * @param a
+     *            ratio of slope
+     * @param r
+     *            division of slope
+     * @param b
+     *            y-intercept
+     * @return true if above
+     */
+    private static boolean isAboveLine(Point point, int a, int r, int b) {
+        // Y head to South !
+        return point.y * r <= a * point.x + b * r;
+    }
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/borderednode/CanonicalDBorderItemLocator.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/borderednode/CanonicalDBorderItemLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES.
+ * Copyright (c) 2011, 2025 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -181,7 +181,16 @@ public class CanonicalDBorderItemLocator {
     }
 
     /**
-     * Find the closest side when x,y is inside parent.
+     * Find the closest side when x, y is inside parent.
+     * <p>
+     * Possible results are:
+     * <ul>
+     * <li> {@link PositionConstants.NORTH}, </li>
+     * <li> {@link PositionConstants.SOUTH}, </li>
+     * <li> {@link PositionConstants.EAST}, </li>
+     * <li> {@link PositionConstants.WEST}. </li>
+     * </ul>
+     * </p>
      * 
      * @param proposedBounds
      *            the proposed bounds
@@ -191,6 +200,29 @@ public class CanonicalDBorderItemLocator {
      */
     public static int findClosestSideOfParent(final Rectangle proposedBounds, final Rectangle parentBorder) {
         return findClosestSideOfParent(proposedBounds, parentBorder, null, false, 0);
+    }
+
+    /**
+     * Find the closest side when x, y is inside parent.
+     * <p>
+     * Possible results are:
+     * <ul>
+     * <li> {@link PositionConstants.NORTH}, </li>
+     * <li> {@link PositionConstants.SOUTH}, </li>
+     * <li> {@link PositionConstants.EAST}, </li>
+     * <li> {@link PositionConstants.WEST}. </li>
+     * </ul>
+     * </p>
+     * 
+     * @param proposedBounds
+     *            the proposed bounds
+     * @param parentBorder
+     *            the parent border
+     * @return draw constant
+     */
+    public static int findClosestSideOfParent(final Bounds proposedBounds, final Bounds parentBorder) {
+        return findClosestSideOfParent(new Rectangle(proposedBounds.getX(), proposedBounds.getY(), proposedBounds.getWidth(), proposedBounds.getHeight()),
+                new Rectangle(parentBorder.getX(), parentBorder.getY(), parentBorder.getWidth(), parentBorder.getHeight()));
     }
 
     /**

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/diagram/DDiagramCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/diagram/DDiagramCanonicalSynchronizer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2025 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,11 +39,12 @@ import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.gef.rulers.RulerProvider;
 import org.eclipse.gmf.runtime.common.ui.services.editor.EditorService;
 import org.eclipse.gmf.runtime.common.ui.util.DisplayUtils;
+import org.eclipse.gmf.runtime.diagram.core.preferences.PreferencesHint;
 import org.eclipse.gmf.runtime.diagram.core.util.ViewType;
 import org.eclipse.gmf.runtime.diagram.ui.internal.properties.WorkspaceViewerProperties;
 import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor;
 import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramGraphicalViewer;
-import org.eclipse.gmf.runtime.diagram.ui.parts.IDiagramGraphicalViewer;
+import org.eclipse.gmf.runtime.diagram.ui.preferences.IPreferenceConstants;
 import org.eclipse.gmf.runtime.diagram.ui.util.MeasurementUnitHelper;
 import org.eclipse.gmf.runtime.draw2d.ui.mapmode.IMapMode;
 import org.eclipse.gmf.runtime.notation.Bounds;
@@ -70,6 +71,7 @@ import org.eclipse.sirius.diagram.ui.internal.refresh.CanonicalSynchronizerResul
 import org.eclipse.sirius.diagram.ui.part.SiriusDiagramUpdater;
 import org.eclipse.sirius.diagram.ui.part.SiriusLinkDescriptor;
 import org.eclipse.sirius.diagram.ui.part.SiriusVisualIDRegistry;
+import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.ext.base.Options;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Display;
@@ -108,7 +110,7 @@ public class DDiagramCanonicalSynchronizer extends AbstractCanonicalSynchronizer
         this.gmfDiagram = gmfDiagram;
         this.connectionsFactory = new ConnectionsFactory(gmfDiagram, viewpointViewProvider);
         // Search if it possible to get snapToGrid and gridSpacing values from the store associated to an opened editor.
-        loadPreferencesFromOpenedDiagram();
+        loadPreferences();
     }
 
     /**
@@ -116,23 +118,37 @@ public class DDiagramCanonicalSynchronizer extends AbstractCanonicalSynchronizer
      * Inspired from
      * {@link org.eclipse.sirius.diagram.ui.tools.internal.print.SiriusDiagramPrintPreviewHelper#loadPreferencesFromOpenDiagram(String)}.
      */
-    private void loadPreferencesFromOpenedDiagram() {
+    private void loadPreferences() {
         List<? extends Object> diagramEditors = EditorService.getInstance().getRegisteredEditorParts();
         @SuppressWarnings("unchecked")
         Optional<DiagramEditor> diagramEditor = (Optional<DiagramEditor>) diagramEditors.stream()
                 .filter(de -> de instanceof DiagramEditor && ((DiagramEditor) de).getDiagramEditPart() != null && gmfDiagram.equals(((DiagramEditor) de).getDiagramEditPart().getDiagramView()))
                 .findFirst();
+
+        double gridSpaceValue = 0;
+        int rulerUnit = 0;
+        
         if (diagramEditor.isPresent()) {
-            IDiagramGraphicalViewer viewer = diagramEditor.get().getDiagramGraphicalViewer();
-            if (viewer instanceof DiagramGraphicalViewer) {
-                DiagramGraphicalViewer diagramGraphicalViewer = (DiagramGraphicalViewer) viewer;
+            if (diagramEditor.get().getDiagramGraphicalViewer() instanceof DiagramGraphicalViewer viewer) {
                 // Load preferences
-                IPreferenceStore store = diagramGraphicalViewer.getWorkspaceViewerPreferenceStore();
+                IPreferenceStore store = viewer.getWorkspaceViewerPreferenceStore();
                 setSnapToGrid(store.getBoolean(WorkspaceViewerProperties.SNAPTOGRID));
-                setGridSpacing(convertGridSpacingInPixels(store.getDouble(WorkspaceViewerProperties.GRIDSPACING), store.getInt(WorkspaceViewerProperties.RULERUNIT),
-                        MeasurementUnitHelper.getMapMode(gmfDiagram.getMeasurementUnit())));
+                gridSpaceValue = store.getDouble(WorkspaceViewerProperties.GRIDSPACING);
+                rulerUnit = store.getInt(WorkspaceViewerProperties.RULERUNIT);
             }
+        } else {
+            // Synchronization is related to creation when no editor is provided.
+            IPreferenceStore store = (IPreferenceStore) DiagramUIPlugin.DIAGRAM_PREFERENCES_HINT.getPreferenceStore();
+            setSnapToGrid(store.getBoolean(IPreferenceConstants.PREF_SNAP_TO_GRID));
+            gridSpaceValue = store.getDouble(IPreferenceConstants.PREF_GRID_SPACING);
+            rulerUnit = store.getInt(IPreferenceConstants.PREF_RULER_UNITS);
         }
+        
+        if (isSnapToGrid()) {
+            setGridSpacing(convertGridSpacingInPixels(gridSpaceValue, rulerUnit,
+                    MeasurementUnitHelper.getMapMode(gmfDiagram.getMeasurementUnit())));
+        }
+
     }
 
     /**
@@ -275,7 +291,7 @@ public class DDiagramCanonicalSynchronizer extends AbstractCanonicalSynchronizer
                     newView.eAdapters().remove(SiriusLayoutDataManager.INSTANCE.getCenterAdapterMarker());
                     newView.eAdapters().add(SiriusLayoutDataManager.INSTANCE.getReferenceAdapterMarker());
                 }
-                updateSizeConstraint(newBound, new Dimension(oldBound.getWidth(), oldBound.getHeight()), newNode.getElement());
+                updateSizeConstraint(newNode, newBound, new Dimension(oldBound.getWidth(), oldBound.getHeight()));
             }
         }
     }

--- a/plugins/org.eclipse.sirius.tests.junit/data/unit/refresh/grid/noderefresh.odesign
+++ b/plugins/org.eclipse.sirius.tests.junit/data/unit/refresh/grid/noderefresh.odesign
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="ASCII"?>
+<description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" version="15.4.0.202401051836">
+  <ownedViewpoints name="UML2" modelFileExtension="uml">
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" name="Node Class and Package Diagram with Ports" domainClass="Package">
+      <metamodel href="platform:/plugin/org.eclipse.uml2.uml/model/UML.ecore#/"/>
+      <filters xsi:type="filter:CompositeFilterDescription" name="FilterPropertyStartingWithA">
+        <filters xsi:type="filter:MappingFilter" filterKind="COLLAPSE" mappings="//@ownedViewpoints[name='UML2']/@ownedRepresentations[name='Node%20Class%20and%20Package%20Diagram%20with%20Ports']/@defaultLayer/@nodeMappings[name='CPDP%20Class']/@borderedNodeMappings[name='CPDP%20Property']" semanticConditionExpression="aql:not (self.name.startsWith('a'))"/>
+      </filters>
+      <filters xsi:type="filter:CompositeFilterDescription" name="FilterClassAndPackageStartingWithA">
+        <filters xsi:type="filter:MappingFilter" filterKind="COLLAPSE" mappings="//@ownedViewpoints[name='UML2']/@ownedRepresentations[name='Node%20Class%20and%20Package%20Diagram%20with%20Ports']/@defaultLayer/@nodeMappings[name='CPDP%20Class']" semanticConditionExpression="aql:not (self.name.startsWith('a'))"/>
+      </filters>
+      <defaultLayer name="Default">
+        <nodeMappings name="CPDP Class" semanticCandidatesExpression="aql:self.eContents()" synchronizationLock="true" domainClass="uml::Class">
+          <borderedNodeMappings name="CPDP Property" semanticCandidatesExpression="aql:self.eContents()" domainClass="uml::Property">
+            <style xsi:type="style:BundledImageDescription" showIcon="false" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <forbiddenSides>WEST</forbiddenSides>
+              <forbiddenSides>EAST</forbiddenSides>
+              <forbiddenSides>NORTH</forbiddenSides>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='blue']"/>
+            </style>
+          </borderedNodeMappings>
+          <borderedNodeMappings name="CPDP Association" semanticCandidatesExpression="aql:self.eContents()->select( e | not e.toString().startsWith('a'))" domainClass="uml::Association">
+            <style xsi:type="style:SquareDescription" showIcon="false" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <forbiddenSides>WEST</forbiddenSides>
+              <forbiddenSides>SOUTH</forbiddenSides>
+              <forbiddenSides>NORTH</forbiddenSides>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_green']"/>
+            </style>
+          </borderedNodeMappings>
+          <style xsi:type="style:BundledImageDescription" sizeComputationExpression="18" resizeKind="NSEW">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='blue']"/>
+          </style>
+          <conditionnalStyles predicateExpression="aql:self.isAbstract">
+            <style xsi:type="style:BundledImageDescription" sizeComputationExpression="18">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='blue']"/>
+            </style>
+          </conditionnalStyles>
+        </nodeMappings>
+        <containerMappings name="CPDP Package" detailDescriptions="//@ownedViewpoints[name='UML2']/@ownedRepresentations[name='Node%20Class%20and%20Package%20Diagram%20with%20Ports']/@toolSection/@ownedTools[name='New%20diagram']" semanticCandidatesExpression="aql:self.eContents()" synchronizationLock="true" domainClass="uml::Package" reusedNodeMappings="//@ownedViewpoints[name='UML2']/@ownedRepresentations[name='Node%20Class%20and%20Package%20Diagram%20with%20Ports']/@defaultLayer/@nodeMappings[name='CPDP%20Class']" reusedContainerMappings="//@ownedViewpoints[name='UML2']/@ownedRepresentations[name='Node%20Class%20and%20Package%20Diagram%20with%20Ports']/@defaultLayer/@containerMappings[name='CPDP%20Package']">
+          <style xsi:type="style:FlatContainerStyleDescription" borderSizeComputationExpression="1" labelSize="12" widthComputationExpression="18" heightComputationExpression="18">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_gray']"/>
+          </style>
+        </containerMappings>
+      </defaultLayer>
+      <toolSection name="navigation">
+        <ownedTools xsi:type="tool:DiagramCreationDescription" name="New diagram" diagramDescription="//@ownedViewpoints[name='UML2']/@ownedRepresentations[name='Node%20Class%20and%20Package%20Diagram%20with%20Ports']">
+          <initialOperation/>
+          <containerViewVariable name="containerView"/>
+          <representationNameVariable name="diagramName"/>
+        </ownedTools>
+      </toolSection>
+    </ownedRepresentations>
+  </ownedViewpoints>
+</description:Group>

--- a/plugins/org.eclipse.sirius.tests.junit/data/unit/refresh/grid/noderefresh.uml
+++ b/plugins/org.eclipse.sirius.tests.junit/data/unit/refresh/grid/noderefresh.uml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="2.1" xmlns:xmi="http://schema.omg.org/spec/XMI/2.1" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Wh_KkEjgEd2dA-w4B9F6fQ">
+  <packagedElement xmi:type="uml:Class" xmi:id="_Zfig0EjgEd2dA-w4B9F6fQ" name="Class1">
+    <ownedAttribute xmi:id="_tReeYUmdEd2kFfZE5plhWg" name="Prop1to2" type="_bZr5UEjgEd2dA-w4B9F6fQ"/>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Class" xmi:id="_bZr5UEjgEd2dA-w4B9F6fQ" name="Class2">
+    <ownedAttribute xmi:id="_rDAP8FNGEd2swLTvVm1NKg" name="Prop2to2" type="_bZr5UEjgEd2dA-w4B9F6fQ"/>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Class" xmi:id="_cPW9EEjgEd2dA-w4B9F6fQ" name="Class3">
+    <ownedAttribute xmi:id="_u8vGUEmdEd2kFfZE5plhWg" name="Prop3to2" type="_bZr5UEjgEd2dA-w4B9F6fQ"/>
+    <ownedAttribute xmi:id="_k5sIUFNGEd2swLTvVm1NKg" name="OtherProp3to2" type="_bZr5UEjgEd2dA-w4B9F6fQ"/>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Package" xmi:id="_6o6RMEmrEd2kFfZE5plhWg" name="SubPackage">
+    <packagedElement xmi:type="uml:Package" xmi:id="_nhLckAM9EfCYdNmG1JniBQ" name="Sub2">
+      <packagedElement xmi:type="uml:Class" xmi:id="_cMxa8AP_EfCkhq75xJPwpA" name="InClass1"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_qYAKkAP_EfCkhq75xJPwpA" name="InClass2"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="_8WNggEmrEd2kFfZE5plhWg" name="SubClass1">
+      <ownedAttribute xmi:id="_rOlyIPBoEe-sUa64Dl7qNw" name="a"/>
+      <ownedAttribute xmi:id="__y-NcPBuEe-sUa64Dl7qNw" name="b"/>
+      <nestedClassifier xmi:type="uml:AssociationClass" xmi:id="_W0W_UADfEfCCQaB7ukJWEg" name="c"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="_7ZyHQADjEfCCQaB7ukJWEg" name="SubClass2" isAbstract="true"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_FbJD8AQEEfCkhq75xJPwpA" name="Sub1"/>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Package" xmi:id="_sQN84FM5Ed2swLTvVm1NKg" name="EmptyPackage">
+  </packagedElement>
+</uml:Model>

--- a/plugins/org.eclipse.sirius.tests.junit/launchers/PortLocationTest.launch
+++ b/plugins/org.eclipse.sirius.tests.junit/launchers/PortLocationTest.launch
@@ -15,7 +15,7 @@
     <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
     <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/suite/AllSiriusTestSuite.java"/>
+        <listEntry value="/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/modeler/uml/PortLocationTest.java"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="1"/>
@@ -24,7 +24,6 @@
         <mapEntry key="DISPLAY" value=":1"/>
         <mapEntry key="SWT_GTK3" value="0"/>
     </mapAttribute>
-    <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/org.eclipse.sirius.tests}/output.log"/>
     <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
         <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
     </listAttribute>
@@ -35,7 +34,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
-    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.sirius.tests.suite.AllSiriusTestSuite"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.sirius.tests.unit.diagram.modeler.uml.PortLocationTest"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl}"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.sirius.tests.junit"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/modeler/uml/GridOnLocationTest.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/modeler/uml/GridOnLocationTest.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2017 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.tests.unit.diagram.modeler.uml;
+
+import java.util.concurrent.Callable;
+import java.util.function.Predicate;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.impl.InternalTransaction;
+import org.eclipse.emf.transaction.impl.InternalTransactionalEditingDomain;
+import org.eclipse.gef.rulers.RulerProvider;
+import org.eclipse.gmf.runtime.diagram.ui.preferences.IPreferenceConstants;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.gmf.runtime.notation.Size;
+import org.eclipse.sirius.business.api.dialect.DialectManager;
+import org.eclipse.sirius.business.internal.session.danalysis.SaveSessionJob;
+import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.diagram.DDiagramElement;
+import org.eclipse.sirius.tests.support.api.SiriusDiagramTestCase;
+import org.eclipse.sirius.tests.support.api.TestsUtil;
+import org.eclipse.sirius.ui.business.api.dialect.DialectUIManager;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.uml2.uml.Class;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.Model;
+import org.eclipse.uml2.uml.Package;
+import org.junit.Ignore;
+
+/**
+ * Tests that when on-grid is active, node corners are on the grid.
+ * 
+ * @author nperansin
+ */
+public class GridOnLocationTest extends SiriusDiagramTestCase {
+    
+    private static final int SPACING = 50;
+    
+    private static final String RESOURCE_PATH = "/org.eclipse.sirius.tests.junit/data/unit/refresh/grid/";
+
+    private static final String SEMANTIC_MODEL_PATH = RESOURCE_PATH + "noderefresh.uml";
+
+    private static final String MODELER_PATH = RESOURCE_PATH + "noderefresh.odesign";
+
+    private static final String VIEWPOINT_NAME = "UML2";
+
+    private static final String DIAGRAM_DESC_NAME = "Node Class and Package Diagram with Ports";
+
+    private static final Predicate<Size> WIDTH_ON_GRID = size -> onGrid(size.getWidth());
+    private static final Predicate<Size> HEIGHT_ON_GRID = size -> onGrid(size.getHeight());
+    private static final Predicate<Size> SIZE_ON_GRID = WIDTH_ON_GRID.and(HEIGHT_ON_GRID);
+    
+    
+    private DDiagram diagram;
+    private IEditorPart editorPart;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        genericSetUp(SEMANTIC_MODEL_PATH, MODELER_PATH);
+        initViewpoint(VIEWPOINT_NAME);
+        changeDiagramUIPreference(IPreferenceConstants.PREF_SNAP_TO_GRID, true);
+        changeDiagramUIPreference(IPreferenceConstants.PREF_RULER_UNITS, RulerProvider.UNIT_PIXELS);
+        changeDiagramUIPreference(IPreferenceConstants.PREF_GRID_SPACING, SPACING);
+    }
+    
+    /**
+     * Tests elements size matches grid spacing when creating a diagram.
+     */
+    @Ignore
+    public void testNodeSizeOnGridAtCreation() throws Exception {
+
+        // Get target of diagram
+        Package diagramTarget = (Package) ((Model) semanticModel).getPackagedElement("SubPackage");
+
+        ensureDiagram(diagramTarget, DIAGRAM_DESC_NAME);
+
+        // Check size on resizable node
+        Class subClass1 = (Class) diagramTarget.getPackagedElement("SubClass1");
+        assertTrue(!subClass1.isAbstract()); // not abstract is resizable
+
+        assertOnSize("GMF node Size should be on grid", subClass1, SIZE_ON_GRID);
+
+        // Port size on horizontal side (Property)
+        assertOnSize("GMF port has unexpected width", subClass1.getOwnedAttribute("a", null), WIDTH_ON_GRID);
+        assertOnSize("GMF port has unexpected width", subClass1.getOwnedAttribute("b", null), WIDTH_ON_GRID);
+
+        // Port size on vertical side (Association)
+        assertOnSize("GMF port has unexpected height", subClass1.getNestedClassifier("c"), HEIGHT_ON_GRID);
+
+        // Check size on fixed-size node
+        Class subClass2 = (Class) diagramTarget.getPackagedElement("SubClass2");
+        assertTrue(subClass2.isAbstract()); // abstract is not resizable
+        assertOnSize("GMF node size should be fix", subClass2, size -> size.getWidth() == 180 && size.getHeight() == 180);
+
+        // Check size on container (always resizable)
+        Package inPack = (Package) diagramTarget.getPackagedElement("Sub1");
+        // FIXME
+        // Container is not on grid as Diagram creation performs an "Arrange All".
+        // "Arrange All" simply removes explicit dimension but do not arrange size on grid.
+        assertOnSize("GMF node has unexpected size", inPack,
+                // should be : SIZE_ON_GRID;
+                size -> true);
+    }
+
+    /**
+     * Tests elements size matches grid spacing when created element in a open diagram.
+     */
+    public void testNodeSizeOnGridOnRefresh() throws Exception {
+
+        // Get target of diagram
+        Package diagramTarget = (Package) ((Model) semanticModel).getPackagedElement("EmptyPackage");
+
+        // Check size on node with free resize
+        ensureDiagram(diagramTarget, DIAGRAM_DESC_NAME);
+        Class subClass1 = executeInSession(() -> {
+            // not abstract is resizable
+            Class creation = diagramTarget.createOwnedClass("SubClass1", false);
+            creation.createOwnedAttribute("a", null);
+
+            return creation;
+        });
+        
+        assertOnSize("GMF node Size should be on grid", subClass1, SIZE_ON_GRID);
+        assertOnSize("GMF port has unexpected width", subClass1.getOwnedAttribute("a", null), WIDTH_ON_GRID);
+        
+        // Check size on container
+        Package inPack = executeInSession(() -> diagramTarget.createNestedPackage("Sub1"));
+        assertOnSize("GMF node has unexpected size", inPack, SIZE_ON_GRID);
+    }
+    
+    private <V> V executeInSession(Callable<V> task) {
+        UpdateCommand<V> command = new UpdateCommand<V>(task);
+        executeCommand(command);
+        TestsUtil.synchronizationWithUIThread();
+
+        if (command.failure instanceof RuntimeException re) {
+            throw re;
+        } else if (command.failure instanceof Error re) {
+            throw re;
+        } else if (command.failure != null) {
+            throw new RuntimeException(command.failure);
+        } else if (command.transaction.getStatus().getSeverity() > IStatus.WARNING) {
+            throw new RuntimeException(command.transaction.getStatus().getException());
+        }
+        return command.value;
+    }
+    
+    private class UpdateCommand<V> extends RecordingCommand {
+        
+        final Callable<V> task;
+        V value;
+        Throwable failure;
+        InternalTransaction transaction;
+        
+        protected UpdateCommand(Callable<V> task) {
+            super(session.getTransactionalEditingDomain());
+            this.task = task;
+        }
+        
+        @Override
+        protected void doExecute() {
+            transaction = ((InternalTransactionalEditingDomain) session.getTransactionalEditingDomain()).getActiveTransaction();
+            try {
+                value = task.call();
+                // Diagram refresh is not automatic
+                DialectManager.INSTANCE.refresh(diagram, new NullProgressMonitor());
+            } catch (Throwable fail) {
+                failure = fail;
+            }
+        }
+    }
+    
+    private void ensureDiagram(EObject diagramTarget, String diagramDescrName) throws Exception {
+        TestsUtil.synchronizationWithUIThread();
+        Job.getJobManager().join(SaveSessionJob.FAMILY, new NullProgressMonitor());
+        
+        // Get the diagram for the root of this model.
+        diagram = (DDiagram) createRepresentation(diagramDescrName, diagramTarget);
+
+        // Open the editor (and refresh it)
+        editorPart = DialectUIManager.INSTANCE.openEditor(session, diagram, new NullProgressMonitor());
+        TestsUtil.synchronizationWithUIThread();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (editorPart != null) {
+            DialectUIManager.INSTANCE.closeEditor(editorPart, false);
+            TestsUtil.synchronizationWithUIThread();
+        }
+        super.tearDown();
+    }
+    
+    private static boolean onGrid(int value) {
+        return value % SPACING == 0;
+    }
+    
+    private void assertOnSize(String message, Element target, Predicate<Size> expectation) {
+        DDiagramElement siriusElement = getFirstDiagramElement(diagram, target);
+        Node node = getGmfNode(siriusElement);
+        assertTrue(message, expectation.test((Size) node.getLayoutConstraint()));
+    }
+    
+}

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/modeler/uml/PortLocationTest.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/modeler/uml/PortLocationTest.java
@@ -62,10 +62,13 @@ import org.eclipse.uml2.uml.UMLFactory;
  * @author lredor
  */
 public class PortLocationTest extends SiriusDiagramTestCase {
+    
+    
+    private static final String RESOURCE_PATH = "/org.eclipse.sirius.tests.junit/data/unit/refresh/grid/";
 
-    private static final String SEMANTIC_MODEL_PATH = "/org.eclipse.sirius.tests.junit/data/unit/refresh/node/noderefresh.uml";
+    private static final String SEMANTIC_MODEL_PATH = RESOURCE_PATH + "noderefresh.uml";
 
-    private static final String MODELER_PATH = "/org.eclipse.sirius.tests.junit/data/unit/refresh/node/noderefresh.odesign";
+    private static final String MODELER_PATH = RESOURCE_PATH + "noderefresh.odesign";
 
     private static final String VIEWPOINT_NAME = "UML2";
 


### PR DESCRIPTION
When creating a node and snap-to-grid is active, size is adjusted so all corner are on the grid.

This is limited to node mapping with size hint on resizable axis.
Node with no-size hint mapping are driven by Edit Part and Edit Part are not available when node is placed at creation time.

## Steps to tests

- Use provided VSM to create elements
[noderefresh.zip](https://github.com/user-attachments/files/19623490/noderefresh.zip)
- Create a diagram with snap-on-grid, displayed grid, and grid spacing = 40
- Element must match grid spacing