### PR TITLE
[694] Fix Distribute tabbar tool visibility on initialization

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/contributions/TabbarContributionFactory.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/editor/tabbar/contributions/TabbarContributionFactory.java
@@ -526,6 +526,7 @@ public class TabbarContributionFactory {
      */
     public IContributionItem createDistributeContribution() {
         TabbarDistributeMenuManager distributeMenu = new TabbarDistributeMenuManager();
+        distributeMenu.setVisible(true);
         return distributeMenu;
     }
 


### PR DESCRIPTION
The visibility of the Distribute tabbar tool needs to be set to true otherwise it is not visible on a custom tabbar (provided by extension point) on the first diagram element selection

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/694