### PR TITLE
[cleanup] Remove redundant device parameter from Color constructors

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/graphical/edit/policies/BracketBendpointEditPolicy.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/graphical/edit/policies/BracketBendpointEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2012, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -70,7 +70,7 @@ public class BracketBendpointEditPolicy extends BendpointEditPolicy {
     public static final String ROTATE_COMMAND_LABEL = Messages.BracketBendpointEditPolicy_rotateBracketCommandLabel;
 
     /** The background feedback color as in GMF. */
-    private static final Color GRAY = new Color(null, 200, 200, 200);
+    private static final Color GRAY = new Color(200, 200, 200);
 
     /** The feeback figure. */
     private IFigure feedbackFigure;

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/graphical/edit/policies/SiriusContainerDropPolicy.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/graphical/edit/policies/SiriusContainerDropPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2022 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -168,7 +168,7 @@ public class SiriusContainerDropPolicy extends DragDropEditPolicy {
     public static final String DROP_ELEMENTS_CMD_NAME = Messages.SiriusContainerDropPolicy_dropElementsCommandLabel;
 
     /** The background feedback color as in GMF. */
-    private static final Color GRAY = new Color(null, 200, 200, 200);
+    private static final Color GRAY = new Color(200, 200, 200);
 
     /**
      * the original target figure

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DDiagramEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DDiagramEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2023 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2007, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -280,7 +280,7 @@ public class DDiagramEditPart extends AbstractDDiagramEditPart {
                     if (WHITE.equals(rgb)) {
                         backgroundColor = null;
                     } else {
-                        backgroundColor = new Color(viewer.getControl().getDisplay(), rgb.getRed(), rgb.getGreen(), rgb.getBlue());
+                        backgroundColor = new Color(rgb.getRed(), rgb.getGreen(), rgb.getBlue());
                     }
                     fig.setBackgroundColor(backgroundColor);
                     fig.setOpaque(backgroundColor != null);

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/widgets/gallery/DefaultGalleryItemRenderer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/widgets/gallery/DefaultGalleryItemRenderer.java
@@ -1,6 +1,6 @@
 // CHECKSTYLE:OFF copied from org.eclipse.nebula.widgets.gallery.DefaultGalleryItemRenderer
 /*******************************************************************************
- * Copyright (c) 2006-2007 Nicolas Richeton.
+ * Copyright (c) 2006-2026 Nicolas Richeton and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -287,7 +287,7 @@ public class DefaultGalleryItemRenderer extends AbstractGalleryItemRenderer {
 			// Create new colors
 			for (int i = dropShadowsSize - 1; i >= 0; i--) {
 				int value = 255 - i * step;
-				Color c = new Color(Display.getDefault(), value, value, value);
+				Color c = new Color(value, value, value);
 				dropShadowsColors.add(c);
 			}
 		}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/widgets/gallery/ListItemRenderer.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/dialogs/widgets/gallery/ListItemRenderer.java
@@ -1,6 +1,6 @@
 // CHECKSTYLE:OFF copied from org.eclipse.nebula.widgets.gallery.ListItemRenderer
 /*******************************************************************************
- * Copyright (c) 2006-2007 Nicolas Richeton.
+ * Copyright (c) 2006-2026 Nicolas Richeton and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -273,7 +273,7 @@ public class ListItemRenderer extends AbstractGalleryItemRenderer {
 			// Create new colors
 			for (int i = dropShadowsSize - 1; i >= 0; i--) {
 				int value = 255 - i * step;
-				Color c = new Color(Display.getDefault(), value, value, value);
+				Color c = new Color(value, value, value);
 				dropShadowsColors.add(c);
 			}
 		}

--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/figure/ContainerWithTitleBlockFigure.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/internal/figure/ContainerWithTitleBlockFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2010, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -185,7 +185,7 @@ public class ContainerWithTitleBlockFigure extends SiriusDefaultSizeNodeFigure {
             if (viewNode.getStyle() instanceof BorderedStyle) {
                 RGBValues borderColor = ((BorderedStyle) viewNode.getStyle()).getBorderColor();
                 if (borderColor != null) {
-                    return new Color(null, borderColor.getRed(), borderColor.getGreen(), borderColor.getBlue());
+                    return new Color(borderColor.getRed(), borderColor.getGreen(), borderColor.getBlue());
                 }
             }
         } catch (IllegalStateException e) {

--- a/plugins/org.eclipse.sirius.editor/src/org/eclipse/sirius/editor/tools/internal/presentation/GeneratedElementsLabelProvider.java
+++ b/plugins/org.eclipse.sirius.editor/src/org/eclipse/sirius/editor/tools/internal/presentation/GeneratedElementsLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 THALES GLOBAL SERVICES.
+ * Copyright (c) 2009, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.jface.viewers.DecoratingStyledCellLabelProvider;
 import org.eclipse.jface.viewers.ILabelDecorator;
 import org.eclipse.sirius.ui.business.api.template.RepresentationTemplateEditManager;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * Label provider highlighting generated model elements with a specific color.
@@ -27,7 +26,7 @@ import org.eclipse.swt.widgets.Display;
  */
 public class GeneratedElementsLabelProvider extends DecoratingStyledCellLabelProvider {
 
-    private final Color generated = new Color(Display.getDefault(), 136, 138, 133);
+    private final Color generated = new Color(136, 138, 133);
 
     /**
      * Create the provider.

--- a/plugins/org.eclipse.sirius.ext.gef/src/org/eclipse/sirius/ext/gef/editpolicies/SiriusSnapFeedbackPolicy.java
+++ b/plugins/org.eclipse.sirius.ext.gef/src/org/eclipse/sirius/ext/gef/editpolicies/SiriusSnapFeedbackPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,14 +63,14 @@ public class SiriusSnapFeedbackPolicy extends GraphicalEditPolicy {
      * This is the original color used by GEF in
      * {@link org.eclipse.gef.editpolicies.SnapFeedbackPolicy}.
      */
-    public static final Color VERTICAL_HORIZONTAL_ORIGINAL_GUIDE_COLOR = new Color(null, 255, 175, 175);
+    public static final Color VERTICAL_HORIZONTAL_ORIGINAL_GUIDE_COLOR = new Color(255, 175, 175);
 
     /**
      * Color for guides corresponding to Vertical guide or Horizontal guide.
      * Replace the red color of
      * {@link org.eclipse.gef.editpolicies.SnapFeedbackPolicy}.
      */
-    public static final Color VERTICAL_HORIZONTAL_GUIDE_COLOR = new Color(null, 255, 175, 175);
+    public static final Color VERTICAL_HORIZONTAL_GUIDE_COLOR = new Color(255, 175, 175);
 
     /**
      * Color for guides of North, South, East or West side for snap to geometry.

--- a/plugins/org.eclipse.sirius.ext.gmf.runtime/src/org/eclipse/sirius/ext/gmf/runtime/editpolicies/SiriusSnapFeedbackPolicy.java
+++ b/plugins/org.eclipse.sirius.ext.gmf.runtime/src/org/eclipse/sirius/ext/gmf/runtime/editpolicies/SiriusSnapFeedbackPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -60,14 +60,14 @@ public class SiriusSnapFeedbackPolicy extends GraphicalEditPolicy {
      * This is the original color used by GEF in
      * {@link org.eclipse.gef.editpolicies.SnapFeedbackPolicy}.
      */
-    public static final Color VERTICAL_HORIZONTAL_ORIGINAL_GUIDE_COLOR = new Color(null, 255, 175, 175);
+    public static final Color VERTICAL_HORIZONTAL_ORIGINAL_GUIDE_COLOR = new Color(255, 175, 175);
 
     /**
      * Color for guides corresponding to Vertical guide or Horizontal guide.
      * Replace the red color of
      * {@link org.eclipse.gef.editpolicies.SnapFeedbackPolicy}.
      */
-    public static final Color VERTICAL_HORIZONTAL_GUIDE_COLOR = new Color(null, 255, 175, 175);
+    public static final Color VERTICAL_HORIZONTAL_GUIDE_COLOR = new Color(255, 175, 175);
 
     /**
      * Color for guides of North, South, East or West side for snap to geometry.

--- a/plugins/org.eclipse.sirius.tests.junit.support/src/org/eclipse/sirius/tests/support/api/SiriusTestCase.java
+++ b/plugins/org.eclipse.sirius.tests.junit.support/src/org/eclipse/sirius/tests/support/api/SiriusTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 THALES GLOBAL SERVICES and others.
+ * Copyright (c) 2009, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -142,7 +142,7 @@ public abstract class SiriusTestCase extends TestCase {
     private static final String DOT = ".";
 
     /** Default grid spacing. */
-    public static final int DEFAULT_GRID_SPACING = 20;
+    private static final int DEFAULT_GRID_SPACING = 20;
 
     /** The local session. */
     protected Session session;

--- a/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/modeler/ecore/design/EntitiesDiagramBackgroundTests.java
+++ b/plugins/org.eclipse.sirius.tests.junit/src/org/eclipse/sirius/tests/unit/diagram/modeler/ecore/design/EntitiesDiagramBackgroundTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Obeo.
+ * Copyright (c) 2018, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,16 +56,16 @@ public class EntitiesDiagramBackgroundTests extends SiriusDiagramTestCase implem
     private DDiagramEditPart dDiagramEditPart;
 
     /** White color */
-    private final Color WHITE_COLOR = new Color(null, 255, 255, 255);
+    private final Color WHITE_COLOR = new Color(255, 255, 255);
 
     /** Green color */
-    private final Color GREEN_COLOR = new Color(null, 0, 255, 0);
+    private final Color GREEN_COLOR = new Color(0, 255, 0);
 
     /** Red color */
-    private final Color RED_COLOR = new Color(null, 255, 0, 0);
+    private final Color RED_COLOR = new Color(255, 0, 0);
 
     /** Intense blue color */
-    private final Color INTENSE_BLUE_COLOR = new Color(null, 0, 255, 255);
+    private final Color INTENSE_BLUE_COLOR = new Color(0, 255, 255);
 
     @Override
     protected void setUp() throws Exception {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/BorderedNodeCopyPasteFormatTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/BorderedNodeCopyPasteFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -212,8 +212,8 @@ public class BorderedNodeCopyPasteFormatTest extends AbstractSiriusSwtBotGefTest
         // layout.
         checkFirstContainerABorderedNodes(diagramEditor1, expectedAList, expectedAList_GMF);
         // Check the color before copy layout
-        Color yellow = new Color(null, 225, 225, 135);
-        Color lightBlue = new Color(null, 194, 239, 255);
+        Color yellow = new Color(225, 225, 135);
+        Color lightBlue = new Color(194, 239, 255);
         try {
             checkBorderNodeColor("r", diagramEditor1, yellow, "Yellow", 1);
             checkBorderNodeColor("r", diagramEditor2, lightBlue, "Light Blue", 1);
@@ -885,7 +885,7 @@ public class BorderedNodeCopyPasteFormatTest extends AbstractSiriusSwtBotGefTest
         checkBorderNode("a", diagramEditor4, A1_SECOND_DIAG_LOCATION, A1_SECOND_DIAG_GMF_LOCATION, 1);
 
         // Check border node color
-        Color yellow = new Color(null, 252, 233, 79);
+        Color yellow = new Color(252, 233, 79);
         try {
             checkBorderNodeColor("a", diagramEditor4, yellow, "Yellow", 1);
         } finally {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/ContainerAndNodeCopyPasteFormatTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/layout/ContainerAndNodeCopyPasteFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 THALES GLOBAL SERVICES.
+ * Copyright (c) 2016, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1294,7 +1294,7 @@ public class ContainerAndNodeCopyPasteFormatTest extends AbstractSiriusSwtBotGef
             AbstractDiagramNodeEditPart part = (AbstractDiagramNodeEditPart) editPart.part();
             Object shape = part.getStyleEditPart().getFigure().getChildren().get(0);
             assertTrue("The shape of figure for " + label + " must be a square.", shape instanceof SquareFigure);
-            Color gray = new Color(null, 136, 136, 136);
+            Color gray = new Color(136, 136, 136);
             try {
                 assertEquals("The color of figure for " + label + " must be gray.", gray, ((Shape) shape).getBackgroundColor());
             } finally {
@@ -1317,8 +1317,8 @@ public class ContainerAndNodeCopyPasteFormatTest extends AbstractSiriusSwtBotGef
             AbstractDiagramNodeEditPart part = (AbstractDiagramNodeEditPart) editPart.part();
             Object shape = part.getStyleEditPart().getFigure().getChildren().get(0);
             assertTrue("The shape of figure for " + label + " must be a diamond.", shape instanceof LozengeFigure);
-            Color orange = new Color(null, 252, 175, 62);
-            Color blue = new Color(null, 152, 168, 191);
+            Color orange = new Color(252, 175, 62);
+            Color blue = new Color(152, 168, 191);
             try {
                 assertEquals("The color of figure for " + label + " must be orange.", orange, ((Shape) shape).getBackgroundColor());
                 assertEquals("The color of the label for " + label + " must be blue.", blue, ((IFigure) ((Shape) shape).getChildren().get(0)).getForegroundColor());
@@ -1343,7 +1343,7 @@ public class ContainerAndNodeCopyPasteFormatTest extends AbstractSiriusSwtBotGef
             AbstractDiagramNodeEditPart part = (AbstractDiagramNodeEditPart) editPart.part();
             Object shape = part.getStyleEditPart().getFigure().getChildren().get(0);
             assertTrue("The shape of figure for " + label + " must be an ellipse.", shape instanceof ODesignEllipseFigure);
-            Color yellow = new Color(null, 252, 233, 79);
+            Color yellow = new Color(252, 233, 79);
             try {
                 assertEquals("The color of figure for " + label + " must be yellow.", yellow, ((Shape) shape).getBackgroundColor());
             } finally {

--- a/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteFormatOfLabelOfBorderedNodeTest.java
+++ b/plugins/org.eclipse.sirius.tests.swtbot/src/org/eclipse/sirius/tests/swtbot/uml/CopyPasteFormatOfLabelOfBorderedNodeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2024 THALES GLOBAL SERVICES.
+ * Copyright (c) 2010, 2026 THALES GLOBAL SERVICES and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public class CopyPasteFormatOfLabelOfBorderedNodeTest extends AbstractUmlDragAnd
      * launching Paste Layout action.
      */
     public void testCopyPasteLayout() {
-        Color red = new Color(null, 227, 164, 156);
+        Color red = new Color(227, 164, 156);
         try {
             final EditPart srcLabelEditPart = editor.getEditPart("DropPort", AbstractDiagramNameEditPart.class).part();
             assertTrue("The model of the DropPort editPart in source diagram should be a Node", srcLabelEditPart.getModel() instanceof Node);
@@ -102,7 +102,7 @@ public class CopyPasteFormatOfLabelOfBorderedNodeTest extends AbstractUmlDragAnd
      * launching Paste Style action.
      */
     public void testCopyPasteStyle() {
-        Color red = new Color(null, 227, 164, 156);
+        Color red = new Color(227, 164, 156);
         try {
             final EditPart srcLabelEditPart = editor.getEditPart("DropPort", AbstractDiagramNameEditPart.class).part();
             checkBorderNodeLabelColor(srcLabelEditPart, red, "Red");
@@ -141,7 +141,7 @@ public class CopyPasteFormatOfLabelOfBorderedNodeTest extends AbstractUmlDragAnd
      * launching Paste Format action.
      */
     public void testCopyPasteFormat() {
-        Color red = new Color(null, 227, 164, 156);
+        Color red = new Color(227, 164, 156);
         try {
             final EditPart srcLabelEditPart = editor.getEditPart("DropPort", AbstractDiagramNameEditPart.class).part();
             assertTrue("The model of the DropPort editPart in source diagram should be a Node", srcLabelEditPart.getModel() instanceof Node);


### PR DESCRIPTION
See eclipse-gef/gef-classic#1086 and eclipse-platform/eclipse.platform.swt#3233.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
