### PR TITLE
[620] Improve move of Oblique message connected to Gate elements

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/tool/internal/edit/policy/SequenceMessageEditPolicy.java
+++ b/plugins/org.eclipse.sirius.diagram.sequence.ui/src/org/eclipse/sirius/diagram/sequence/ui/tool/internal/edit/policy/SequenceMessageEditPolicy.java
@@ -944,15 +944,19 @@ public class SequenceMessageEditPolicy extends ConnectionBendpointEditPolicy {
                 }
 
                 valid = sourceFinalOperand.get() == targetFinalOperand.get();
-            } else if (message.getSourceElement() instanceof Gate g) {
-                ISequenceElement hierarchicalParent = g.getHierarchicalParent();
-                if (hierarchicalParent instanceof ISequenceEvent ise) {
-                    valid = ise.getVerticalRange().includes(finalRange.get());
-                }
-            } else if (message.getTargetElement() instanceof Gate g) {
-                ISequenceElement hierarchicalParent = g.getHierarchicalParent();
-                if (hierarchicalParent instanceof ISequenceEvent ise) {
-                    valid = ise.getVerticalRange().includes(finalRange.get());
+            } else {
+                if (message.getSourceElement() instanceof Gate g) {
+                    ISequenceElement hierarchicalParent = g.getHierarchicalParent();
+                    if (hierarchicalParent instanceof ISequenceEvent ise) {
+                        valid = valid && ise.getVerticalRange().includes(finalRange.get().getLowerBound());
+                    }
+                } 
+                
+                if (message.getTargetElement() instanceof Gate g) {
+                    ISequenceElement hierarchicalParent = g.getHierarchicalParent();
+                    if (hierarchicalParent instanceof ISequenceEvent ise) {
+                        valid = valid && ise.getVerticalRange().includes(finalRange.get().getUpperBound());
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Case with message connected to a source Gate AND a target Gate was not handled
- For Oblique messages, range is no more "empty", inclusion check with hierarchical parent must be done on the source or target position not the full range. For non oblique message it will be the same.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/620