### PR TITLE
[580] Snap to grid on center for not-resizable node

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
@@ -141,6 +141,10 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
         }
     }
 
+    private NodePositionHelper getNodePositionHelper() {
+        return new NodePositionHelper(isSnapToGrid(), getGridSpacing());
+    }
+
     /**
      * Refresh the specified {@link View} children with the specified semantic element.
      * 
@@ -543,14 +547,14 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
                 }
             }
 
-            final Point location = new NodePositionHelper(isSnapToGrid(), getGridSpacing()).getOnBorderPositionFromParent(createdNode, contextLocation, size);
+            final Point location = getNodePositionHelper().getOnBorderPositionFromParent(createdNode, contextLocation, size);
 
             laidOut = laidOut || createdNode.getLayoutConstraint() instanceof Location;
             updateBoundsConstraint(createdNode, location, size != null ? size : NO_CHANGE_SIZE);
 
         } else {
             laidOut = true;
-            final Point location = new NodePositionHelper(isSnapToGrid(), getGridSpacing()).getOnBorderPositionFromLayoutData(createdNode, layoutData);
+            final Point location = getNodePositionHelper().getOnBorderPositionFromLayoutData(createdNode, layoutData);
 
             updateBoundsConstraint(createdNode, location, layoutData.getSize());
         }
@@ -623,7 +627,7 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
     protected void updateSizeConstraint(Node createdNode, Size constraint, Dimension size) {
         Dimension safeSize = size != null ? size : NO_CHANGE_SIZE;
 
-        Dimension defaultSize = new NodePositionHelper(isSnapToGrid(), getGridSpacing()).getAdjustedDimension(createdNode, constraint);
+        Dimension defaultSize = getNodePositionHelper().getAdjustedDimension(createdNode, constraint);
 
         // Dnd nodes are not really new and must be kept as-is.
         boolean collapsedSizeForced = new NodeQuery(createdNode).isCollapsed() && size != null;
@@ -639,7 +643,8 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
     private void updateBoundsConstraint(Node createdNode, Point location, Dimension size) {
         LayoutConstraint constraint = createdNode.getLayoutConstraint();
         if (constraint instanceof Location locationConstraint) {
-            updateLocationConstraint(locationConstraint, location);
+            Point ajdustedLocation = getNodePositionHelper().getAdjustedLocation(createdNode, location);
+            updateLocationConstraint(locationConstraint, ajdustedLocation);  
         }
         if (constraint instanceof Size sizeConstraint) {
             updateSizeConstraint(createdNode, sizeConstraint, size);
@@ -668,9 +673,7 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
      * @return view descriptor
      */
     protected CreateViewRequest.ViewDescriptor getViewDescriptor(final EObject element, final String factoryHint) {
-        //
-        // create the view descritor
-        // final IAdaptable elementAdapter = new EObjectAdapter(element);
+        // Create the view descriptor
         final IAdaptable elementAdapter = new CanonicalElementAdapter(element, factoryHint);
 
         final int pos = ViewUtil.APPEND;

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/ruler/SiriusSnapToGrid.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/ruler/SiriusSnapToGrid.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.diagram.ui.tools.internal.ruler;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PrecisionRectangle;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.Request;
+import org.eclipse.gef.requests.ChangeBoundsRequest;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.ShapeNodeEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.internal.ruler.SnapToGridEx;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.gmf.runtime.notation.Size;
+import org.eclipse.sirius.diagram.ui.internal.refresh.NodePositionHelper;
+
+@SuppressWarnings("restriction") // gmf is very (too) restrictive
+public class SiriusSnapToGrid extends SnapToGridEx {
+
+    /**
+     * Default constructor.
+     * 
+     * @param container edit part
+     */
+    public SiriusSnapToGrid(GraphicalEditPart container) {
+        super(container);
+    }
+
+    @Override
+    public int snapRectangle(Request request, int snapLocations, PrecisionRectangle rect, PrecisionRectangle result) {
+        Point oldOrigin = origin;
+
+        if (request instanceof ChangeBoundsRequest cbr) {
+            // only case for snap to grid
+            ajustForFixedSizeNode(cbr);
+        }
+        try {
+            return super.snapRectangle(request, snapLocations, rect, result);
+        } finally {
+            origin = oldOrigin;
+        }
+    }
+
+    private void ajustForFixedSizeNode(ChangeBoundsRequest request) {
+        if (request.getEditParts().size() == 1 // for single-selection,
+                && request.getEditParts().get(0) instanceof ShapeNodeEditPart ep // of nodes
+                && ep.getModel() instanceof Node node // with size (for example, list elements have no size)
+                && node.getLayoutConstraint() instanceof Size size) {
+
+            // It is easier to shift the origin than to alter the result.
+            origin = origin.getCopy().translate(NodePositionHelper.getShiftToCenter(node, size,
+                    // In Sirius diagram, gridX == gridY
+                    gridX));
+        }
+    }
+
+}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/ruler/SiriusSnapToHelperUtil.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/ruler/SiriusSnapToHelperUtil.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2007, 2016 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,6 @@ import org.eclipse.gef.rulers.RulerProvider;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.internal.editparts.ISurfaceEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.internal.ruler.CompoundSnapToHelperEx;
-import org.eclipse.gmf.runtime.diagram.ui.internal.ruler.SnapToGridEx;
 import org.eclipse.gmf.runtime.diagram.ui.internal.ruler.SnapToGuidesEx;
 import org.eclipse.gmf.runtime.diagram.ui.internal.ruler.SnapToHelperUtil;
 import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNodeEditPart;
@@ -90,7 +89,7 @@ public class SiriusSnapToHelperUtil extends SnapToHelperUtil {
         val = (Boolean) viewer.getProperty(SnapToGrid.PROPERTY_GRID_ENABLED);
 
         if (val != null && val.booleanValue()) {
-            snapStrategies.add(new SnapToGridEx(diagramEditPart));
+            snapStrategies.add(new SiriusSnapToGrid(diagramEditPart));
         }
 
         if (snapStrategies.size() == 0) {

--- a/plugins/org.eclipse.sirius.doc/doc/Release_Notes.html
+++ b/plugins/org.eclipse.sirius.doc/doc/Release_Notes.html
@@ -296,6 +296,7 @@
 			<li><span class="label label-info">Modified</span> Edition using the Grid has been improved. 
 				<ul>
 					<li>When creating a node with &#8220;Snap to Grid&#8221; enabled, its size is adjusted to the grid spacing so that its resizable sides align with the grid. This ensures that the node’s corners match the grid intersections. Currently, this only applies when the node mapping provides size hints to define a preferred size.</li>
+					<li>When creating or moving a node with &#8220;Snap to Grid&#8221; enabled, its position is adjusted to the grid spacing so that fixed-size sides are centered. This results in better alignment and centering of edges, as well as for most border and image-based nodes.</li>
 				</ul>
 			</li>
 		</ul>

--- a/plugins/org.eclipse.sirius.doc/doc/Release_Notes.textile
+++ b/plugins/org.eclipse.sirius.doc/doc/Release_Notes.textile
@@ -17,6 +17,7 @@ h3. User-Visible Changes
 
 * <span class="label label-info">Modified</span> Edition using the Grid has been improved. 
 ** When creating a node with "Snap to Grid" enabled, its size is adjusted to the grid spacing so that its resizable sides align with the grid. This ensures that the node’s corners match the grid intersections. Currently, this only applies when the node mapping provides size hints to define a preferred size.
+** When creating or moving a node with "Snap to Grid" enabled, its position is adjusted to the grid spacing so that fixed-size sides are centered. This results in better alignment and centering of edges, as well as for most border and image-based nodes.
 
 h3. Specifiers-Visible Changes
 

--- a/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/editor/SWTBotSiriusDiagramEditor.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot.support/src/org/eclipse/sirius/tests/swtbot/support/api/editor/SWTBotSiriusDiagramEditor.java
@@ -42,13 +42,13 @@ import org.eclipse.gmf.runtime.diagram.ui.editparts.AbstractBorderedShapeEditPar
 import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.internal.properties.WorkspaceViewerProperties;
-import org.eclipse.gmf.runtime.diagram.ui.internal.ruler.SnapToGridEx;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramUIMessages;
 import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramGraphicalViewer;
 import org.eclipse.gmf.runtime.diagram.ui.parts.IDiagramGraphicalViewer;
 import org.eclipse.gmf.runtime.diagram.ui.parts.IDiagramWorkbenchPart;
 import org.eclipse.gmf.runtime.diagram.ui.requests.RequestConstants;
 import org.eclipse.jface.bindings.keys.KeyStroke;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.sirius.business.api.query.EObjectQuery;
 import org.eclipse.sirius.business.api.session.Session;
@@ -63,6 +63,7 @@ import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeEndNameEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeNameEditPart;
 import org.eclipse.sirius.diagram.ui.provider.DiagramUIPlugin;
 import org.eclipse.sirius.diagram.ui.tools.api.preferences.SiriusDiagramUiPreferencesKeys;
+import org.eclipse.sirius.diagram.ui.tools.internal.ruler.SiriusSnapToGrid;
 import org.eclipse.sirius.ext.draw2d.figure.FigureUtilities;
 import org.eclipse.sirius.tests.swtbot.support.api.bot.SWTDesignerBot;
 import org.eclipse.sirius.tests.swtbot.support.api.business.UIDiagramRepresentation;
@@ -90,7 +91,6 @@ import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefFigureCanvas;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 import org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory;
-import org.eclipse.swtbot.swt.finder.results.BoolResult;
 import org.eclipse.swtbot.swt.finder.results.Result;
 import org.eclipse.swtbot.swt.finder.results.VoidResult;
 import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
@@ -1588,6 +1588,10 @@ public class SWTBotSiriusDiagramEditor extends SWTBotGefEditor {
         setSnapToGrid(false);
     }
 
+    private IPreferenceStore getDiagramPreferenceStore() {
+        return ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore();
+    }
+    
     /**
      * Disable or enable the snapToGrid option for this editor.
      * 
@@ -1595,12 +1599,7 @@ public class SWTBotSiriusDiagramEditor extends SWTBotGefEditor {
      *            true to enable, false to disable snap to grid property
      */
     public void setSnapToGrid(final boolean snap) {
-        UIThreadRunnable.syncExec(SWTUtils.display(), new VoidResult() {
-            @Override
-            public void run() {
-                ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().setValue(WorkspaceViewerProperties.SNAPTOGRID, snap);
-            }
-        });
+        UIThreadRunnable.syncExec(() -> getDiagramPreferenceStore().setValue(WorkspaceViewerProperties.SNAPTOGRID, snap));
     }
 
     /**
@@ -1610,12 +1609,7 @@ public class SWTBotSiriusDiagramEditor extends SWTBotGefEditor {
      *            true to enable, false to disable snap to shape property
      */
     public void setSnapToShape(final boolean snap) {
-        UIThreadRunnable.syncExec(SWTUtils.display(), new VoidResult() {
-            @Override
-            public void run() {
-                ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().setValue(WorkspaceViewerProperties.SNAPTOGEOMETRY, snap);
-            }
-        });
+        UIThreadRunnable.syncExec(() -> getDiagramPreferenceStore().setValue(WorkspaceViewerProperties.SNAPTOGEOMETRY, snap));
     }
 
     /**
@@ -1624,14 +1618,7 @@ public class SWTBotSiriusDiagramEditor extends SWTBotGefEditor {
      * @return the "Snap to grid" option value for this editor.
      */
     public boolean isSnapToShape() {
-        BoolResult snapToShape = new BoolResult() {
-
-            @Override
-            public Boolean run() {
-                return ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().getBoolean(WorkspaceViewerProperties.SNAPTOGEOMETRY);
-            }
-        };
-        return UIThreadRunnable.syncExec(snapToShape).booleanValue();
+        return UIThreadRunnable.syncExec(() -> getDiagramPreferenceStore().getBoolean(WorkspaceViewerProperties.SNAPTOGEOMETRY));
     }
 
     /**
@@ -1645,14 +1632,12 @@ public class SWTBotSiriusDiagramEditor extends SWTBotGefEditor {
      *            The ruler units value (0 for Inches, 1 for Centimeters, 2 for Pixels)
      */
     public void setSnapToGrid(final boolean snap, final double gridSpacing, final int rulerUnits) {
-        PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
-            @Override
-            public void run() {
-                ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().setValue(WorkspaceViewerProperties.SNAPTOGRID, snap);
-                ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().setValue(WorkspaceViewerProperties.VIEWGRID, snap);
-                ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().setValue(WorkspaceViewerProperties.GRIDSPACING, gridSpacing);
-                ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().setValue(WorkspaceViewerProperties.RULERUNIT, rulerUnits);
-            }
+        UIThreadRunnable.syncExec(() -> {
+            var prefStore = getDiagramPreferenceStore();
+            prefStore.setValue(WorkspaceViewerProperties.SNAPTOGRID, snap);
+            prefStore.setValue(WorkspaceViewerProperties.VIEWGRID, snap);
+            prefStore.setValue(WorkspaceViewerProperties.GRIDSPACING, gridSpacing);
+            prefStore.setValue(WorkspaceViewerProperties.RULERUNIT, rulerUnits);
         });
     }
 
@@ -1662,14 +1647,7 @@ public class SWTBotSiriusDiagramEditor extends SWTBotGefEditor {
      * @return the "Snap to grid" option value for this editor.
      */
     public boolean isSnapToGrid() {
-        BoolResult snapToGrid = new BoolResult() {
-
-            @Override
-            public Boolean run() {
-                return ((DiagramGraphicalViewer) getDiagramGraphicalViewer()).getWorkspaceViewerPreferenceStore().getBoolean(WorkspaceViewerProperties.SNAPTOGRID);
-            }
-        };
-        return UIThreadRunnable.syncExec(snapToGrid).booleanValue();
+        return UIThreadRunnable.syncExec(() -> getDiagramPreferenceStore().getBoolean(WorkspaceViewerProperties.SNAPTOGRID));
     }
 
     /**
@@ -1889,7 +1867,7 @@ public class SWTBotSiriusDiagramEditor extends SWTBotGefEditor {
      */
     public PrecisionPoint adaptLocationToSnap(Point expectedAbsoluteLocation) {
         IGraphicalEditPart diagramEditPart = getDiagramEditPart();
-        SnapToHelper snapToHelper = new SnapToGridEx(diagramEditPart);
+        SnapToHelper snapToHelper = new SiriusSnapToGrid(diagramEditPart);
         PrecisionPoint preciseLocation = new PrecisionPoint(expectedAbsoluteLocation);
         diagramEditPart.getFigure().translateToAbsolute(preciseLocation);
         PrecisionPoint result = new PrecisionPoint(preciseLocation);

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeCreationTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeCreationTest.java
@@ -314,9 +314,7 @@ public class NodeCreationTest extends AbstractSiriusSwtBotGefTestCase {
     }
 
     /**
-     * Check that the created Node is near the expected location. We don't check
-     * precisely the location because the zoom can have round effect on the
-     * location.
+     * Check that the created Node is near the expected location.
      * 
      * @param nodeLabel
      *            the name of the Node to check
@@ -326,7 +324,7 @@ public class NodeCreationTest extends AbstractSiriusSwtBotGefTestCase {
      */
     private void assertNodeAtLocation(String nodeLabel, Point expectedLocation) {
         Point nodeLocation = editor.getAbsoluteLocation(nodeLabel, NodeEditPart.class);
-        assertEquals("The Node has been created at wrong location.", adaptLocation(expectedLocation), nodeLocation);
+        assertEquals("The Node has been created at wrong location.", adaptNodeLocation(expectedLocation), nodeLocation);
     }
 
     /**
@@ -337,7 +335,7 @@ public class NodeCreationTest extends AbstractSiriusSwtBotGefTestCase {
      *            The initial expected location
      * @return The adapted location
      */
-    protected Point adaptLocation(Point expectedLocation) {
+    protected Point adaptNodeLocation(Point expectedLocation) {
         return expectedLocation;
     }
 }

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeCreationWithSnapToGridTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/NodeCreationWithSnapToGridTest.java
@@ -13,6 +13,8 @@
 package org.eclipse.sirius.tests.swtbot;
 
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.rulers.RulerProvider;
+import org.eclipse.sirius.diagram.ui.tools.api.layout.LayoutUtils;
 
 /**
  * Same tests as {@link NodeCreationTest} but with snapToGrid enabled.
@@ -21,15 +23,28 @@ import org.eclipse.draw2d.geometry.Point;
  */
 public class NodeCreationWithSnapToGridTest extends NodeCreationTest {
 
+    // In vp-1174.odesign, 
+    // Class mapping is un-resizable square.
+    
+    protected static final int VSM_SIDE_SIZE = 3; // as expressed 
+    protected static final int SIDE_SIZE = VSM_SIDE_SIZE * LayoutUtils.SCALE; // as expressed 
+    protected static final int GRID_SIZE = 100;
+    
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-
-        editor.setSnapToGrid(true, 100, 2);
+        
+        editor.setSnapToGrid(true, GRID_SIZE, RulerProvider.UNIT_PIXELS);
     }
 
     @Override
-    protected Point adaptLocation(Point expectedAbsoluteLocation) {
-        return editor.adaptLocationToSnap(expectedAbsoluteLocation);
+    protected Point adaptNodeLocation(Point expectedAbsoluteLocation) {
+        Point onGridLocation = editor.adaptLocationToSnap(expectedAbsoluteLocation);
+        // As the element is not resizable,
+        // its position is shifted so the node center is on a grid point.
+        int shift = - SIDE_SIZE % GRID_SIZE / 2;
+        // Negative shift is consistent with NodePositionHelper#shiftLocationToCenter(...) implementation.
+                
+        return onGridLocation.translate(shift, shift);
     }
 }


### PR DESCRIPTION
When moving or creating fixed size nodes, the center of the node snap to center instead of its side.

For those nodes, creating edges will be aligned to grid.

## Steps to tests
- Use provided VSM to create elements
[noderefresh.zip](https://github.com/user-attachments/files/19623490/noderefresh.zip)
- Create a diagram with snap-on-grid, displayed grid, and grid spacing = 40
- Creates elements: Instance 
- "Instance" must be centered vertically on creation and when moved
- "Property" and "Association" on "Class" must be centered on creation and when moved