### PR TITLE
#737 Paint SVG figure background before rendering image

### DIFF
--- a/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/figure/SVGFigure.java
+++ b/plugins/org.eclipse.sirius.diagram.ui/src-diag/org/eclipse/sirius/diagram/ui/tools/api/figure/SVGFigure.java
@@ -481,11 +481,34 @@ public class SVGFigure extends Figure implements StyledFigure, ITransparentFigur
         return result.toString();
     }
 
+    /**
+     * Paints the figure background before the SVG image is drawn.
+     *
+     * This keeps transparent areas of SVG files transparent while still showing the configured figure background color.
+     *
+     * @param graphics
+     *            Graphics
+     * @param area
+     *            Area to fill
+     */
+    protected void paintSVGBackground(Graphics graphics, Rectangle area) {
+        if (graphics != null && area != null && area.width > 0 && area.height > 0 && getBackgroundColor() != null) {
+            graphics.pushState();
+            try {
+                graphics.setBackgroundColor(getBackgroundColor());
+                graphics.fillRectangle(area);
+            } finally {
+                graphics.popState();
+            }
+        }
+    }
+
     @Override
     protected void paintFigure(Graphics graphics) {
         TransparentFigureGraphicsModifier modifier = new TransparentFigureGraphicsModifier(this, graphics);
         modifier.pushState();
         Rectangle svgArea = getClientArea();
+        paintSVGBackground(graphics, svgArea);
         if (CACHE_SCALED_IMAGES) {
             Rectangle scaledArea = new PrecisionRectangle(svgArea);
             scaledArea.performScale(graphics.getAbsoluteScale());


### PR DESCRIPTION
## Problem

Transparent areas of SVG workspace images currently show the diagram/canvas background instead of the configured figure background color.

This is visible in Capella diagrams when a node uses an SVG workspace image with transparent areas.

Related Capella issue:
[eclipse-capella/capella#3001](https://github.com/eclipse-capella/capella/issues/3001)

## Solution

Paint the figure background in the SVG client area before rendering the SVG image or SVG reference.

The change is local to:

```text
org.eclipse.sirius.diagram.ui.tools.api.figure.SVGFigure