### PR TITLE
[590] Remove not handled mappings from layers children creation menu

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/business/api/diagramtype/SequenceDiagramTypeProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/business/api/diagramtype/SequenceDiagramTypeProvider.java
@@ -116,17 +116,11 @@ public class SequenceDiagramTypeProvider implements IDiagramDescriptionProvider 
         return DescriptionPackage.eINSTANCE.equals(eClass.getEPackage());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DiagramDescription createDiagramDescription() {
         return DescriptionFactory.eINSTANCE.createSequenceDiagramDescription();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<? extends CommandParameter> collectToolCommands(EObject context) {
         Collection<CommandParameter> result = new ArrayList<>();
@@ -148,25 +142,17 @@ public class SequenceDiagramTypeProvider implements IDiagramDescriptionProvider 
         return result;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<? extends CommandParameter> collectMappingsCommands() {
         Collection<CommandParameter> result = new ArrayList<>();
         // Nodes
         result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__NODE_MAPPINGS, DescriptionFactory.eINSTANCE.createInstanceRoleMapping()));
-        result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__NODE_MAPPINGS, DescriptionFactory.eINSTANCE.createExecutionMapping()));
-        result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__NODE_MAPPINGS, DescriptionFactory.eINSTANCE.createStateMapping()));
-        result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__NODE_MAPPINGS, DescriptionFactory.eINSTANCE.createEndOfLifeMapping()));
         result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__NODE_MAPPINGS, DescriptionFactory.eINSTANCE.createObservationPointMapping()));
-        result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__NODE_MAPPINGS, DescriptionFactory.eINSTANCE.createGateMapping()));
         // Containers
         result.add(
                 new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__CONTAINER_MAPPINGS, DescriptionFactory.eINSTANCE.createInteractionUseMapping()));
         result.add(
                 new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__CONTAINER_MAPPINGS, DescriptionFactory.eINSTANCE.createCombinedFragmentMapping()));
-        result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__CONTAINER_MAPPINGS, DescriptionFactory.eINSTANCE.createOperandMapping()));
         result.add(new CommandParameter(null, org.eclipse.sirius.diagram.description.DescriptionPackage.Literals.LAYER__CONTAINER_MAPPINGS,
                 DescriptionFactory.eINSTANCE.createInteractionContainerMapping()));
         // Edges
@@ -177,9 +163,6 @@ public class SequenceDiagramTypeProvider implements IDiagramDescriptionProvider 
         return result;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public AdapterFactory getAdapterFactory() {
         ComposedAdapterFactory composed = new ComposedAdapterFactory();

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/sequence/NewChildMenusExtensionTests.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/sequence/NewChildMenusExtensionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2025 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,15 +29,11 @@ import org.eclipse.sirius.diagram.sequence.description.CombinedFragmentMapping;
 import org.eclipse.sirius.diagram.sequence.description.CreationMessageMapping;
 import org.eclipse.sirius.diagram.sequence.description.DescriptionFactory;
 import org.eclipse.sirius.diagram.sequence.description.DestructionMessageMapping;
-import org.eclipse.sirius.diagram.sequence.description.EndOfLifeMapping;
-import org.eclipse.sirius.diagram.sequence.description.ExecutionMapping;
 import org.eclipse.sirius.diagram.sequence.description.InstanceRoleMapping;
 import org.eclipse.sirius.diagram.sequence.description.InteractionUseMapping;
 import org.eclipse.sirius.diagram.sequence.description.ObservationPointMapping;
-import org.eclipse.sirius.diagram.sequence.description.OperandMapping;
 import org.eclipse.sirius.diagram.sequence.description.ReturnMessageMapping;
 import org.eclipse.sirius.diagram.sequence.description.SequenceDiagramDescription;
-import org.eclipse.sirius.diagram.sequence.description.StateMapping;
 import org.eclipse.sirius.diagram.sequence.description.tool.CombinedFragmentCreationTool;
 import org.eclipse.sirius.diagram.sequence.description.tool.ExecutionCreationTool;
 import org.eclipse.sirius.diagram.sequence.description.tool.InteractionUseCreationTool;
@@ -111,13 +107,6 @@ public class NewChildMenusExtensionTests extends SiriusDiagramTestCase {
         assertContainsCommandFor(descriptors, CombinedFragmentMapping.class);
         assertContainsCommandFor(descriptors, InteractionUseMapping.class);
         assertContainsCommandFor(descriptors, ObservationPointMapping.class);
-        
-        // The current test will not be valid when contextual menu will be
-        // improved for sequence mappings
-        assertContainsCommandFor(descriptors, ExecutionMapping.class);
-        assertContainsCommandFor(descriptors, StateMapping.class);
-        assertContainsCommandFor(descriptors, OperandMapping.class);
-        assertContainsCommandFor(descriptors, EndOfLifeMapping.class);
     }
 
     public void testSequenceSpecificToolsAvailable() throws Exception {


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/590
Change-Id: Ibf6762095e18a84d88294af08a14170a9d6e9da1