### PR TITLE
Default CopyFormatAction on tabbar provided by extension point raises NPE due to null WorkbenchPart initialization

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/actions/layout/CopyFormatAction.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/actions/layout/CopyFormatAction.java
@@ -24,11 +24,13 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.gmf.runtime.common.core.command.CommandResult;
 import org.eclipse.gmf.runtime.diagram.ui.commands.ICommandProxy;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramCommandStack;
 import org.eclipse.gmf.runtime.emf.commands.core.command.AbstractTransactionalCommand;
 import org.eclipse.sirius.common.ui.tools.api.util.EclipseUIUtil;
 import org.eclipse.sirius.diagram.DDiagram;
@@ -250,6 +252,22 @@ public class CopyFormatAction extends AbstractCopyPasteFormatAction {
             }
             return super.doUndo(monitor, info);
         }
+    }
+
+
+    /**
+     * gives access to the diagram command stack.
+     * 
+     * @return the diagram command stack
+     */
+    protected DiagramCommandStack getDiagramCommandStack() {
+        IWorkbenchPart workbenchPart = getWorkbenchPart();
+        if (workbenchPart == null) {
+            workbenchPart = getWorkbenchPage().getActivePart();
+        }
+        Object stack = workbenchPart.getAdapter(CommandStack.class);
+        return (stack instanceof DiagramCommandStack) ? (DiagramCommandStack) stack
+            : null;
     }
 
 }


### PR DESCRIPTION
With a custom tabbar, on diagram opening a CopyFormatAction is initialized with a null workbenchPart. This leads to an NPE when using the tool, but the workbenchPart can be accessed through the workbench page.

Bug: https://github.com/eclipse-sirius/sirius-desktop/issues/697