### PR TITLE
[609] Keep size for moved node if collapsed

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/refresh/AbstractCanonicalSynchronizer.java
@@ -48,6 +48,7 @@ import org.eclipse.sirius.diagram.DNodeList;
 import org.eclipse.sirius.diagram.business.api.refresh.CanonicalSynchronizer;
 import org.eclipse.sirius.diagram.model.business.internal.query.DDiagramElementContainerExperimentalQuery;
 import org.eclipse.sirius.diagram.model.business.internal.query.DNodeContainerExperimentalQuery;
+import org.eclipse.sirius.diagram.ui.business.api.query.NodeQuery;
 import org.eclipse.sirius.diagram.ui.business.api.query.ViewQuery;
 import org.eclipse.sirius.diagram.ui.business.api.view.SiriusLayoutDataManager;
 import org.eclipse.sirius.diagram.ui.business.internal.view.LayoutData;
@@ -624,10 +625,13 @@ public abstract class AbstractCanonicalSynchronizer implements CanonicalSynchron
 
         Dimension defaultSize = new NodePositionHelper(isSnapToGrid(), getGridSpacing()).getAdjustedDimension(createdNode, constraint);
 
-        if (NodePositionHelper.canResizeWidth(createdNode)) { // Horizontal
+        // Dnd nodes are not really new and must be kept as-is.
+        boolean collapsedSizeForced = new NodeQuery(createdNode).isCollapsed() && size != null;
+
+        if (collapsedSizeForced || NodePositionHelper.canResizeWidth(createdNode)) { // Horizontal
             constraint.setWidth(safeSize.width != -1 ? safeSize.width : defaultSize.width);
         }
-        if (NodePositionHelper.canResizeHeight(createdNode)) { // Vertical
+        if (collapsedSizeForced || NodePositionHelper.canResizeHeight(createdNode)) { // Vertical
             constraint.setHeight(safeSize.height != -1 ? safeSize.height : defaultSize.height);
         }
     }


### PR DESCRIPTION
A specific case was missed in the behavior change introduced for issue #609. It was identified through the tests in `org.eclipse.sirius.tests.swtbot.uml.UmlPortDragAndDropTest`.

This commit handles the case of collapsed elements that are drag'n'dropped.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/609