### PR TITLE
[675] Avoid NPE in Edge label item providers on edge creation undo

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/provider/DEdgeBeginLabelItemProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/provider/DEdgeBeginLabelItemProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2025 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class DEdgeBeginLabelItemProvider extends AbstractDDiagramElementLabelIte
      */
     private static boolean hasRelevantDEdgelabelItem(DEdge edge) {
         boolean isRelevant = false;
-        if (edge != null) {
+        if (edge != null && edge.getOwnedStyle() != null) {
             DEdgeQuery candidateEdgeQuery = new DEdgeQuery(edge);
             isRelevant = candidateEdgeQuery.getBeginLabelStyle().some() && candidateEdgeQuery.hasNonEmptyBeginNameDefinition();
         }
@@ -82,8 +82,8 @@ public class DEdgeBeginLabelItemProvider extends AbstractDDiagramElementLabelIte
      *         as children.
      */
     public static boolean hasRelevantLabelItem(DDiagramElement dDiagramElement) {
-        if (dDiagramElement instanceof DEdge) {
-            return DEdgeBeginLabelItemProvider.hasRelevantDEdgelabelItem((DEdge) dDiagramElement);
+        if (dDiagramElement instanceof DEdge edge) {
+            return DEdgeBeginLabelItemProvider.hasRelevantDEdgelabelItem(edge);
         }
         return false;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/provider/DEdgeEndLabelItemProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/provider/DEdgeEndLabelItemProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2025 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class DEdgeEndLabelItemProvider extends AbstractDDiagramElementLabelItemP
      */
     private static boolean hasRelevantDEdgelabelItem(DEdge edge) {
         boolean isRelevant = false;
-        if (edge != null) {
+        if (edge != null && edge.getOwnedStyle() != null) {
             DEdgeQuery candidateEdgeQuery = new DEdgeQuery(edge);
             isRelevant = candidateEdgeQuery.getEndLabelStyle().some() && candidateEdgeQuery.hasNonEmptyEndNameDefinition();
         }
@@ -82,8 +82,8 @@ public class DEdgeEndLabelItemProvider extends AbstractDDiagramElementLabelItemP
      *         as children.
      */
     public static boolean hasRelevantLabelItem(DDiagramElement dDiagramElement) {
-        if (dDiagramElement instanceof DEdge) {
-            return DEdgeEndLabelItemProvider.hasRelevantDEdgelabelItem((DEdge) dDiagramElement);
+        if (dDiagramElement instanceof DEdge edge) {
+            return DEdgeEndLabelItemProvider.hasRelevantDEdgelabelItem(edge);
         }
         return false;
     }

--- a/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/provider/DEdgeLabelItemProvider.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src/org/eclipse/sirius/diagram/ui/business/api/provider/DEdgeLabelItemProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2011, 2025 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -97,8 +97,8 @@ public class DEdgeLabelItemProvider extends AbstractDDiagramElementLabelItemProv
      *         as children.
      */
     public static boolean hasRelevantLabelItem(DDiagramElement dDiagramElement) {
-        if (dDiagramElement instanceof DEdge) {
-            return DEdgeLabelItemProvider.hasRelevantDEdgelabelItem((DEdge) dDiagramElement);
+        if (dDiagramElement instanceof DEdge edge) {
+            return DEdgeLabelItemProvider.hasRelevantDEdgelabelItem(edge);
         }
         return false;
     }


### PR DESCRIPTION
Center label already protected in commit
b96a8b79803d3b7c29e0bdf77d437d973e72bd9d done for Bugzilla 579012.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/675