### PR TITLE
[711] Correct background diagram interpretation

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DDiagramEditPart.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/internal/edit/parts/DDiagramEditPart.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.diagram.ui.internal.edit.parts;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
-import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.SnapToHelper;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.EditPolicyRoles;
@@ -57,8 +56,6 @@ public class DDiagramEditPart extends AbstractDDiagramEditPart {
     public static final String MODEL_ID = "Sirius"; //$NON-NLS-1$
 
     public static final int VISUAL_ID = 1000;
-
-    private static final RGBValues WHITE = RGBValues.create(255, 255, 255);
     
     public DDiagramEditPart(View view) {
         super(view);
@@ -254,7 +251,7 @@ public class DDiagramEditPart extends AbstractDDiagramEditPart {
         if (resolveDDiagram().some() && fig != null) {
             DSemanticDiagram dSemanticDiagram = (DSemanticDiagram) this.resolveDDiagram().get();
             ColorDescription colorDesc = dSemanticDiagram.getDescription().getBackgroundColor();
-            RGBValues rgb = WHITE;
+            RGBValues rgb = null;
             if (colorDesc != null) {
                 // Save the diagram variable initial value to restore it after configuring the diagram background to
                 // avoid any side effect.
@@ -273,28 +270,23 @@ public class DDiagramEditPart extends AbstractDDiagramEditPart {
             }
 
             Color previousColor = fig.getBackgroundColor();
-            if (!sameColor(previousColor, rgb)) {
-                EditPartViewer viewer = this.getViewer();
-                if (viewer instanceof SiriusDiagramGraphicalViewer) {
-                    Color backgroundColor;
-                    if (WHITE.equals(rgb)) {
-                        backgroundColor = null;
-                    } else {
-                        backgroundColor = new Color(viewer.getControl().getDisplay(), rgb.getRed(), rgb.getGreen(), rgb.getBlue());
-                    }
-                    fig.setBackgroundColor(backgroundColor);
-                    fig.setOpaque(backgroundColor != null);
-                    ((SiriusDiagramGraphicalViewer) viewer).setBackgroundColor(backgroundColor);
+            if (!sameColor(previousColor, rgb) && getViewer() instanceof SiriusDiagramGraphicalViewer viewer) {
+                Color backgroundColor = null;
+                if (rgb != null) {
+                    backgroundColor = new Color(rgb.getRed(), rgb.getGreen(), rgb.getBlue());
                 }
+                fig.setBackgroundColor(backgroundColor);
+                fig.setOpaque(backgroundColor != null);
+                viewer.setBackgroundColor(backgroundColor);
             }
         }
     }
 
     private boolean sameColor(Color current, RGBValues expected) {
-        if (current == null) {
-            return WHITE.equals(expected);
-        } else {
-            return current.getRed() == expected.getRed() && current.getGreen() == expected.getGreen() && current.getBlue() == expected.getBlue();
-        }
+        // If current is null, its real value depends of Preferences theme.
+        // So color must be forced if current is null.
+        return current == null && expected == null
+                || current != null && expected != null && current.getRed() == expected.getRed() && current.getGreen() == expected.getGreen() && current.getBlue() == expected.getBlue();
     }
+    
 }

--- a/plugins/org.eclipse.sirius.doc/doc/Release_Notes.html
+++ b/plugins/org.eclipse.sirius.doc/doc/Release_Notes.html
@@ -14,6 +14,11 @@
 				<ol style="list-style: disc;">
 					<li>
 						<a href="#sirius7.6.1">Changes in Sirius  Desktop 7.6.1</a>
+						<ol style="list-style: disc;">
+							<li>
+								<a href="#sirius7.6.1user">User-Visible Changes</a>
+							</li>
+						</ol>
 					</li>
 					<li>
 						<a href="#sirius7.6.0">Changes in Sirius  Desktop 7.6.0</a>
@@ -282,7 +287,12 @@
 			<a href="Release_Notes_Previous.html">the release notes from previous versions</a> for details about older releases.
 		</p>
 		<h2 id="sirius7.6.1">Changes in Sirius  Desktop 7.6.1</h2>
-		<p>Nothing.</p>
+		<h3 id="sirius7.6.1user">User-Visible Changes</h3>
+		<ul>
+			<li><span class="label label-info">Modified</span> Background color is no more transparent when diagram description specifies a 
+				<b>White</b> background. If user is using a dark theme, diagram background is now opaque and white.
+			</li>
+		</ul>
 		<h2 id="sirius7.6.0">Changes in Sirius  Desktop 7.6.0</h2>
 		<ul>
 			<li><span class="label label-info">Modified</span> As of version 7.6.0, Sirius Desktop now requires 

--- a/plugins/org.eclipse.sirius.doc/doc/Release_Notes.textile
+++ b/plugins/org.eclipse.sirius.doc/doc/Release_Notes.textile
@@ -6,7 +6,9 @@ This document contains the release notes for recent major releases of Sirius. Se
 
 h2(#sirius7.6.1). Changes in Sirius  Desktop 7.6.1
 
-Nothing.
+h3(#sirius7.6.1user). User-Visible Changes
+
+* <span class="label label-info">Modified</span> Background color is no more transparent when diagram description specifies a **White** background. If user is using a dark theme, diagram background is now opaque and white.
 
 h2(#sirius7.6.0). Changes in Sirius  Desktop 7.6.0
 


### PR DESCRIPTION
Previously when diagram background was defined as white, edit part showed a theme based color.
Now for no diagram background color, edit part is theme based. If diagram background is described as white, edit part background is always white for any theme.

### How to test
 - Create a modeling Project with following VSM et Ecore model sample:
[test_resources.zip](https://github.com/user-attachments/files/28103021/test_resources.zip)
 - In Window.. > Preference \ General > Appearance, set Theme to Dark.
 - Create and open "class diagram" using EPackage from semantic model.
 - Expected: background of diagram should be White
 - Change "background color" in diagram description to null.
 - Reload VMS
 - Expected: background of diagram should be the default background color of the workbench.